### PR TITLE
ci(build): implement static ONNX Runtime builds and musl support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,14 @@ jobs:
               echo "==> Using cached ONNX Runtime static build"
             fi
 
+            # Install protobuf-dev AFTER ORT build: lance-encoding build.rs
+            # needs the well-known .proto includes (google/protobuf/empty.proto)
+            # which only ship in protobuf-dev. Installing it earlier would pull
+            # abseil-cpp-dev and make ORT CMake skip its bundled abseil + drop
+            # re2. By this point ORT artifacts already exist, and cargo only
+            # links pre-built .a files via ORT_LIB_LOCATION.
+            apk add --no-cache protobuf-dev
+
             export ORT_LIB_LOCATION="$ORT_LIB_LOCATION"
             export RUSTFLAGS="-C link-arg=-lgcc"
             cargo build --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,18 @@ jobs:
         RUSTC_WRAPPER: sccache
         # Windows: ORT prebuilts (pyke download-binaries) are compiled with /MD
         # (dynamic CRT). Rust on MSVC defaults to /MT (static CRT) → __imp_*
-        # unresolved-symbol link errors. Switch to dynamic CRT to match.
+        # unresolved-symbol link errors. Switch rust to dynamic CRT to match.
         # vcruntime140.dll is present on all GitHub Windows runners.
         RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=-crt-static' || '' }}
+        # esaxx-rs 0.1.10 (pulled by tokenizers/esaxx_fast in the huggingface
+        # feature) hardcodes `cc::Build::static_crt(true)` in its build.rs,
+        # forcing /MT regardless of RUSTFLAGS. That conflicts with ort's /MD
+        # at link time (LNK2038 RuntimeLibrary mismatch). cc-rs appends
+        # CXXFLAGS_<target> AFTER its own /MT, and cl.exe takes the last
+        # /M* flag for both compile and the RuntimeLibrary directive in the
+        # .obj — so /MD wins. Same trick for CFLAGS in case any C dep flips.
+        CFLAGS_x86_64_pc_windows_msvc: ${{ runner.os == 'Windows' && '/MD' || '' }}
+        CXXFLAGS_x86_64_pc_windows_msvc: ${{ runner.os == 'Windows' && '/MD' || '' }}
       run: cargo test --verbose --all-features
 
   musl-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,13 +117,135 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
 
