### PR TITLE
fix(indexer): correct end_idx calculation in text chunking

### DIFF
--- a/src/indexer/text_processing.rs
+++ b/src/indexer/text_processing.rs
@@ -44,9 +44,9 @@ impl TextProcessor {
 			// Build chunk content and track character count
 			for (idx, line) in lines
 				.iter()
-				.enumerate()
 				.skip(start_idx)
 				.take(end_idx - start_idx)
+				.enumerate()
 			{
 				if char_count + line.len() + 1 > chunk_size && !current_content.is_empty() {
 					end_idx = start_idx + idx;


### PR DESCRIPTION
Move enumerate() after skip() to ensure idx represents relative offset from start_idx, fixing the semantic of end_idx calculation.