### PR TITLE
fix(indexer): guarantee forward progress in text chunking loop

### DIFF
--- a/src/indexer/text_processing.rs
+++ b/src/indexer/text_processing.rs
@@ -74,11 +74,17 @@ impl TextProcessor {
 				break;
 			}
 
-			let next_start = if overlap > 0 && end_idx > overlap {
+			let mut next_start = if overlap > 0 && end_idx > overlap {
 				end_idx - overlap
 			} else {
 				end_idx
 			};
+
+			// Critical: ensure forward progress. If overlap would keep us at the same start,
+			// fall back to non-overlapped advancing.
+			if next_start <= start_idx {
+				next_start = end_idx;
+			}
 
 			current_line += end_idx - start_idx;
 			start_idx = next_start;


### PR DESCRIPTION
One of my small projects frequently experiences OOM during indexing, and after investigation, it turned out to be due to code issues. 

This situation happens when **the current chunk ends up containing exactly `overlap` lines**.

That can easily happen in `chunk_text` because:

- The chunk boundary is determined by a **character limit** (`chunk_size`) and is cut early when  
  `char_count + line.len() + 1 > chunk_size`.
- But the overlap is configured in **number of lines**, via `next_start = end_idx - overlap`.

A minimal example (independent of total file size):

- Assume each line is very long, so `chunk_size` can fit only **100 lines**.
- Set `overlap = 100`.
- Iteration 1: `start_idx = 0`, the chunk ends at `end_idx = 100`.
- Compute `next_start = end_idx - overlap = 100 - 100 = 0`.
- Now `next_start == start_idx`, so the next iteration starts at the same place again → repeats forever → keeps pushing chunks → the vector grows without bound → OOM. https://github.com/Muvon/octocode/issues/25

By the way, cool project, I think this project is better than `mgrep` because I can run it completely locally, and its output format is also better than mgrep's