### PR TITLE
feat(search): add text output format for search results

### DIFF
--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -838,41 +838,6 @@ fn format_memories(memories: &[octocode::memory::Memory], format: &str) {
 }
 
 fn format_search_results(results: &[octocode::memory::MemorySearchResult], format: &str) {
-	match format {
-		"json" => {
-			println!("{}", serde_json::to_string_pretty(results).unwrap());
-		}
-		"compact" => {
-			println!("🧠 {} memories:", results.len());
-			for result in results {
-				println!(
-					"- [{}] {} (Score: {:.2}) - {}",
-					result.memory.memory_type,
-					result.memory.title,
-					result.relevance_score,
-					result.memory.id
-				);
-			}
-		}
-		_ => {
-			println!("🧠 {} memories:\n", results.len());
-			for result in results {
-				println!("Memory ID: {}", result.memory.id);
-				println!("Title: {}", result.memory.title);
-				println!("Type: {}", result.memory.memory_type);
-				println!("Relevance: {:.2}", result.relevance_score);
-				println!("Importance: {:.2}", result.memory.metadata.importance);
-				println!(
-					"Created: {}",
-					result.memory.created_at.format("%Y-%m-%d %H:%M:%S")
-				);
-				if !result.memory.metadata.tags.is_empty() {
-					println!("Tags: {}", result.memory.metadata.tags.join(", "));
-				}
-				println!("Content: {}", result.memory.content);
-				println!("Why selected: {}", result.selection_reason);
-				println!();
-			}
-		}
-	}
+	// Use shared formatting function
+	octocode::memory::format_memories_for_cli(results, format);
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -64,6 +64,10 @@ pub struct SearchArgs {
 	#[arg(long)]
 	pub md: bool,
 
+	/// Output in text format (token-efficient)
+	#[arg(long)]
+	pub text: bool,
+
 	/// Search mode: all (default), code, docs, or text
 	#[arg(long, default_value = "all")]
 	pub mode: String,
@@ -514,7 +518,7 @@ pub async fn execute(
 		code_blocks = indexer::expand_symbols(store, code_blocks).await?;
 	}
 
-	// Use EXISTING output formatting (completely unchanged)
+	// Use EXISTING output formatting with added text support
 	match search_mode {
 		"code" => {
 			if args.json {
@@ -522,6 +526,11 @@ pub async fn execute(
 			} else if args.md {
 				let markdown = indexer::code_blocks_to_markdown_with_config(&code_blocks, config);
 				println!("{}", markdown);
+			} else if args.text {
+				// Use text formatting function for token efficiency
+				let text_output =
+					indexer::search::format_code_search_results_as_text(&code_blocks, "partial");
+				println!("{}", text_output);
 			} else {
 				indexer::render_code_blocks_with_config(&code_blocks, config);
 			}
@@ -534,6 +543,10 @@ pub async fn execute(
 				let markdown =
 					indexer::document_blocks_to_markdown_with_config(&doc_blocks, config);
 				println!("{}", markdown);
+			} else if args.text {
+				// Use text formatting function for token efficiency
+				let text_output = indexer::search::format_doc_search_results_as_text(&doc_blocks);
+				println!("{}", text_output);
 			} else {
 				render_document_blocks_with_config(&doc_blocks, config);
 			}
@@ -545,6 +558,10 @@ pub async fn execute(
 			} else if args.md {
 				let markdown = indexer::text_blocks_to_markdown_with_config(&text_blocks, config);
 				println!("{}", markdown);
+			} else if args.text {
+				// Use text formatting function for token efficiency
+				let text_output = indexer::search::format_text_search_results_as_text(&text_blocks);
+				println!("{}", text_output);
 			} else {
 				render_text_blocks_with_config(&text_blocks, config);
 			}
@@ -620,6 +637,15 @@ pub async fn execute(
 				}
 
 				println!("{}", combined_markdown);
+			} else if args.text {
+				// Use text formatting function for token efficiency
+				let text_output = indexer::search::format_combined_search_results_as_text(
+					&final_code_results,
+					&text_blocks,
+					&doc_blocks,
+					"partial",
+				);
+				println!("{}", text_output);
 			} else {
 				if !doc_blocks.is_empty() {
 					println!("=== DOCUMENTATION RESULTS ===\n");

--- a/src/indexer/render_utils.rs
+++ b/src/indexer/render_utils.rs
@@ -199,6 +199,61 @@ pub fn signatures_to_markdown(signatures: &[FileSignature]) -> String {
 	markdown
 }
 
+/// Render signatures as text string (token-efficient)
+pub fn signatures_to_text(signatures: &[FileSignature]) -> String {
+	let mut output = String::new();
+
+	if signatures.is_empty() {
+		output.push_str("No signatures found.");
+		return output;
+	}
+
+	output.push_str(&format!("SIGNATURES ({} files)\n\n", signatures.len()));
+
+	for file in signatures {
+		output.push_str(&format!("FILE: {}\n", file.path));
+		output.push_str(&format!("Language: {}\n", file.language));
+
+		// Show file comment if available
+		if let Some(comment) = &file.file_comment {
+			output.push_str(&format!("Description: {}\n", comment.replace('\n', " ")));
+		}
+
+		if file.signatures.is_empty() {
+			output.push_str("No signatures found.\n");
+		} else {
+			for signature in &file.signatures {
+				// Display line range
+				let line_display = if signature.start_line == signature.end_line {
+					format!("{}", signature.start_line + 1)
+				} else {
+					format!("{}-{}", signature.start_line + 1, signature.end_line + 1)
+				};
+
+				output.push_str(&format!(
+					"{} {} (line {})\n",
+					signature.kind, signature.name, line_display
+				));
+
+				// Show description if available
+				if let Some(desc) = &signature.description {
+					output.push_str(&format!("Description: {}\n", desc.replace('\n', " ")));
+				}
+
+				// Add signature content as-is without truncation
+				output.push_str(&signature.signature);
+				if !signature.signature.ends_with('\n') {
+					output.push('\n');
+				}
+				output.push('\n');
+			}
+		}
+		output.push('\n');
+	}
+
+	output
+}
+
 /// Render code blocks (search results) as markdown string
 pub fn code_blocks_to_markdown(blocks: &[CodeBlock]) -> String {
 	code_blocks_to_markdown_with_config(blocks, &Config::default())

--- a/src/mcp/semantic_code.rs
+++ b/src/mcp/semantic_code.rs
@@ -18,9 +18,9 @@ use tracing::debug;
 
 use crate::config::Config;
 use crate::indexer::search::{
-	search_codebase_with_details, search_codebase_with_details_multi_query,
+	search_codebase_with_details_multi_query_text, search_codebase_with_details_text,
 };
-use crate::indexer::{extract_file_signatures, signatures_to_markdown, NoindexWalker, PathUtils};
+use crate::indexer::{extract_file_signatures, signatures_to_text, NoindexWalker, PathUtils};
 use crate::mcp::types::McpTool;
 
 /// Semantic code search tool provider
@@ -232,14 +232,20 @@ impl SemanticCodeProvider {
 		let original_dir = std::env::current_dir()?;
 		std::env::set_current_dir(&self.working_directory)?;
 
-		// Use the enhanced search functionality with multi-query support
+		// Use the enhanced search functionality with multi-query support - TEXT FORMAT for token efficiency
 		let results = if queries.len() == 1 {
-			// Single query - use existing function
-			search_codebase_with_details(&queries[0], mode, detail_level, max_results, &self.config)
-				.await
+			// Single query - use text function for token efficiency
+			search_codebase_with_details_text(
+				&queries[0],
+				mode,
+				detail_level,
+				max_results,
+				&self.config,
+			)
+			.await
 		} else {
-			// Multi-query - use new function
-			search_codebase_with_details_multi_query(
+			// Multi-query - use text function for token efficiency
+			search_codebase_with_details_multi_query_text(
 				&queries,
 				mode,
 				detail_level,
@@ -364,8 +370,8 @@ impl SemanticCodeProvider {
 		// Restore original directory
 		std::env::set_current_dir(&original_dir)?;
 
-		// Always return markdown format
-		let markdown = signatures_to_markdown(&signatures);
-		Ok(markdown)
+		// Return text format for token efficiency
+		let text_output = signatures_to_text(&signatures);
+		Ok(text_output)
 	}
 }

--- a/src/memory/formatting.rs
+++ b/src/memory/formatting.rs
@@ -1,0 +1,157 @@
+// Copyright 2025 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared memory formatting functions for CLI and MCP
+
+use crate::memory::MemorySearchResult;
+
+/// Format memory search results as text (token-efficient, for MCP)
+pub fn format_memories_as_text(results: &[MemorySearchResult]) -> String {
+	if results.is_empty() {
+		return "No stored memories match your query. Try using different search terms, removing filters, or checking if any memories have been stored yet.".to_string();
+	}
+
+	let mut output = String::new();
+	output.push_str(&format!("MEMORIES ({} found)\n\n", results.len()));
+
+	for (i, result) in results.iter().enumerate() {
+		output.push_str(&format!(
+			"{}. {} | Score: {:.2}\n",
+			i + 1,
+			sanitize_content(&result.memory.title),
+			result.relevance_score
+		));
+
+		output.push_str(&format!(
+			"Type: {} | Importance: {:.1} | Created: {}\n",
+			result.memory.memory_type,
+			result.memory.metadata.importance,
+			result.memory.created_at.format("%Y-%m-%d %H:%M:%S UTC")
+		));
+
+		if !result.memory.metadata.tags.is_empty() {
+			output.push_str(&format!(
+				"Tags: {}\n",
+				result.memory.metadata.tags.join(", ")
+			));
+		}
+
+		if !result.memory.metadata.related_files.is_empty() {
+			output.push_str(&format!(
+				"Files: {}\n",
+				result.memory.metadata.related_files.join(", ")
+			));
+		}
+
+		if let Some(git_commit) = &result.memory.metadata.git_commit {
+			output.push_str(&format!("Git: {}\n", git_commit));
+		}
+
+		output.push_str(&format!("ID: {}\n", result.memory.id));
+
+		// Add content as-is without truncation for text mode
+		let content = sanitize_content(&result.memory.content);
+		output.push_str(&content);
+		if !content.ends_with('\n') {
+			output.push('\n');
+		}
+
+		output.push_str(&format!(
+			"Why: {}\n\n",
+			sanitize_content(&result.selection_reason)
+		));
+	}
+
+	output
+}
+
+/// Format memory search results for CLI (with emojis and formatting)
+pub fn format_memories_for_cli(results: &[MemorySearchResult], format: &str) {
+	match format {
+		"json" => {
+			println!("{}", serde_json::to_string_pretty(results).unwrap());
+		}
+		"compact" => {
+			println!("🧠 {} memories:", results.len());
+			for result in results {
+				println!(
+					"- [{}] {} (Score: {:.2}) - {}",
+					result.memory.memory_type,
+					result.memory.title,
+					result.relevance_score,
+					result.memory.id
+				);
+			}
+		}
+		_ => {
+			println!("🧠 {} memories:\n", results.len());
+			for result in results {
+				println!("Memory ID: {}", result.memory.id);
+				println!("Title: {}", result.memory.title);
+				println!("Type: {}", result.memory.memory_type);
+				println!("Relevance: {:.2}", result.relevance_score);
+				println!("Importance: {:.2}", result.memory.metadata.importance);
+				println!(
+					"Created: {}",
+					result.memory.created_at.format("%Y-%m-%d %H:%M:%S")
+				);
+				if !result.memory.metadata.tags.is_empty() {
+					println!("Tags: {}", result.memory.metadata.tags.join(", "));
+				}
+				println!("Content: {}", result.memory.content);
+				println!("Why selected: {}", result.selection_reason);
+				println!();
+			}
+		}
+	}
+}
+
+/// Sanitize content by removing control characters while preserving safe Unicode
+pub fn sanitize_content(content: &str) -> String {
+	content
+		.chars()
+		.filter(|&c| !c.is_control() && (c.is_ascii_graphic() || is_safe_unicode(c)))
+		.collect()
+}
+
+/// Check if a character is a safe Unicode character (including emojis)
+pub fn is_safe_unicode(c: char) -> bool {
+	// Allow a broader range of Unicode characters, including emojis
+	let code = c as u32;
+	// Emoji ranges and other safe Unicode ranges
+	matches!(code,
+		// Emoji ranges
+		0x1F600..=0x1F64F | // Emoticons
+		0x1F300..=0x1F5FF | // Misc Symbols and Pictographs
+		0x1F680..=0x1F6FF | // Transport and Map
+		0x1F1E6..=0x1F1FF | // Regional indicators
+		0x2600..=0x26FF   | // Misc symbols
+		0x2700..=0x27BF   | // Dingbats
+
+		// Allow variation selectors and zero-width joiner
+		0xFE0F | 0x200D    |
+
+		// Some additional safe Unicode ranges
+		0x0080..=0x00FF   | // Latin-1 Supplement
+		0x0100..=0x017F   | // Latin Extended-A
+		0x0180..=0x024F   | // Latin Extended-B
+		0x0370..=0x03FF   | // Greek and Coptic
+		0x0400..=0x04FF   | // Cyrillic
+		0x0530..=0x058F   | // Armenian
+		0x0590..=0x05FF   | // Hebrew
+		0x0600..=0x06FF   | // Arabic
+		0x0900..=0x097F   | // Devanagari
+		0x4E00..=0x9FFF     // CJK Unified Ideographs
+	)
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -15,12 +15,14 @@
 // Memory module for AI context and conversation state management
 // Uses LanceDB for vector storage and semantic search capabilities
 
+pub mod formatting;
 pub mod git_utils;
 pub mod manager;
 pub mod store;
 pub mod types;
 
 // Re-export the main types and interfaces
+pub use formatting::{format_memories_as_text, format_memories_for_cli};
 pub use git_utils::{CommitInfo, GitUtils};
 pub use manager::{MemoryManager, MemoryStats};
 pub use store::MemoryStore;


### PR DESCRIPTION
- Introduce --text flag to output search results in token-efficient text format
- Support text output for code, docs, text, and combined search modes
- Replace custom memory search result formatting with shared CLI formatter