+    # Linux: csukuangfj ships a single bundled libonnxruntime.a — ort-sys's
+    # single-file shortcut links it directly. Just point ORT_LIB_LOCATION at
+    # the extracted lib/ dir. ubuntu-latest is glibc-based so the
+    # glibc2_17-built static archive is ABI-compatible.
+    # Windows MSVC: nothing to download — ort-sys's download-binaries feature
+    # pulls pyke's prebuilts automatically; we only flip RUSTFLAGS below.
+    # macOS aarch64: pyke prebuilts work out of the box.
+    - name: Download ONNX Runtime static library (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        ORT_VERSION="1.24.2"
+        ORT_ASSET="onnxruntime-linux-x64-static_lib-${ORT_VERSION}-glibc2_17"
+        curl -sL "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${ORT_VERSION}/${ORT_ASSET}.zip" -o /tmp/ort.zip
+        unzip -q /tmp/ort.zip -d /tmp/ort
+        echo "ORT_LIB_LOCATION=/tmp/ort/${ORT_ASSET}/lib" >> "$GITHUB_ENV"
+
     - name: Run tests
       shell: bash
       env:
         RUSTC_WRAPPER: sccache
+        # Windows: ORT prebuilts (pyke download-binaries) are compiled with /MD
+        # (dynamic CRT). Rust on MSVC defaults to /MT (static CRT) → __imp_*
+        # unresolved-symbol link errors. Switch to dynamic CRT to match.
+        # vcruntime140.dll is present on all GitHub Windows runners.
+        RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=-crt-static' || '' }}
+      run: cargo test --verbose --all-features
+
+  musl-build:
+    name: Musl Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-22.04-arm
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Cache the static ONNX Runtime build (45–60 min cold) between runs.
+    # Cache full source+build tree because ort-sys's static-link branch
+    # walks build/_deps/ for re2/abseil/protobuf — flattening .a files
+    # into one dir breaks linking.
+    - name: Cache ONNX Runtime static build
+      uses: actions/cache@v4
+      with:
+        path: onnxruntime-src
+        key: onnxruntime-1.24.2-${{ matrix.target }}-alpine3.22-v6
+
+    - name: Cache cargo registry and target
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: docker-alpine-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          docker-alpine-${{ matrix.target }}-cargo-
+
+    - name: Build in Alpine (mirrors release pipeline)
       run: |
-        # We have issue with onnx runtime so we use no default features
-        cargo test --verbose --no-default-features
+        mkdir -p onnxruntime-src
+        chmod -R 777 onnxruntime-src
+
+        docker run --rm \
+          --user 0:0 \
+          -v "$(pwd):/workspace" \
+          -w /workspace \
+          rust:1.95.0-alpine3.22 \
+          sh -c '
+            set -eu
+            apk add --no-cache \
+              git perl bash musl-dev openssl-dev openssl-libs-static \
+              pkgconfig gcc g++ \
+              cmake make linux-headers python3 py3-pip patch
+
+            mkdir -p /tmp/include
+            cat > /tmp/include/execinfo.h << "EOF"
+        #ifndef _EXECINFO_H
+        #define _EXECINFO_H
+        #include <stddef.h>
+        static inline int backtrace(void **buffer, int size) { (void)buffer; (void)size; return 0; }
+        static inline char **backtrace_symbols(void *const *buffer, int size) { (void)buffer; (void)size; return NULL; }
+        static inline void backtrace_symbols_fd(void *const *buffer, int size, int fd) { (void)buffer; (void)size; (void)fd; }
+        #endif
+        EOF
+            export C_INCLUDE_PATH=/tmp/include
+            export CPLUS_INCLUDE_PATH=/tmp/include
+
+            rustup target add ${{ matrix.target }}
+
+            ORT_SRC=/workspace/onnxruntime-src
+            ORT_LIB_LOCATION="$ORT_SRC/build/Release"
+            if [ ! -f "$ORT_LIB_LOCATION/_deps/re2-build/libre2.a" ]; then
+              echo "==> Building ONNX Runtime 1.24.2 from source (static, musl)"
+              rm -rf "$ORT_SRC"
+              git clone --single-branch --branch v1.24.2 --recursive \
+                https://github.com/microsoft/onnxruntime.git "$ORT_SRC"
+              cd "$ORT_SRC"
+              ./build.sh \
+                --config Release \
+                --build_dir build \
+                --parallel \
+                --skip_tests \
+                --skip_submodule_sync \
+                --allow_running_as_root \
+                --compile_no_warning_as_error \
+                --no_kleidiai \
+                --no_sve \
+                --cmake_extra_defines \
+                  CMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  onnxruntime_BUILD_UNIT_TESTS=OFF \
+                  onnxruntime_BUILD_SHARED_LIB=OFF \
+                  onnxruntime_USE_KLEIDIAI=OFF
+              cmake --build "$ORT_LIB_LOCATION" --target re2 -j
+              cd /workspace
+            else
+              echo "==> Using cached ONNX Runtime static build"
+            fi
+
+            export ORT_LIB_LOCATION="$ORT_LIB_LOCATION"
+            export RUSTFLAGS="-C link-arg=-lgcc"
+            cargo build --target ${{ matrix.target }}
+          '
 
   security:
     name: Security Audit
@@ -170,10 +292,19 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
 
+    - name: Download ONNX Runtime static library
+      shell: bash
+      run: |
+        ORT_VERSION="1.24.2"
+        ORT_ASSET="onnxruntime-linux-x64-static_lib-${ORT_VERSION}-glibc2_17"
+        curl -sL "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${ORT_VERSION}/${ORT_ASSET}.zip" -o /tmp/ort.zip
+        unzip -q /tmp/ort.zip -d /tmp/ort
+        echo "ORT_LIB_LOCATION=/tmp/ort/${ORT_ASSET}/lib" >> "$GITHUB_ENV"
+
     - name: Generate code coverage
       env:
         RUSTC_WRAPPER: sccache
-      run: cargo tarpaulin --verbose --no-default-features --workspace --timeout 120 --out xml
+      run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,27 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
 
+    # On macos-latest the runner ships a preinstalled rust that can collide
+    # with the toolchain dtolnay/rust-toolchain just installed — leaving
+    # `cargo` resolving to the `rustup-init` binary rather than the proxy.
+    # Force the requested toolchain as default and dump the proxy state
+    # before tests run. Diagnostic output is harmless on the other runners
+    # and invaluable when this breaks again.
+    - name: Verify Rust toolchain
+      shell: bash
+      run: |
+        set -x
+        echo "PATH=$PATH"
+        for bin in cargo rustc rustup rustup-init; do
+          command -v "$bin" || true
+        done
+        ls -la "$HOME/.cargo/bin/" || true
+        file "$HOME/.cargo/bin/cargo" || true
+        rustup default "${{ matrix.rust }}" || true
+        rustup show || true
+        cargo --version
+        rustc --version
+
     - name: Install protobuf compiler
       uses: arduino/setup-protoc@v3
       with:
@@ -301,10 +322,15 @@ jobs:
         unzip -q /tmp/ort.zip -d /tmp/ort
         echo "ORT_LIB_LOCATION=/tmp/ort/${ORT_ASSET}/lib" >> "$GITHUB_ENV"
 
+    # `--engine llvm` uses LLVM source-based coverage instead of the default
+    # ptrace engine. Ptrace requires `-Clink-dead-code`, which forces
+    # monomorphizations of dead-code paths and trips pulp v0.22.2's
+    # `CheckSameSize::<i8, u16>` const-eval assertion. llvm coverage doesn't
+    # need link-dead-code, so the offending instantiations never happen.
     - name: Generate code coverage
       env:
         RUSTC_WRAPPER: sccache
-      run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+      run: cargo tarpaulin --engine llvm --verbose --all-features --workspace --timeout 120 --out xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,16 +163,9 @@ jobs:
         # (dynamic CRT). Rust on MSVC defaults to /MT (static CRT) → __imp_*
         # unresolved-symbol link errors. Switch rust to dynamic CRT to match.
         # vcruntime140.dll is present on all GitHub Windows runners.
+        # (esaxx-rs is also /MT via hardcoded static_crt(true); patched via
+        # [patch.crates-io] in Cargo.toml to a vendored copy with /MD.)
         RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=-crt-static' || '' }}
-        # esaxx-rs 0.1.10 (pulled by tokenizers/esaxx_fast in the huggingface
-        # feature) hardcodes `cc::Build::static_crt(true)` in its build.rs,
-        # forcing /MT regardless of RUSTFLAGS. That conflicts with ort's /MD
-        # at link time (LNK2038 RuntimeLibrary mismatch). cc-rs appends
-        # CXXFLAGS_<target> AFTER its own /MT, and cl.exe takes the last
-        # /M* flag for both compile and the RuntimeLibrary directive in the
-        # .obj — so /MD wins. Same trick for CFLAGS in case any C dep flips.
-        CFLAGS_x86_64_pc_windows_msvc: ${{ runner.os == 'Windows' && '/MD' || '' }}
-        CXXFLAGS_x86_64_pc_windows_msvc: ${{ runner.os == 'Windows' && '/MD' || '' }}
       run: cargo test --verbose --all-features
 
   musl-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,14 @@ jobs:
                 echo "==> Using cached ONNX Runtime static build"
               fi
 
+              # Install protobuf-dev AFTER ORT build: lance-encoding build.rs
+              # needs the well-known .proto includes (google/protobuf/empty.proto)
+              # which only ship in protobuf-dev. Installing it earlier would pull
+              # abseil-cpp-dev and make ORT CMake skip its bundled abseil + drop
+              # re2. By this point ORT artifacts already exist, and cargo only
+              # links pre-built .a files via ORT_LIB_LOCATION.
+              apk add --no-cache protobuf-dev
+
               # ort-sys static_config #1 with empty profile detection.
               # ORT_LIB_LOCATION = build/Release (where libonnxruntime_common.a lives directly).
               # Profile detection iterates build/Release/{Release,RelWithDebInfo,...},

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,46 +208,170 @@ jobs:
         free -h
         swapon --show
 
+    # Cache the static ONNX Runtime build for targets where pyke ships no
+    # prebuilts (musl, x86_64-apple-darwin). Cache full source+build tree
+    # because ort-sys's full static-link branch needs build/_deps/ subtrees
+    # for re2/abseil/protobuf/etc.
+    - name: Cache ONNX Runtime static build
+      if: endsWith(matrix.target, '-unknown-linux-musl') || matrix.target == 'x86_64-apple-darwin'
+      uses: actions/cache@v4
+      with:
+        path: onnxruntime-src
+        key: onnxruntime-1.24.2-${{ matrix.target }}-v6
+
     - name: Build binary
       shell: sh
       run: |
         if [ "${{ runner.os }}" = "Linux" ]; then
-          # Use official Rust Docker image for Linux builds
-          # Select correct sccache binary for the target architecture
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
-            SCCACHE_ARCH="aarch64-unknown-linux-musl"
-          else
-            SCCACHE_ARCH="x86_64-unknown-linux-musl"
-          fi
+          # Linux musl: build ONNX Runtime statically from source inside Alpine,
+          # then build octocode with fastembed enabled, linking ort-sys against
+          # the local static build via ORT_LIB_LOCATION. Pyke ships no musl
+          # prebuilts, so this is the only supported path. ORT 1.24.2 matches
+          # ort-sys 2.0.0-rc.12 / fastembed's api-24 feature.
+          #
+          # Pre-create the cache dir on the host so Docker volume-mount
+          # inherits writable permissions.
+          mkdir -p onnxruntime-src
+          chmod -R 777 onnxruntime-src
+
           docker run --rm \
+            --user 0:0 \
             -v "$(pwd):/workspace" \
-            -v "$RUNNER_TEMP/sccache-cache:/sccache-cache" \
             -w /workspace \
-            -e SCCACHE_GHA_ENABLED=true \
-            -e ACTIONS_CACHE_URL="${ACTIONS_CACHE_URL}" \
-            -e ACTIONS_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN}" \
-            -e SCCACHE_DIR=/sccache-cache \
-            rust:1.95.0-alpine3.23 \
-            sh -c "
-              apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconfig gcc g++ protobuf-dev curl && \
-              curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-${SCCACHE_ARCH}.tar.gz | tar xz --strip-components=1 -C /usr/local/bin sccache-v0.10.0-${SCCACHE_ARCH}/sccache && \
-              rustup target add ${{ matrix.target }} && \
-              if sccache --start-server 2>/dev/null; then
-                export RUSTC_WRAPPER=sccache
-              fi && \
-              cargo build --release --target ${{ matrix.target }} --no-default-features
-            "
+            rust:1.95.0-alpine3.22 \
+            sh -c '
+              set -eu
+              # No protobuf-dev: it pulls in abseil-cpp-dev transitively, which
+              # makes ORT'\''s CMake skip its bundled abseil and (because re2
+              # depends on bundled absl targets) drop re2 from the build entirely.
+              # ort-sys 2.0.0-rc.12 hardcodes static links to ~25 absl_*, re2,
+              # protobuf libs at fixed _deps/ paths, so all three must be built
+              # by ORT, not the system. Without the system packages ORT
+              # FetchContent'\''s and compiles all three from source.
+              apk add --no-cache \
+                git perl bash musl-dev openssl-dev openssl-libs-static \
+                pkgconfig gcc g++ \
+                cmake make linux-headers python3 py3-pip patch
+
+              # Provide stub execinfo.h — musl lacks it and Alpine 3.17+ removed
+              # libexecinfo. ORT'\''s stacktrace.cc unconditionally includes it on
+              # non-Android POSIX. The stub provides no-op backtrace functions.
+              mkdir -p /tmp/include
+              cat > /tmp/include/execinfo.h << "EOF"
+        #ifndef _EXECINFO_H
+        #define _EXECINFO_H
+        #include <stddef.h>
+        static inline int backtrace(void **buffer, int size) { (void)buffer; (void)size; return 0; }
+        static inline char **backtrace_symbols(void *const *buffer, int size) { (void)buffer; (void)size; return NULL; }
+        static inline void backtrace_symbols_fd(void *const *buffer, int size, int fd) { (void)buffer; (void)size; (void)fd; }
+        #endif
+        EOF
+              export C_INCLUDE_PATH=/tmp/include
+              export CPLUS_INCLUDE_PATH=/tmp/include
+
+              rustup target add ${{ matrix.target }}
+
+              ORT_SRC=/workspace/onnxruntime-src
+              ORT_LIB_LOCATION="$ORT_SRC/build/Release"
+              # libre2.a is the late marker — re2 is built last in the bundled
+              # dep graph (after abseil + protobuf), so its presence proves the
+              # full static tree is in place. A partial cache that only has
+              # libonnxruntime_common.a but no libre2.a triggers a clean rebuild.
+              if [ ! -f "$ORT_LIB_LOCATION/_deps/re2-build/libre2.a" ]; then
+                echo "==> Building ONNX Runtime 1.24.2 from source (static, musl)"
+                rm -rf "$ORT_SRC"
+                git clone --single-branch --branch v1.24.2 --recursive \
+                  https://github.com/microsoft/onnxruntime.git "$ORT_SRC"
+                cd "$ORT_SRC"
+                ./build.sh \
+                  --config Release \
+                  --build_dir build \
+                  --parallel \
+                  --skip_tests \
+                  --skip_submodule_sync \
+                  --allow_running_as_root \
+                  --compile_no_warning_as_error \
+                  --no_kleidiai \
+                  --no_sve \
+                  --cmake_extra_defines \
+                    CMAKE_POSITION_INDEPENDENT_CODE=ON \
+                    onnxruntime_BUILD_UNIT_TESTS=OFF \
+                    onnxruntime_BUILD_SHARED_LIB=OFF \
+                    onnxruntime_USE_KLEIDIAI=OFF
+                # ORT'\''s static build (.a archives, --skip_tests) never link an
+                # executable, so target_link_libraries deps like re2::re2 don'\''t
+                # trigger compilation — re2 is FetchContent-populated but its
+                # CMake target stays unbuilt. ort-sys 2.0.0-rc.12 hardcodes a
+                # static link to it. Explicitly drive the re2 target inside ORT'\''s
+                # configured build tree (uses bundled abseil from the same tree).
+                cmake --build "$ORT_LIB_LOCATION" --target re2 -j
+                cd /workspace
+              else
+                echo "==> Using cached ONNX Runtime static build"
+              fi
+
+              # ort-sys static_config #1 with empty profile detection.
+              # ORT_LIB_LOCATION = build/Release (where libonnxruntime_common.a lives directly).
+              # Profile detection iterates build/Release/{Release,RelWithDebInfo,...},
+              # none exist → profile="" → transform_dep adds no suffix.
+              # lib_dir = base ✓, external_lib_dir = base/_deps = build/Release/_deps
+              # which is where cmake actually places onnx-build/, re2-build/, abseil_cpp-build/, etc.
+              #
+              # DO NOT use ORT_LIB_LOCATION="$ORT_SRC/build": that triggers profile=Release
+              # detection, which makes transform_dep append /Release to every _deps path,
+              # so search paths land at build/_deps/onnx-build/Release (non-existent) and
+              # linking fails with "could not find native static library '\''onnx'\''".
+              export ORT_LIB_LOCATION="$ORT_LIB_LOCATION"
+              # GCC 15 (Alpine 3.23) introduced __cpu_features2 in libgcc.
+              # ORT'\''s cpuid_info.cc.o references it; musl static link needs
+              # libgcc.a explicitly or the symbol is undefined at link time.
+              export RUSTFLAGS="-C link-arg=-lgcc"
+              cargo build --release --target ${{ matrix.target }}
+            '
         elif [ "${{ runner.os }}" = "Windows" ]; then
