### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org)
 
+<a href="https://glama.ai/mcp/servers/Muvon/octocode">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/Muvon/octocode/badge" alt="Octocode MCP server" />
+</a>
+
 ## 🚀 Overview
 
 Octocode is a powerful code indexer and semantic search engine that builds intelligent knowledge graphs of your codebase. It combines advanced AI capabilities with local-first design to provide deep code understanding, relationship mapping, and intelligent assistance for developers.


### PR DESCRIPTION
This PR adds a badge for the [Octocode](https://glama.ai/mcp/servers/Muvon/octocode) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/Muvon/octocode">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/Muvon/octocode/badge" alt="Octocode MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.