-          # Windows: disable default features to avoid ONNX Runtime issues
-          cargo build --release --target ${{ matrix.target }} --no-default-features
-        elif [ "${{ runner.os }}" = "macOS" ]; then
-          # macOS: only use --no-default-features for x86_64 (Intel) due to ONNX Runtime
-          # not providing prebuilt binaries for this target. aarch64 (Apple Silicon) works.
-          if [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
-            cargo build --release --target ${{ matrix.target }} --no-default-features
+          # Pyke's prebuilt ORT static lib is compiled with /MD (dynamic CRT).
+          # Rust on MSVC defaults to /MT (static CRT) → __imp_* unresolved
+          # symbol errors at link time. Switch to dynamic CRT to match.
+          # vcruntime140.dll is present on all Windows hosts.
+          export RUSTFLAGS="-C target-feature=-crt-static"
+          cargo build --release --target ${{ matrix.target }}
+        elif [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
+          # macOS x86_64: pyke 2.0.0-rc.12 ships no x86_64-apple-darwin
+          # prebuilt (xcframework linking unsupported on this target). Build
+          # ONNX Runtime 1.24.2 from source statically and link via
+          # ORT_LIB_LOCATION, same approach as Linux musl.
+          ORT_SRC="$(pwd)/onnxruntime-src"
+          ORT_LIB_LOCATION="$ORT_SRC/build/Release"
+          if [ ! -f "$ORT_LIB_LOCATION/_deps/re2-build/libre2.a" ]; then
+            echo "==> Building ONNX Runtime 1.24.2 from source (static, macOS x86_64)"
+            rm -rf "$ORT_SRC"
+            git clone --single-branch --branch v1.24.2 --recursive \
+              https://github.com/microsoft/onnxruntime.git "$ORT_SRC"
+            (cd "$ORT_SRC" && ./build.sh \
+              --config Release \
+              --build_dir build \
+              --parallel \
+              --skip_tests \
+              --skip_submodule_sync \
+              --compile_no_warning_as_error \
+              --cmake_extra_defines \
+                CMAKE_POSITION_INDEPENDENT_CODE=ON \
+                CMAKE_OSX_ARCHITECTURES=x86_64 \
+                CMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+                onnxruntime_BUILD_UNIT_TESTS=OFF \
+                onnxruntime_BUILD_SHARED_LIB=OFF)
+            # Static archive build never links an executable, so re2's
+            # CMake target stays unbuilt while ort-sys hardcodes a static
+            # link to libre2.a. Force-build it.
+            cmake --build "$ORT_LIB_LOCATION" --target re2 -j
           else
-            cargo build --release --target ${{ matrix.target }}
+            echo "==> Using cached ONNX Runtime static build"
           fi
+          export ORT_LIB_LOCATION="$ORT_LIB_LOCATION"
+          cargo build --release --target ${{ matrix.target }}
+        else
+          # Native build for other macOS targets (aarch64) — pyke ships prebuilts.
+          cargo build --release --target ${{ matrix.target }}
         fi
     - name: Create archive directory
       shell: sh
@@ -335,7 +459,7 @@ jobs:
       if: steps.check_published.outputs.already_published == 'false'
       run: |
         echo "🔍 Running dry-run publish to validate package..."
-        cargo publish --dry-run --no-default-features
+        cargo publish --dry-run
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -343,7 +467,7 @@ jobs:
       if: steps.check_published.outputs.already_published == 'false'
       run: |
         echo "🚀 Publishing to crates.io..."
-        cargo publish --no-default-features
+        cargo publish
         echo "✅ Successfully published to crates.io!"
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,9 +339,21 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           # Pyke's prebuilt ORT static lib is compiled with /MD (dynamic CRT).
           # Rust on MSVC defaults to /MT (static CRT) → __imp_* unresolved
-          # symbol errors at link time. Switch to dynamic CRT to match.
+          # symbol errors at link time. Switch rust to dynamic CRT to match.
           # vcruntime140.dll is present on all Windows hosts.
           export RUSTFLAGS="-C target-feature=-crt-static"
+          # esaxx-rs 0.1.10 (pulled by tokenizers/esaxx_fast) hardcodes
+          # cc::Build::static_crt(true), forcing /MT regardless of RUSTFLAGS.
+          # cc-rs appends CXXFLAGS_<target> AFTER its own /MT, and cl.exe
+          # takes the last /M* flag — so /MD wins both at compile time and
+          # in the .obj RuntimeLibrary directive. Mirror for CFLAGS too.
+          if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
+            export CFLAGS_x86_64_pc_windows_msvc=/MD
+            export CXXFLAGS_x86_64_pc_windows_msvc=/MD
+          else
+            export CFLAGS_aarch64_pc_windows_msvc=/MD
+            export CXXFLAGS_aarch64_pc_windows_msvc=/MD
+          fi
           cargo build --release --target ${{ matrix.target }}
         elif [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
           # macOS x86_64: pyke 2.0.0-rc.12 ships no x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,19 +341,9 @@ jobs:
           # Rust on MSVC defaults to /MT (static CRT) → __imp_* unresolved
           # symbol errors at link time. Switch rust to dynamic CRT to match.
           # vcruntime140.dll is present on all Windows hosts.
+          # (esaxx-rs is also /MT via hardcoded static_crt(true); patched via
+          # [patch.crates-io] in Cargo.toml to a vendored copy with /MD.)
           export RUSTFLAGS="-C target-feature=-crt-static"
-          # esaxx-rs 0.1.10 (pulled by tokenizers/esaxx_fast) hardcodes
-          # cc::Build::static_crt(true), forcing /MT regardless of RUSTFLAGS.
-          # cc-rs appends CXXFLAGS_<target> AFTER its own /MT, and cl.exe
-          # takes the last /M* flag — so /MD wins both at compile time and
-          # in the .obj RuntimeLibrary directive. Mirror for CFLAGS too.
-          if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
-            export CFLAGS_x86_64_pc_windows_msvc=/MD
-            export CXXFLAGS_x86_64_pc_windows_msvc=/MD
-          else
-            export CFLAGS_aarch64_pc_windows_msvc=/MD
-            export CXXFLAGS_aarch64_pc_windows_msvc=/MD
-          fi
           cargo build --release --target ${{ matrix.target }}
         elif [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
           # macOS x86_64: pyke 2.0.0-rc.12 ships no x86_64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,8 +2122,7 @@ dependencies = [
 [[package]]
 name = "esaxx-rs"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+source = "git+https://github.com/ocentra/esaxx-rs?rev=4f4fd5acd624e43c770a0d198fcaa9d97bfd7f0b#4f4fd5acd624e43c770a0d198fcaa9d97bfd7f0b"
 dependencies = [
  "cc",
 ]
@@ -4772,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "octolib"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5960f24a5c3a48e13c2406ca9aa0b4123b49a13d5c63ef507c711cadbae946e"
+checksum = "ec833fb6df7129c81cdeca503ae94989b8f7cab9b705a3999c0e6cf5c8a02a19"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,15 @@ hyper = { version = "1", features = ["server", "http1"] }  # Required for HTTP m
 hyper-util = { version = "0.1", features = ["server", "tokio", "service"] }  # Required for HTTP mode connection handling
 http-body-util = "0.1"  # Required for proxy HTTP body types (matches rmcp's version)
 
+# Replace esaxx-rs 0.1.10 (transitive: tokenizers/esaxx_fast → esaxx-rs/cpp).
+# Upstream build.rs hardcodes cc::Build::static_crt(true), forcing /MT on
+# Windows MSVC and producing LNK2038 RuntimeLibrary mismatches when linking
+# with ort (pyke prebuilt onnxruntime, built /MD). Pinned by SHA so a
+# force-push on the fork branch cannot silently flip our build.
+# Upstream PR: https://github.com/Narsil/esaxx-rs/pull/19 (unmerged).
+[patch.crates-io]
+esaxx-rs = { git = "https://github.com/ocentra/esaxx-rs", rev = "4f4fd5acd624e43c770a0d198fcaa9d97bfd7f0b" }
+
 [profile.dev]
 opt-level = 1          # Basic optimizations without slowing compilation too much
 debug = true           # Keep debug symbols for backtraces

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,26 @@ RUN apt-get update && apt-get install -y \
 		pkg-config \
 		protobuf-compiler \
 		libssl-dev \
+		curl \
+		unzip \
 		&& rm -rf /var/lib/apt/lists/*
+
+# Download prebuilt static ONNX Runtime (csukuangfj/onnxruntime-libs).
+# ort-sys's single-file shortcut links libonnxruntime.a directly; built
+# against glibc 2.17 so it works on debian bookworm and older.
+ENV ORT_VERSION=1.24.2
+RUN set -eu; \
+		case "$(uname -m)" in \
+			x86_64)  ORT_ARCH=x64 ;; \
+			aarch64) ORT_ARCH=arm64 ;; \
+			*) echo "unsupported arch $(uname -m)"; exit 1 ;; \
+		esac; \
+		ORT_ASSET="onnxruntime-linux-${ORT_ARCH}-static_lib-${ORT_VERSION}-glibc2_17"; \
+		curl -sL "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${ORT_VERSION}/${ORT_ASSET}.zip" -o /tmp/ort.zip; \
+		unzip -q /tmp/ort.zip -d /opt; \
+		ln -s "/opt/${ORT_ASSET}/lib" /opt/ort-lib; \
+		rm /tmp/ort.zip
+ENV ORT_LIB_LOCATION=/opt/ort-lib
 
 # Create app directory
 WORKDIR /app
@@ -35,7 +54,7 @@ RUN mkdir -p src && echo 'fn main() {}' > src/main.rs
 # Build dependencies only (cached via BuildKit mount)
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
 	--mount=type=cache,target=/app/target \
-	cargo build --release --no-default-features 2>/dev/null || true
+	cargo build --release 2>/dev/null || true
 
 # Remove dummy source and copy real source code + config templates
 RUN rm -rf src
@@ -45,7 +64,7 @@ COPY config-templates ./config-templates
 # Build the application (dependencies hit cache, only source recompiled)
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
 	--mount=type=cache,target=/app/target \
-	touch src/main.rs && cargo build --release --no-default-features
+	touch src/main.rs && cargo build --release
 
 # Copy binary out of cache mount to a known location
 RUN --mount=type=cache,target=/app/target \


### PR DESCRIPTION
- Add musl-specific build job using Alpine 3.22 Docker container
- Implement caching for ONNX Runtime static library artifacts
- Configure static linking for glibc and musl Linux runners
- Fix MSVC link errors on Windows by disabling static CRT
- Add source builds for musl and x86_64-apple-darwin targets
- Download prebuilt static ONNX libraries for x64 and arm64 in Docker
- Configure ORT_LIB_LOCATION for static linking during builds
- Add stub execinfo.h for Alpine compatibility
- Force build re2 dependency for static linking
- Enable all-features and remove no-default-features restrictions
- Install curl and unzip for dependency retrieval in Docker steps