### PR TITLE
refactor(store): centralize table names and secure SQL queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3384,9 +3384,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3399,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6131,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"

--- a/src/store/block_trait.rs
+++ b/src/store/block_trait.rs
@@ -42,7 +42,7 @@ pub trait BlockType: Clone + Send + Sync + 'static {
 }
 
 impl BlockType for CodeBlock {
-	const TABLE_NAME: &'static str = "code_blocks";
+	const TABLE_NAME: &'static str = super::tables::CODE_BLOCKS;
 
 	fn to_batch(
 		blocks: &[Self],
@@ -71,7 +71,7 @@ impl BlockType for CodeBlock {
 }
 
 impl BlockType for TextBlock {
-	const TABLE_NAME: &'static str = "text_blocks";
+	const TABLE_NAME: &'static str = super::tables::TEXT_BLOCKS;
 
 	fn to_batch(
 		blocks: &[Self],
@@ -100,7 +100,7 @@ impl BlockType for TextBlock {
 }
 
 impl BlockType for DocumentBlock {
-	const TABLE_NAME: &'static str = "document_blocks";
+	const TABLE_NAME: &'static str = super::tables::DOCUMENT_BLOCKS;
 
 	fn to_batch(
 		blocks: &[Self],
@@ -129,7 +129,7 @@ impl BlockType for DocumentBlock {
 }
 
 impl BlockType for CommitBlock {
-	const TABLE_NAME: &'static str = "commit_blocks";
+	const TABLE_NAME: &'static str = super::tables::COMMIT_BLOCKS;
 
 	fn to_batch(
 		blocks: &[Self],

--- a/src/store/debug.rs
+++ b/src/store/debug.rs
@@ -25,8 +25,8 @@ use lancedb::{
 };
 
 use crate::store::{
-	batch_converter::BatchConverter, table_ops::TableOperations, CodeBlock, DocumentBlock,
-	TextBlock,
+	batch_converter::BatchConverter, sql::escape_single_quotes, table_ops::TableOperations, tables,
+	CodeBlock, DocumentBlock, TextBlock,
 };
 
 /// Debug and inspection operations for the database
@@ -50,7 +50,11 @@ impl<'a> DebugOperations<'a> {
 		let table_names = self.db.table_names().execute().await?;
 		let mut total_files = 0;
 
-		for table_name in &["code_blocks", "text_blocks", "document_blocks"] {
+		for table_name in &[
+			tables::CODE_BLOCKS,
+			tables::TEXT_BLOCKS,
+			tables::DOCUMENT_BLOCKS,
+		] {
 			if table_names.contains(&table_name.to_string()) {
 				println!("\n📁 Files in {} table:", table_name);
 				let table = self.db.open_table(*table_name).execute().await?;
@@ -110,7 +114,7 @@ impl<'a> DebugOperations<'a> {
 		println!("{}", "=".repeat(80));
 
 		// Check code_blocks table
-		if table_names.contains(&"code_blocks".to_string()) {
+		if table_names.contains(&tables::CODE_BLOCKS.to_string()) {
 			if let Ok(chunks) = self.get_file_code_blocks(file_path).await {
 				if !chunks.is_empty() {
 					found_in_any_table = true;
@@ -133,7 +137,7 @@ impl<'a> DebugOperations<'a> {
 		}
 
 		// Check text_blocks table
-		if table_names.contains(&"text_blocks".to_string()) {
+		if table_names.contains(&tables::TEXT_BLOCKS.to_string()) {
 			if let Ok(chunks) = self.get_file_text_blocks(file_path).await {
 				if !chunks.is_empty() {
 					found_in_any_table = true;
@@ -154,7 +158,7 @@ impl<'a> DebugOperations<'a> {
 		}
 
 		// Check document_blocks table
-		if table_names.contains(&"document_blocks".to_string()) {
+		if table_names.contains(&tables::DOCUMENT_BLOCKS.to_string()) {
 			if let Ok(chunks) = self.get_file_document_blocks(file_path).await {
 				if !chunks.is_empty() {
 					found_in_any_table = true;
@@ -194,11 +198,11 @@ impl<'a> DebugOperations<'a> {
 
 	/// Get all code blocks for a specific file
 	async fn get_file_code_blocks(&self, file_path: &str) -> Result<Vec<CodeBlock>> {
-		let table = self.db.open_table("code_blocks").execute().await?;
+		let table = self.db.open_table(tables::CODE_BLOCKS).execute().await?;
 
 		let mut results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(format!("path = '{}'", escape_single_quotes(file_path)))
 			.execute()
 			.await?;
 
@@ -218,11 +222,11 @@ impl<'a> DebugOperations<'a> {
 
 	/// Get all text blocks for a specific file
 	async fn get_file_text_blocks(&self, file_path: &str) -> Result<Vec<TextBlock>> {
-		let table = self.db.open_table("text_blocks").execute().await?;
+		let table = self.db.open_table(tables::TEXT_BLOCKS).execute().await?;
 
 		let mut results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(format!("path = '{}'", escape_single_quotes(file_path)))
 			.execute()
 			.await?;
 
@@ -242,11 +246,15 @@ impl<'a> DebugOperations<'a> {
 
 	/// Get all document blocks for a specific file
 	async fn get_file_document_blocks(&self, file_path: &str) -> Result<Vec<DocumentBlock>> {
-		let table = self.db.open_table("document_blocks").execute().await?;
+		let table = self
+			.db
+			.open_table(tables::DOCUMENT_BLOCKS)
+			.execute()
+			.await?;
 
 		let mut results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(format!("path = '{}'", escape_single_quotes(file_path)))
 			.execute()
 			.await?;
 

--- a/src/store/graphrag.rs
+++ b/src/store/graphrag.rs
@@ -22,7 +22,7 @@ use arrow_array::{Array, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 
 // LanceDB imports
-use crate::store::{table_ops::TableOperations, CodeBlock};
+use crate::store::{sql::escape_single_quotes, table_ops::TableOperations, tables, CodeBlock};
 use futures::TryStreamExt;
 use lancedb::{
 	query::{ExecutableQuery, QueryBase},
@@ -184,13 +184,13 @@ impl<'a> GraphRagOperations<'a> {
 		// Check if relationships table exists
 		if !self
 			.table_ops
-			.table_exists("graphrag_relationships")
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
 			.await?
 		{
 			return Ok(());
 		}
 
-		let table = self.get_table("graphrag_relationships").await?;
+		let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		// Stream all relationships
 		let mut results = table.query().execute().await?;
@@ -386,11 +386,11 @@ impl<'a> GraphRagOperations<'a> {
 
 	/// Get all node IDs from the database
 	async fn get_all_node_ids(&self) -> Result<Vec<String>> {
-		if !self.table_ops.table_exists("graphrag_nodes").await? {
+		if !self.table_ops.table_exists(tables::GRAPHRAG_NODES).await? {
 			return Ok(Vec::new());
 		}
 
-		let table = self.get_table("graphrag_nodes").await?;
+		let table = self.get_table(tables::GRAPHRAG_NODES).await?;
 		let mut results = table.query().execute().await?;
 
 		let mut node_ids = Vec::new();
@@ -419,15 +419,15 @@ impl<'a> GraphRagOperations<'a> {
 		// Check if GraphRAG tables exist
 		if !self
 			.table_ops
-			.tables_exist(&["graphrag_nodes", "graphrag_relationships"])
+			.tables_exist(&[tables::GRAPHRAG_NODES, tables::GRAPHRAG_RELATIONSHIPS])
 			.await?
 		{
 			return Ok(true); // Tables don't exist, need indexing
 		}
 
 		// Check if tables are empty
-		let nodes_table = self.get_table("graphrag_nodes").await?;
-		let relationships_table = self.get_table("graphrag_relationships").await?;
+		let nodes_table = self.get_table(tables::GRAPHRAG_NODES).await?;
+		let relationships_table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		let nodes_count = nodes_table.count_rows(None).await?;
 		let relationships_count = relationships_table.count_rows(None).await?;
@@ -448,11 +448,11 @@ impl<'a> GraphRagOperations<'a> {
 	pub async fn get_all_code_blocks_for_graphrag(&self) -> Result<Vec<CodeBlock>> {
 		let mut all_blocks = Vec::new();
 
-		if !self.table_ops.table_exists("code_blocks").await? {
+		if !self.table_ops.table_exists(tables::CODE_BLOCKS).await? {
 			return Ok(all_blocks);
 		}
 
-		let table = self.get_table("code_blocks").await?;
+		let table = self.get_table(tables::CODE_BLOCKS).await?;
 
 		// Get all code blocks in batches to avoid memory issues
 		let mut results = table.query().execute().await?;
@@ -483,24 +483,25 @@ impl<'a> GraphRagOperations<'a> {
 	pub async fn store_graph_nodes(&self, node_batch: RecordBatch) -> Result<()> {
 		// Use the same proven pattern as code_blocks, text_blocks, document_blocks
 		self.table_ops
-			.store_batch("graphrag_nodes", node_batch)
+			.store_batch(tables::GRAPHRAG_NODES, node_batch)
 			.await?;
 
-		// Create or optimize vector index based on dataset growth
-		if let Ok(table) = self.db.open_table("graphrag_nodes").execute().await {
-			let row_count = table.count_rows(None).await?;
+		// Create the vector index once the table is large enough to benefit (the
+		// optimizer skips indexing small datasets where brute-force is faster).
+		// Extending the index to cover rows added by later batches is handled by
+		// `Store::optimize_tables`, the LanceDB-recommended maintenance pass.
+		if let Ok(table) = self.db.open_table(tables::GRAPHRAG_NODES).execute().await {
 			let indices = table.list_indices().await?;
 			let has_index = indices.iter().any(|idx| idx.columns == vec!["embedding"]);
-			let use_quantization = crate::config::Config::load()
-				.map(|c| c.index.quantization)
-				.unwrap_or(true);
 
 			if !has_index {
-				// Create initial index
+				let use_quantization = crate::config::Config::load()
+					.map(|c| c.index.quantization)
+					.unwrap_or(true);
 				if let Err(e) = self
 					.table_ops
 					.create_vector_index_optimized(
-						"graphrag_nodes",
+						tables::GRAPHRAG_NODES,
 						"embedding",
 						self.code_vector_dim,
 						use_quantization,
@@ -508,33 +509,9 @@ impl<'a> GraphRagOperations<'a> {
 					.await
 				{
 					tracing::warn!(
-						"Failed to create optimized vector index on graph_nodes: {}",
+						"Failed to create optimized vector index on graphrag_nodes: {}",
 						e
 					);
-				}
-			} else {
-				// Check if we should optimize existing index due to growth
-				if super::vector_optimizer::VectorOptimizer::should_optimize_for_growth(
-					row_count,
-					self.code_vector_dim,
-					true,
-				) {
-					tracing::info!("Dataset growth detected, optimizing graphrag_nodes index");
-					if let Err(e) = self
-						.table_ops
-						.recreate_vector_index_optimized(
-							"graphrag_nodes",
-							"embedding",
-							self.code_vector_dim,
-							use_quantization,
-						)
-						.await
-					{
-						tracing::warn!(
-							"Failed to recreate optimized vector index on graphrag_nodes: {}",
-							e
-						);
-					}
 				}
 			}
 		}
@@ -546,7 +523,7 @@ impl<'a> GraphRagOperations<'a> {
 	pub async fn store_graph_relationships(&self, rel_batch: RecordBatch) -> Result<()> {
 		// Store in database first
 		self.table_ops
-			.store_batch("graphrag_relationships", rel_batch.clone())
+			.store_batch(tables::GRAPHRAG_RELATIONSHIPS, rel_batch.clone())
 			.await?;
 
 		// Update adjacency cache with new relationships
@@ -596,7 +573,7 @@ impl<'a> GraphRagOperations<'a> {
 
 	/// Clear all graph nodes from the database
 	pub async fn clear_graph_nodes(&self) -> Result<()> {
-		self.table_ops.clear_table("graphrag_nodes").await?;
+		self.table_ops.clear_table(tables::GRAPHRAG_NODES).await?;
 		// Clear cache when clearing nodes
 		self.clear_cache();
 		Ok(())
@@ -604,7 +581,9 @@ impl<'a> GraphRagOperations<'a> {
 
 	/// Clear all graph relationships from the database
 	pub async fn clear_graph_relationships(&self) -> Result<()> {
-		self.table_ops.clear_table("graphrag_relationships").await?;
+		self.table_ops
+			.clear_table(tables::GRAPHRAG_RELATIONSHIPS)
+			.await?;
 		// Clear cache when clearing relationships
 		self.clear_cache();
 		Ok(())
@@ -619,7 +598,7 @@ impl<'a> GraphRagOperations<'a> {
 		let relationships_removed = self.remove_graph_relationships_by_path(file_path).await?;
 		let nodes_removed = node_ids.len();
 		self.table_ops
-			.remove_blocks_by_path(file_path, "graphrag_nodes")
+			.remove_blocks_by_path(file_path, tables::GRAPHRAG_NODES)
 			.await?;
 
 		// Invalidate cache for removed nodes
@@ -643,7 +622,7 @@ impl<'a> GraphRagOperations<'a> {
 	pub async fn remove_graph_relationships_by_path(&self, file_path: &str) -> Result<usize> {
 		if !self
 			.table_ops
-			.table_exists("graphrag_relationships")
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
 			.await?
 		{
 			return Ok(0);
@@ -655,15 +634,16 @@ impl<'a> GraphRagOperations<'a> {
 			return Ok(0); // No nodes for this file, so no relationships to remove
 		}
 
-		let table = self.get_table("graphrag_relationships").await?;
+		let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		// Create filter for relationships where source OR target is any of the node IDs
 		let node_filters: Vec<String> = node_ids
 			.iter()
 			.flat_map(|node_id| {
+				let escaped = escape_single_quotes(node_id);
 				vec![
-					format!("source = '{}'", node_id),
-					format!("target = '{}'", node_id),
+					format!("source = '{}'", escaped),
+					format!("target = '{}'", escaped),
 				]
 			})
 			.collect();
@@ -688,16 +668,16 @@ impl<'a> GraphRagOperations<'a> {
 	async fn get_node_ids_for_file_path(&self, file_path: &str) -> Result<Vec<String>> {
 		let mut node_ids = Vec::new();
 
-		if !self.table_ops.table_exists("graphrag_nodes").await? {
+		if !self.table_ops.table_exists(tables::GRAPHRAG_NODES).await? {
 			return Ok(node_ids);
 		}
 
-		let table = self.get_table("graphrag_nodes").await?;
+		let table = self.get_table(tables::GRAPHRAG_NODES).await?;
 
 		// Query for nodes matching the file path, only selecting id column
 		let mut results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(format!("path = '{}'", escape_single_quotes(file_path)))
 			.select(lancedb::query::Select::Columns(vec!["id".to_string()]))
 			.execute()
 			.await?;
@@ -722,7 +702,7 @@ impl<'a> GraphRagOperations<'a> {
 
 	/// Get all graph nodes via full table scan (no vector search, no limit)
 	pub async fn get_all_graph_nodes(&self) -> Result<RecordBatch> {
-		if !self.table_ops.table_exists("graphrag_nodes").await? {
+		if !self.table_ops.table_exists(tables::GRAPHRAG_NODES).await? {
 			let schema = Arc::new(Schema::new(vec![
 				Field::new("id", DataType::Utf8, false),
 				Field::new("name", DataType::Utf8, false),
@@ -740,7 +720,7 @@ impl<'a> GraphRagOperations<'a> {
 			return Ok(RecordBatch::new_empty(schema));
 		}
 
-		let table = self.get_table("graphrag_nodes").await?;
+		let table = self.get_table(tables::GRAPHRAG_NODES).await?;
 
 		let mut results = table.query().execute().await?;
 
@@ -788,7 +768,7 @@ impl<'a> GraphRagOperations<'a> {
 			));
 		}
 
-		if !self.table_ops.table_exists("graphrag_nodes").await? {
+		if !self.table_ops.table_exists(tables::GRAPHRAG_NODES).await? {
 			// Return empty batch with expected schema that matches the actual storage schema
 			let schema = Arc::new(Schema::new(vec![
 				Field::new("id", DataType::Utf8, false),
@@ -807,7 +787,7 @@ impl<'a> GraphRagOperations<'a> {
 			return Ok(RecordBatch::new_empty(schema));
 		}
 
-		let table = self.get_table("graphrag_nodes").await?;
+		let table = self.get_table(tables::GRAPHRAG_NODES).await?;
 
 		// Perform vector similarity search with optimization
 		let query = table
@@ -819,7 +799,7 @@ impl<'a> GraphRagOperations<'a> {
 		let optimized_query = crate::store::vector_optimizer::VectorOptimizer::optimize_query(
 			query,
 			&table,
-			"graphrag_nodes",
+			tables::GRAPHRAG_NODES,
 		)
 		.await
 		.map_err(|e| anyhow::anyhow!("Failed to optimize query: {}", e))?;
@@ -877,7 +857,7 @@ impl<'a> GraphRagOperations<'a> {
 	pub async fn get_graph_relationships(&self) -> Result<RecordBatch> {
 		if !self
 			.table_ops
-			.table_exists("graphrag_relationships")
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
 			.await?
 		{
 			// Return empty batch with expected schema that matches the actual storage schema
@@ -893,7 +873,7 @@ impl<'a> GraphRagOperations<'a> {
 			return Ok(RecordBatch::new_empty(schema));
 		}
 
-		let table = self.get_table("graphrag_relationships").await?;
+		let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		// Get all relationships
 		let mut results = table.query().execute().await?;
@@ -939,15 +919,16 @@ impl<'a> GraphRagOperations<'a> {
 
 		if !self
 			.table_ops
-			.table_exists("graphrag_relationships")
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
 			.await?
 		{
 			return Ok(Vec::new());
 		}
 
-		let table = self.get_table("graphrag_relationships").await?;
+		let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		// Build filter based on direction
+		let node_id = escape_single_quotes(node_id);
 		let filter = match direction {
 			RelationshipDirection::Outgoing => format!("source = '{}'", node_id),
 			RelationshipDirection::Incoming => format!("target = '{}'", node_id),
@@ -1036,13 +1017,13 @@ impl<'a> GraphRagOperations<'a> {
 	) -> Result<Vec<crate::indexer::graphrag::types::CodeRelationship>> {
 		if !self
 			.table_ops
-			.table_exists("graphrag_relationships")
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
 			.await?
 		{
 			return Ok(Vec::new());
 		}
 
-		let table = self.get_table("graphrag_relationships").await?;
+		let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		// Filter by relationship type
 		let filter = format!("relation_type = '{}'", relation_type.as_str());
@@ -1123,11 +1104,11 @@ impl<'a> GraphRagOperations<'a> {
 		offset: usize,
 		limit: usize,
 	) -> Result<Vec<crate::indexer::graphrag::types::CodeNode>> {
-		if !self.table_ops.table_exists("graphrag_nodes").await? {
+		if !self.table_ops.table_exists(tables::GRAPHRAG_NODES).await? {
 			return Ok(Vec::new());
 		}
 
-		let table = self.get_table("graphrag_nodes").await?;
+		let table = self.get_table(tables::GRAPHRAG_NODES).await?;
 
 		// Use proper pagination instead of vector search
 		let mut results = table.query().limit(limit).offset(offset).execute().await?;
@@ -1286,13 +1267,13 @@ impl<'a> GraphRagOperations<'a> {
 		// Reuse get_node_relationships logic but without filter
 		if !self
 			.table_ops
-			.table_exists("graphrag_relationships")
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
 			.await?
 		{
 			return Ok(Vec::new());
 		}
 
-		let table = self.get_table("graphrag_relationships").await?;
+		let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
 
 		let mut results = table.query().execute().await?;
 

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -26,7 +26,9 @@ use lancedb::{
 	Connection,
 };
 
+use crate::store::sql::escape_single_quotes;
 use crate::store::table_ops::TableOperations;
+use crate::store::tables;
 
 /// Handles git and file metadata operations
 pub struct MetadataOperations<'a> {
@@ -42,54 +44,31 @@ impl<'a> MetadataOperations<'a> {
 		}
 	}
 
-	/// Store git metadata (commit hash, etc.)
-	pub async fn store_git_metadata(&self, commit_hash: &str) -> Result<()> {
-		// Check if table exists, create if not
-		if !self.table_ops.table_exists("git_metadata").await? {
-			self.create_git_metadata_table().await?;
-		}
+	// ========================================================================
+	// Commit-marker tables
+	//
+	// `git_metadata`, `graphrag_git_metadata` and `commits_git_metadata` are
+	// structurally identical: each holds a single row tracking the last commit
+	// hash a given pipeline indexed, plus a timestamp. They differ only by which
+	// pipeline owns them, so the schema and the get/store logic are shared here
+	// and the per-pipeline methods are thin delegates.
+	// ========================================================================
 
-		// Check if the commit hash is already stored
-		if let Ok(Some(existing_hash)) = self.get_last_commit_hash().await {
-			if existing_hash == commit_hash {
-				// Same commit hash, no need to update
-				return Ok(());
-			}
-		}
-
-		// Create a record with the current timestamp
-		let schema = Arc::new(Schema::new(vec![
+	/// Schema shared by every commit-marker table.
+	fn commit_marker_schema() -> Arc<Schema> {
+		Arc::new(Schema::new(vec![
 			Field::new("commit_hash", DataType::Utf8, false),
 			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		let commit_hashes = vec![commit_hash];
-		let timestamps = vec![chrono::Utc::now().timestamp()];
-
-		let batch = RecordBatch::try_new(
-			schema,
-			vec![
-				Arc::new(StringArray::from(commit_hashes)),
-				Arc::new(Int64Array::from(timestamps)),
-			],
-		)?;
-
-		// Only clear and store if we have a different commit hash
-		self.table_ops.clear_table("git_metadata").await?;
-		self.table_ops.store_batch("git_metadata", batch).await?;
-
-		Ok(())
+		]))
 	}
 
-	/// Get last indexed git commit hash
-	pub async fn get_last_commit_hash(&self) -> Result<Option<String>> {
-		if !self.table_ops.table_exists("git_metadata").await? {
+	/// Read the stored commit hash from a commit-marker table, if present.
+	async fn get_commit_marker(&self, table_name: &str) -> Result<Option<String>> {
+		if !self.table_ops.table_exists(table_name).await? {
 			return Ok(None);
 		}
 
-		let table = self.db.open_table("git_metadata").execute().await?;
-
-		// Get the most recent commit hash
+		let table = self.db.open_table(table_name).execute().await?;
 		let mut results = table
 			.query()
 			.select(Select::Columns(vec!["commit_hash".to_string()]))
@@ -97,7 +76,6 @@ impl<'a> MetadataOperations<'a> {
 			.execute()
 			.await?;
 
-		// Process results
 		while let Some(batch) = results.try_next().await? {
 			if batch.num_rows() > 0 {
 				if let Some(column) = batch.column_by_name("commit_hash") {
@@ -113,19 +91,109 @@ impl<'a> MetadataOperations<'a> {
 		Ok(None)
 	}
 
+	/// Overwrite a commit-marker table with `commit_hash` and the current time.
+	/// No-op when the stored hash already matches. The table holds exactly one
+	/// row, so we clear and rewrite rather than update in place. `store_batch`
+	/// creates the table on first write, so no explicit create step is needed.
+	async fn store_commit_marker(&self, table_name: &str, commit_hash: &str) -> Result<()> {
+		if let Ok(Some(existing_hash)) = self.get_commit_marker(table_name).await {
+			if existing_hash == commit_hash {
+				return Ok(());
+			}
+		}
+
+		let batch = RecordBatch::try_new(
+			Self::commit_marker_schema(),
+			vec![
+				Arc::new(StringArray::from(vec![commit_hash])),
+				Arc::new(Int64Array::from(vec![chrono::Utc::now().timestamp()])),
+			],
+		)?;
+
+		self.table_ops.clear_table(table_name).await?;
+		self.table_ops.store_batch(table_name, batch).await?;
+
+		Ok(())
+	}
+
+	// ----- git_metadata (main code index) -----
+
+	/// Store git metadata (commit hash, etc.)
+	pub async fn store_git_metadata(&self, commit_hash: &str) -> Result<()> {
+		self.store_commit_marker(tables::GIT_METADATA, commit_hash)
+			.await
+	}
+
+	/// Get last indexed git commit hash
+	pub async fn get_last_commit_hash(&self) -> Result<Option<String>> {
+		self.get_commit_marker(tables::GIT_METADATA).await
+	}
+
+	/// Clear git metadata table to force full re-scan
+	pub async fn clear_git_metadata(&self) -> Result<()> {
+		self.table_ops.clear_table(tables::GIT_METADATA).await
+	}
+
+	// ----- graphrag_git_metadata -----
+
+	/// Get the last GraphRAG commit hash
+	pub async fn get_graphrag_last_commit_hash(&self) -> Result<Option<String>> {
+		self.get_commit_marker(tables::GRAPHRAG_GIT_METADATA).await
+	}
+
+	/// Store GraphRAG git metadata (commit hash and timestamp)
+	pub async fn store_graphrag_commit_hash(&self, commit_hash: &str) -> Result<()> {
+		self.store_commit_marker(tables::GRAPHRAG_GIT_METADATA, commit_hash)
+			.await
+	}
+
+	// ----- commits_git_metadata (commit history index) -----
+
+	/// Get the last commits commit hash
+	pub async fn get_commits_last_commit_hash(&self) -> Result<Option<String>> {
+		self.get_commit_marker(tables::COMMITS_GIT_METADATA).await
+	}
+
+	/// Store commits git metadata (commit hash and timestamp)
+	pub async fn store_commits_last_commit_hash(&self, commit_hash: &str) -> Result<()> {
+		self.store_commit_marker(tables::COMMITS_GIT_METADATA, commit_hash)
+			.await
+	}
+
+	// ========================================================================
+	// File metadata (per-file modification time, for incremental reindex)
+	// ========================================================================
+
+	/// Schema for the `file_metadata` table.
+	fn file_metadata_schema() -> Arc<Schema> {
+		Arc::new(Schema::new(vec![
+			Field::new("path", DataType::Utf8, false),
+			Field::new("mtime", DataType::Int64, false),
+			Field::new("indexed_at", DataType::Int64, false),
+		]))
+	}
+
+	/// Create the file metadata table.
+	async fn create_file_metadata_table(&self) -> Result<()> {
+		self.table_ops
+			.create_table_with_schema(tables::FILE_METADATA, Self::file_metadata_schema())
+			.await
+	}
+
 	/// Store file metadata (modification time, etc.)
 	pub async fn store_file_metadata(&self, file_path: &str, mtime: u64) -> Result<()> {
 		// Check if table exists, create if not
-		if !self.table_ops.table_exists("file_metadata").await? {
+		if !self.table_ops.table_exists(tables::FILE_METADATA).await? {
 			self.create_file_metadata_table().await?;
 		}
 
-		let table = self.db.open_table("file_metadata").execute().await?;
+		let table = self.db.open_table(tables::FILE_METADATA).execute().await?;
+		let path_predicate = format!("path = '{}'", escape_single_quotes(file_path));
 
 		// Check if file already exists in metadata
 		let mut existing_results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(path_predicate.clone())
 			.limit(1)
 			.execute()
 			.await?;
@@ -142,38 +210,24 @@ impl<'a> MetadataOperations<'a> {
 			// Update existing record using correct LanceDB UpdateBuilder API
 			table
 				.update()
-				.only_if(format!("path = '{}'", file_path))
+				.only_if(path_predicate)
 				.column("mtime", (mtime as i64).to_string())
 				.column("indexed_at", chrono::Utc::now().timestamp().to_string())
 				.execute()
 				.await?;
 		} else {
 			// Insert new record
-			let schema = Arc::new(Schema::new(vec![
-				Field::new("path", DataType::Utf8, false),
-				Field::new("mtime", DataType::Int64, false),
-				Field::new("indexed_at", DataType::Int64, false),
-			]));
-
-			let paths = vec![file_path];
-			let mtimes = vec![mtime as i64];
-			let timestamps = vec![chrono::Utc::now().timestamp()];
-
 			let batch = RecordBatch::try_new(
-				schema,
+				Self::file_metadata_schema(),
 				vec![
-					Arc::new(StringArray::from(paths)),
-					Arc::new(Int64Array::from(mtimes)),
-					Arc::new(Int64Array::from(timestamps)),
+					Arc::new(StringArray::from(vec![file_path])),
+					Arc::new(Int64Array::from(vec![mtime as i64])),
+					Arc::new(Int64Array::from(vec![chrono::Utc::now().timestamp()])),
 				],
 			)?;
-
-			// Use RecordBatchIterator instead of Vec<RecordBatch>
-			use std::iter::once;
-			let batches = once(Ok(batch.clone()));
-			let batch_reader =
-				arrow::record_batch::RecordBatchIterator::new(batches, batch.schema());
-			table.add(batch_reader).execute().await?;
+			self.table_ops
+				.store_batch(tables::FILE_METADATA, batch)
+				.await?;
 		}
 
 		Ok(())
@@ -181,16 +235,16 @@ impl<'a> MetadataOperations<'a> {
 
 	/// Get file modification time from metadata
 	pub async fn get_file_mtime(&self, file_path: &str) -> Result<Option<u64>> {
-		if !self.table_ops.table_exists("file_metadata").await? {
+		if !self.table_ops.table_exists(tables::FILE_METADATA).await? {
 			return Ok(None);
 		}
 
-		let table = self.db.open_table("file_metadata").execute().await?;
+		let table = self.db.open_table(tables::FILE_METADATA).execute().await?;
 
 		// Query for the specific file
 		let mut results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(format!("path = '{}'", escape_single_quotes(file_path)))
 			.select(Select::Columns(vec!["mtime".to_string()]))
 			.limit(1)
 			.execute()
@@ -217,11 +271,11 @@ impl<'a> MetadataOperations<'a> {
 	pub async fn get_all_file_metadata(&self) -> Result<std::collections::HashMap<String, u64>> {
 		let mut metadata_map = std::collections::HashMap::new();
 
-		if !self.table_ops.table_exists("file_metadata").await? {
+		if !self.table_ops.table_exists(tables::FILE_METADATA).await? {
 			return Ok(metadata_map);
 		}
 
-		let table = self.db.open_table("file_metadata").execute().await?;
+		let table = self.db.open_table(tables::FILE_METADATA).execute().await?;
 
 		// Query for all file metadata
 		let mut results = table
@@ -257,202 +311,5 @@ impl<'a> MetadataOperations<'a> {
 		}
 
 		Ok(metadata_map)
-	}
-
-	/// Clear git metadata table to force full re-scan
-	pub async fn clear_git_metadata(&self) -> Result<()> {
-		self.table_ops.clear_table("git_metadata").await
-	}
-
-	/// Create git metadata table
-	async fn create_git_metadata_table(&self) -> Result<()> {
-		let schema = Arc::new(Schema::new(vec![
-			Field::new("commit_hash", DataType::Utf8, false),
-			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		self.table_ops
-			.create_table_with_schema("git_metadata", schema)
-			.await
-	}
-
-	/// Create file metadata table
-	async fn create_file_metadata_table(&self) -> Result<()> {
-		let schema = Arc::new(Schema::new(vec![
-			Field::new("path", DataType::Utf8, false),
-			Field::new("mtime", DataType::Int64, false),
-			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		self.table_ops
-			.create_table_with_schema("file_metadata", schema)
-			.await
-	}
-
-	/// Get the last GraphRAG commit hash
-	pub async fn get_graphrag_last_commit_hash(&self) -> Result<Option<String>> {
-		// Check if table exists
-		if !self.table_ops.table_exists("graphrag_git_metadata").await? {
-			return Ok(None);
-		}
-
-		let table = self
-			.db
-			.open_table("graphrag_git_metadata")
-			.execute()
-			.await?;
-
-		// Get the most recent commit hash
-		let mut results = table
-			.query()
-			.select(Select::Columns(vec!["commit_hash".to_string()]))
-			.limit(1)
-			.execute()
-			.await?;
-
-		// Process results
-		while let Some(batch) = results.try_next().await? {
-			if batch.num_rows() > 0 {
-				if let Some(column) = batch.column_by_name("commit_hash") {
-					if let Some(hash_array) = column.as_any().downcast_ref::<StringArray>() {
-						if let Some(hash) = hash_array.iter().next() {
-							return Ok(hash.map(|s| s.to_string()));
-						}
-					}
-				}
-			}
-		}
-
-		Ok(None)
-	}
-
-	/// Store GraphRAG git metadata (commit hash and timestamp)
-	pub async fn store_graphrag_commit_hash(&self, commit_hash: &str) -> Result<()> {
-		// Check if table exists, create if not
-		if !self.table_ops.table_exists("graphrag_git_metadata").await? {
-			self.create_graphrag_git_metadata_table().await?;
-		}
-
-		// Check if the commit hash is already stored
-		if let Ok(Some(existing_hash)) = self.get_graphrag_last_commit_hash().await {
-			if existing_hash == commit_hash {
-				// Same commit hash, no need to update
-				return Ok(());
-			}
-		}
-
-		// Create a record with the current timestamp
-		let schema = Arc::new(Schema::new(vec![
-			Field::new("commit_hash", DataType::Utf8, false),
-			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		let commit_hashes = vec![commit_hash];
-		let timestamps = vec![chrono::Utc::now().timestamp()];
-
-		let batch = RecordBatch::try_new(
-			schema,
-			vec![
-				Arc::new(StringArray::from(commit_hashes)),
-				Arc::new(Int64Array::from(timestamps)),
-			],
-		)?;
-
-		// Only clear and store if we have a different commit hash
-		self.table_ops.clear_table("graphrag_git_metadata").await?;
-		self.table_ops
-			.store_batch("graphrag_git_metadata", batch)
-			.await?;
-
-		Ok(())
-	}
-
-	/// Create GraphRAG git metadata table
-	async fn create_graphrag_git_metadata_table(&self) -> Result<()> {
-		let schema = Arc::new(Schema::new(vec![
-			Field::new("commit_hash", DataType::Utf8, false),
-			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		self.table_ops
-			.create_table_with_schema("graphrag_git_metadata", schema)
-			.await
-	}
-
-	/// Get the last commits commit hash
-	pub async fn get_commits_last_commit_hash(&self) -> Result<Option<String>> {
-		if !self.table_ops.table_exists("commits_git_metadata").await? {
-			return Ok(None);
-		}
-
-		let table = self.db.open_table("commits_git_metadata").execute().await?;
-
-		let mut results = table
-			.query()
-			.select(Select::Columns(vec!["commit_hash".to_string()]))
-			.limit(1)
-			.execute()
-			.await?;
-
-		while let Some(batch) = results.try_next().await? {
-			if batch.num_rows() > 0 {
-				if let Some(column) = batch.column_by_name("commit_hash") {
-					if let Some(hash_array) = column.as_any().downcast_ref::<StringArray>() {
-						if let Some(hash) = hash_array.iter().next() {
-							return Ok(hash.map(|s| s.to_string()));
-						}
-					}
-				}
-			}
-		}
-
-		Ok(None)
-	}
-
-	/// Store commits git metadata (commit hash and timestamp)
-	pub async fn store_commits_last_commit_hash(&self, commit_hash: &str) -> Result<()> {
-		if !self.table_ops.table_exists("commits_git_metadata").await? {
-			self.create_commits_git_metadata_table().await?;
-		}
-
-		if let Ok(Some(existing_hash)) = self.get_commits_last_commit_hash().await {
-			if existing_hash == commit_hash {
-				return Ok(());
-			}
-		}
-
-		let schema = Arc::new(Schema::new(vec![
-			Field::new("commit_hash", DataType::Utf8, false),
-			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		let commit_hashes = vec![commit_hash];
-		let timestamps = vec![chrono::Utc::now().timestamp()];
-
-		let batch = RecordBatch::try_new(
-			schema,
-			vec![
-				Arc::new(StringArray::from(commit_hashes)),
-				Arc::new(Int64Array::from(timestamps)),
-			],
-		)?;
-
-		self.table_ops.clear_table("commits_git_metadata").await?;
-		self.table_ops
-			.store_batch("commits_git_metadata", batch)
-			.await?;
-
-		Ok(())
-	}
-
-	async fn create_commits_git_metadata_table(&self) -> Result<()> {
-		let schema = Arc::new(Schema::new(vec![
-			Field::new("commit_hash", DataType::Utf8, false),
-			Field::new("indexed_at", DataType::Int64, false),
-		]));
-
-		self.table_ops
-			.create_table_with_schema("commits_git_metadata", schema)
-			.await
 	}
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -34,8 +34,8 @@ use tokio::sync::RwLock;
 // Import modular components
 use self::{
 	batch_converter::BatchConverter, block_trait::BlockType, debug::DebugOperations,
-	graphrag::GraphRagOperations, metadata::MetadataOperations, table_ops::TableOperations,
-	vector_optimizer::VectorOptimizer,
+	graphrag::GraphRagOperations, metadata::MetadataOperations, sql::escape_single_quotes,
+	table_ops::TableOperations, vector_optimizer::VectorOptimizer,
 };
 
 pub mod batch_converter;
@@ -45,9 +45,28 @@ pub mod graphrag;
 #[cfg(test)]
 mod hybrid_tests;
 pub mod metadata;
+pub mod sql;
 pub mod table_ops;
 pub mod vector_optimizer;
 pub mod weighted_rrf;
+
+/// Canonical LanceDB table names. These are the single source of truth for the
+/// physical table identifiers — referenced everywhere instead of repeating the
+/// string literals, so a rename or typo can't silently desync one call site
+/// from the rest. Block-backed tables also expose the name via
+/// [`block_trait::BlockType::TABLE_NAME`], which is defined in terms of these.
+pub mod tables {
+	pub const CODE_BLOCKS: &str = "code_blocks";
+	pub const TEXT_BLOCKS: &str = "text_blocks";
+	pub const DOCUMENT_BLOCKS: &str = "document_blocks";
+	pub const COMMIT_BLOCKS: &str = "commit_blocks";
+	pub const GRAPHRAG_NODES: &str = "graphrag_nodes";
+	pub const GRAPHRAG_RELATIONSHIPS: &str = "graphrag_relationships";
+	pub const FILE_METADATA: &str = "file_metadata";
+	pub const GIT_METADATA: &str = "git_metadata";
+	pub const GRAPHRAG_GIT_METADATA: &str = "graphrag_git_metadata";
+	pub const COMMITS_GIT_METADATA: &str = "commits_git_metadata";
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CodeBlock {
@@ -216,36 +235,32 @@ impl Store {
 		// Check if tables exist and if their schema matches the current configuration
 		let table_names = db.table_names().execute().await?;
 
-		// Check for schema mismatches and recreate tables if necessary
-		for table_name in [
-			"code_blocks",
-			"text_blocks",
-			"document_blocks",
-			"graphrag_nodes",
-		] {
-			if table_names.contains(&table_name.to_string()) {
-				if let Ok(table) = db.open_table(table_name).execute().await {
-					if let Ok(schema) = table.schema().await {
-						// Check if embedding field has the right dimension
-						if let Ok(field) = schema.field_with_name("embedding") {
-							if let DataType::FixedSizeList(_, size) = field.data_type() {
-								let expected_dim = match table_name {
-									"code_blocks" | "graphrag_nodes" => code_vector_dim as i32,
-									"text_blocks" | "document_blocks" => text_vector_dim as i32,
-									_ => continue,
-								};
-
-								if size != &expected_dim {
-									tracing::warn!("Schema mismatch detected for table '{}': expected dimension {}, found {}. Dropping table for recreation.",
-										table_name, expected_dim, size);
-									drop(table); // Release table handle before dropping
-									if let Err(e) = db.drop_table(table_name, &[]).await {
-										tracing::warn!(
-											"Failed to drop table {}: {}",
-											table_name,
-											e
-										);
-									}
+		// Check for schema mismatches and recreate tables if necessary. Each
+		// embedding-backed table is paired with the dimension its model should
+		// produce; if the stored dimension drifts (model or config changed) we
+		// drop the table so it is recreated with the correct schema on next write.
+		let dim_by_table = [
+			(tables::CODE_BLOCKS, code_vector_dim as i32),
+			(tables::TEXT_BLOCKS, text_vector_dim as i32),
+			(tables::DOCUMENT_BLOCKS, text_vector_dim as i32),
+			(tables::COMMIT_BLOCKS, text_vector_dim as i32),
+			(tables::GRAPHRAG_NODES, code_vector_dim as i32),
+		];
+		for (table_name, expected_dim) in dim_by_table {
+			if !table_names.contains(&table_name.to_string()) {
+				continue;
+			}
+			if let Ok(table) = db.open_table(table_name).execute().await {
+				if let Ok(schema) = table.schema().await {
+					// Check if embedding field has the right dimension
+					if let Ok(field) = schema.field_with_name("embedding") {
+						if let DataType::FixedSizeList(_, size) = field.data_type() {
+							if size != &expected_dim {
+								tracing::warn!("Schema mismatch detected for table '{}': expected dimension {}, found {}. Dropping table for recreation.",
+									table_name, expected_dim, size);
+								drop(table); // Release table handle before dropping
+								if let Err(e) = db.drop_table(table_name, &[]).await {
+									tracing::warn!("Failed to drop table {}: {}", table_name, e);
 								}
 							}
 						}
@@ -293,12 +308,32 @@ impl Store {
 		Ok(table)
 	}
 
+	/// Build a `TableOperations` bound to this Store's connection.
+	fn table_ops(&self) -> TableOperations<'_> {
+		TableOperations::new(&self.db)
+	}
+
+	/// Build a `MetadataOperations` bound to this Store's connection.
+	fn metadata_ops(&self) -> MetadataOperations<'_> {
+		MetadataOperations::new(&self.db)
+	}
+
+	/// Build a `GraphRagOperations` sharing this Store's table cache. Centralises
+	/// the three-argument construction that every GraphRAG delegate needs.
+	fn graphrag_ops(&self) -> GraphRagOperations<'_> {
+		GraphRagOperations::new(
+			&self.db,
+			self.code_vector_dim,
+			Arc::clone(&self.table_cache),
+		)
+	}
+
 	pub async fn initialize_collections(&self) -> Result<()> {
 		// Check if tables exist, if not create them
 		let table_names = self.db.table_names().execute().await?;
 
 		// Create code_blocks table if it doesn't exist
-		if !table_names.contains(&"code_blocks".to_string()) {
+		if !table_names.contains(&tables::CODE_BLOCKS.to_string()) {
 			let schema = Arc::new(Schema::new(vec![
 				Field::new("id", DataType::Utf8, false),
 				Field::new("path", DataType::Utf8, false),
@@ -320,13 +355,13 @@ impl Store {
 
 			let _table = self
 				.db
-				.create_empty_table("code_blocks", schema)
+				.create_empty_table(tables::CODE_BLOCKS, schema)
 				.execute()
 				.await?;
 		}
 
 		// Create text_blocks table if it doesn't exist
-		if !table_names.contains(&"text_blocks".to_string()) {
+		if !table_names.contains(&tables::TEXT_BLOCKS.to_string()) {
 			let schema = Arc::new(Schema::new(vec![
 				Field::new("id", DataType::Utf8, false),
 				Field::new("path", DataType::Utf8, false),
@@ -347,13 +382,13 @@ impl Store {
 
 			let _table = self
 				.db
-				.create_empty_table("text_blocks", schema)
+				.create_empty_table(tables::TEXT_BLOCKS, schema)
 				.execute()
 				.await?;
 		}
 
 		// Create document_blocks table if it doesn't exist
-		if !table_names.contains(&"document_blocks".to_string()) {
+		if !table_names.contains(&tables::DOCUMENT_BLOCKS.to_string()) {
 			let schema = Arc::new(Schema::new(vec![
 				Field::new("id", DataType::Utf8, false),
 				Field::new("path", DataType::Utf8, false),
@@ -380,7 +415,7 @@ impl Store {
 
 			let _table = self
 				.db
-				.create_empty_table("document_blocks", schema)
+				.create_empty_table(tables::DOCUMENT_BLOCKS, schema)
 				.execute()
 				.await?;
 		}
@@ -392,16 +427,13 @@ impl Store {
 	pub async fn content_exists(&self, hash: &str, collection: &str) -> Result<bool> {
 		// Use cached table handle — `content_exists` is called per-block during the
 		// differential pass; opening the table each time costs a manifest read.
-		if !TableOperations::new(&self.db)
-			.table_exists(collection)
-			.await?
-		{
+		if !self.table_ops().table_exists(collection).await? {
 			return Ok(false);
 		}
 		let table = self.get_table(collection).await?;
 		let mut results = table
 			.query()
-			.only_if(format!("hash = '{}'", hash))
+			.only_if(format!("hash = '{}'", escape_single_quotes(hash)))
 			.limit(1)
 			.select(lancedb::query::Select::Columns(vec!["hash".to_string()]))
 			.execute()
@@ -544,45 +576,45 @@ impl Store {
 
 	// Delegate other operations to modular components
 	pub async fn remove_blocks_by_path(&self, file_path: &str) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops
-			.remove_blocks_by_path(file_path, "code_blocks")
+			.remove_blocks_by_path(file_path, tables::CODE_BLOCKS)
 			.await?;
 		table_ops
-			.remove_blocks_by_path(file_path, "text_blocks")
+			.remove_blocks_by_path(file_path, tables::TEXT_BLOCKS)
 			.await?;
 		table_ops
-			.remove_blocks_by_path(file_path, "document_blocks")
+			.remove_blocks_by_path(file_path, tables::DOCUMENT_BLOCKS)
 			.await?;
 		// Clean up GraphRAG data for the file
 		table_ops
-			.remove_blocks_by_path(file_path, "graphrag_nodes")
+			.remove_blocks_by_path(file_path, tables::GRAPHRAG_NODES)
 			.await?;
 		// Use specific GraphRAG operation for relationships (they don't have a 'path' field)
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops
 			.remove_graph_relationships_by_path(file_path)
 			.await?;
 		// Also remove file metadata to prevent stale mtime from causing skip-on-reindex
 		table_ops
-			.remove_blocks_by_path(file_path, "file_metadata")
+			.remove_blocks_by_path(file_path, tables::FILE_METADATA)
 			.await?;
 		Ok(())
 	}
 
 	pub async fn get_all_indexed_file_paths(&self) -> Result<std::collections::HashSet<String>> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops
-			.get_all_indexed_file_paths(&["code_blocks", "text_blocks", "document_blocks"])
+			.get_all_indexed_file_paths(&[
+				tables::CODE_BLOCKS,
+				tables::TEXT_BLOCKS,
+				tables::DOCUMENT_BLOCKS,
+			])
 			.await
 	}
 
 	pub async fn flush(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops.flush_all_tables().await
 	}
 
@@ -601,13 +633,13 @@ impl Store {
 		use lancedb::table::OptimizeAction;
 
 		let candidates = [
-			"code_blocks",
-			"text_blocks",
-			"document_blocks",
-			"commit_blocks",
-			"graphrag_nodes",
-			"graphrag_relationships",
-			"file_metadata",
+			tables::CODE_BLOCKS,
+			tables::TEXT_BLOCKS,
+			tables::DOCUMENT_BLOCKS,
+			tables::COMMIT_BLOCKS,
+			tables::GRAPHRAG_NODES,
+			tables::GRAPHRAG_RELATIONSHIPS,
+			tables::FILE_METADATA,
 		];
 
 		let existing = self.db.table_names().execute().await?;
@@ -649,13 +681,13 @@ impl Store {
 	}
 
 	pub async fn clear_all_tables(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops.clear_all_tables().await
 	}
 
 	pub async fn clear_code_table(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
-		table_ops.clear_table("code_blocks").await
+		let table_ops = self.table_ops();
+		table_ops.clear_table(tables::CODE_BLOCKS).await
 	}
 
 	// ============================================================================
@@ -671,7 +703,7 @@ impl Store {
 		vector_dim: usize,
 	) -> Result<()> {
 		let batch = B::to_batch(blocks, embeddings, vector_dim)?;
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops.store_batch(B::TABLE_NAME, batch).await?;
 
 		// Vector index: only check/create if not cached as present. Avoids
@@ -745,7 +777,7 @@ impl Store {
 		language_filter: Option<&str>,
 		_vector_dim: usize,
 	) -> Result<Vec<B>> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		if !table_ops.table_exists(B::TABLE_NAME).await? {
 			return Ok(Vec::new());
 		}
@@ -759,7 +791,7 @@ impl Store {
 
 		// Apply language filter if specified (only for code/text blocks)
 		if let Some(language) = language_filter {
-			query = query.only_if(format!("language = '{}'", language));
+			query = query.only_if(format!("language = '{}'", escape_single_quotes(language)));
 		}
 
 		// Apply intelligent search optimization
@@ -801,28 +833,28 @@ impl Store {
 	}
 
 	pub async fn clear_docs_table(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
-		table_ops.clear_table("document_blocks").await
+		let table_ops = self.table_ops();
+		table_ops.clear_table(tables::DOCUMENT_BLOCKS).await
 	}
 
 	pub async fn clear_text_table(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
-		table_ops.clear_table("text_blocks").await
+		let table_ops = self.table_ops();
+		table_ops.clear_table(tables::TEXT_BLOCKS).await
 	}
 
 	pub async fn clear_commits_table(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
-		table_ops.clear_table("commit_blocks").await
+		let table_ops = self.table_ops();
+		table_ops.clear_table(tables::COMMIT_BLOCKS).await
 	}
 
 	pub async fn clear_commits_git_metadata(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
-		table_ops.clear_table("commits_git_metadata").await
+		let table_ops = self.table_ops();
+		table_ops.clear_table(tables::COMMITS_GIT_METADATA).await
 	}
 
 	pub async fn clear_graphrag_git_metadata(&self) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
-		table_ops.clear_table("graphrag_git_metadata").await
+		let table_ops = self.table_ops();
+		table_ops.clear_table(tables::GRAPHRAG_GIT_METADATA).await
 	}
 
 	pub fn get_code_vector_dim(&self) -> usize {
@@ -831,7 +863,7 @@ impl Store {
 
 	/// Get row count for a table. Returns 0 if table doesn't exist.
 	pub async fn get_table_row_count(&self, table_name: &str) -> Result<usize> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		if !table_ops.table_exists(table_name).await? {
 			return Ok(0);
 		}
@@ -841,52 +873,52 @@ impl Store {
 
 	// Metadata operations
 	pub async fn store_git_metadata(&self, commit_hash: &str) -> Result<()> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.store_git_metadata(commit_hash).await
 	}
 
 	pub async fn get_last_commit_hash(&self) -> Result<Option<String>> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.get_last_commit_hash().await
 	}
 
 	pub async fn store_file_metadata(&self, file_path: &str, mtime: u64) -> Result<()> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.store_file_metadata(file_path, mtime).await
 	}
 
 	pub async fn get_file_mtime(&self, file_path: &str) -> Result<Option<u64>> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.get_file_mtime(file_path).await
 	}
 
 	pub async fn get_all_file_metadata(&self) -> Result<std::collections::HashMap<String, u64>> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.get_all_file_metadata().await
 	}
 
 	pub async fn clear_git_metadata(&self) -> Result<()> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.clear_git_metadata().await
 	}
 
 	pub async fn get_graphrag_last_commit_hash(&self) -> Result<Option<String>> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.get_graphrag_last_commit_hash().await
 	}
 
 	pub async fn store_graphrag_commit_hash(&self, commit_hash: &str) -> Result<()> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.store_graphrag_commit_hash(commit_hash).await
 	}
 
 	pub async fn get_commits_last_commit_hash(&self) -> Result<Option<String>> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops.get_commits_last_commit_hash().await
 	}
 
 	pub async fn store_commits_last_commit_hash(&self, commit_hash: &str) -> Result<()> {
-		let metadata_ops = MetadataOperations::new(&self.db);
+		let metadata_ops = self.metadata_ops();
 		metadata_ops
 			.store_commits_last_commit_hash(commit_hash)
 			.await
@@ -894,103 +926,59 @@ impl Store {
 
 	// GraphRAG operations
 	pub async fn graphrag_needs_indexing(&self) -> Result<bool> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.graphrag_needs_indexing().await
 	}
 
 	pub async fn get_all_code_blocks_for_graphrag(&self) -> Result<Vec<CodeBlock>> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.get_all_code_blocks_for_graphrag().await
 	}
 
 	pub async fn store_graph_nodes(&self, node_batch: RecordBatch) -> Result<()> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.store_graph_nodes(node_batch).await
 	}
 
 	pub async fn store_graph_relationships(&self, rel_batch: RecordBatch) -> Result<()> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.store_graph_relationships(rel_batch).await
 	}
 
 	pub async fn clear_graph_nodes(&self) -> Result<()> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.clear_graph_nodes().await
 	}
 
 	pub async fn clear_graph_relationships(&self) -> Result<()> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.clear_graph_relationships().await
 	}
 
 	pub async fn remove_graph_nodes_by_path(&self, file_path: &str) -> Result<usize> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.remove_graph_nodes_by_path(file_path).await
 	}
 
 	pub async fn remove_graph_relationships_by_path(&self, file_path: &str) -> Result<usize> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops
 			.remove_graph_relationships_by_path(file_path)
 			.await
 	}
 
 	pub async fn get_all_graph_nodes(&self) -> Result<RecordBatch> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.get_all_graph_nodes().await
 	}
 
 	pub async fn search_graph_nodes(&self, embedding: &[f32], limit: usize) -> Result<RecordBatch> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.search_graph_nodes(embedding, limit).await
 	}
 
 	pub async fn get_graph_relationships(&self) -> Result<RecordBatch> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.get_graph_relationships().await
 	}
 
@@ -1000,11 +988,7 @@ impl Store {
 		node_id: &str,
 		direction: crate::indexer::graphrag::types::RelationshipDirection,
 	) -> Result<Vec<crate::indexer::graphrag::types::CodeRelationship>> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops
 			.get_node_relationships(node_id, direction)
 			.await
@@ -1015,11 +999,7 @@ impl Store {
 		&self,
 		relation_type: &crate::indexer::graphrag::types::RelationType,
 	) -> Result<Vec<crate::indexer::graphrag::types::CodeRelationship>> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.get_relationships_by_type(relation_type).await
 	}
 
@@ -1029,11 +1009,7 @@ impl Store {
 		offset: usize,
 		limit: usize,
 	) -> Result<Vec<crate::indexer::graphrag::types::CodeNode>> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.get_all_nodes_paginated(offset, limit).await
 	}
 
@@ -1041,11 +1017,7 @@ impl Store {
 	pub async fn get_all_relationships_efficient(
 		&self,
 	) -> Result<Vec<crate::indexer::graphrag::types::CodeRelationship>> {
-		let graphrag_ops = GraphRagOperations::new(
-			&self.db,
-			self.code_vector_dim,
-			Arc::clone(&self.table_cache),
-		);
+		let graphrag_ops = self.graphrag_ops();
 		graphrag_ops.get_all_relationships_efficient().await
 	}
 
@@ -1062,15 +1034,15 @@ impl Store {
 
 	// Additional methods for backward compatibility
 	pub async fn get_code_block_by_symbol(&self, symbol: &str) -> Result<Option<CodeBlock>> {
-		let table_ops = TableOperations::new(&self.db);
-		if !table_ops.table_exists("code_blocks").await? {
+		let table_ops = self.table_ops();
+		if !table_ops.table_exists(tables::CODE_BLOCKS).await? {
 			return Ok(None);
 		}
 
-		let table = self.get_table("code_blocks").await?;
+		let table = self.get_table(tables::CODE_BLOCKS).await?;
 		let mut results = table
 			.query()
-			.only_if(format!("symbols LIKE '%{}%'", symbol))
+			.only_if(format!("symbols LIKE '%{}%'", escape_single_quotes(symbol)))
 			.limit(1)
 			.execute()
 			.await?;
@@ -1087,15 +1059,15 @@ impl Store {
 	}
 
 	pub async fn get_code_block_by_hash(&self, hash: &str) -> Result<CodeBlock> {
-		let table_ops = TableOperations::new(&self.db);
-		if !table_ops.table_exists("code_blocks").await? {
+		let table_ops = self.table_ops();
+		if !table_ops.table_exists(tables::CODE_BLOCKS).await? {
 			return Err(anyhow::anyhow!("Code blocks table does not exist"));
 		}
 
-		let table = self.get_table("code_blocks").await?;
+		let table = self.get_table(tables::CODE_BLOCKS).await?;
 		let mut results = table
 			.query()
-			.only_if(format!("hash = '{}'", hash))
+			.only_if(format!("hash = '{}'", escape_single_quotes(hash)))
 			.limit(1)
 			.execute()
 			.await?;
@@ -1115,7 +1087,7 @@ impl Store {
 	}
 
 	pub async fn tables_exist(&self, table_names: &[&str]) -> Result<bool> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops.tables_exist(table_names).await
 	}
 
@@ -1125,14 +1097,14 @@ impl Store {
 		file_path: &str,
 		table_name: &str,
 	) -> Result<Vec<String>> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops
 			.get_file_blocks_metadata(file_path, table_name)
 			.await
 	}
 
 	pub async fn remove_blocks_by_hashes(&self, hashes: &[String], table_name: &str) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops.remove_blocks_by_hashes(hashes, table_name).await
 	}
 	// ===== Hybrid Search =====
@@ -1149,7 +1121,7 @@ impl Store {
 			.validate()
 			.map_err(|e| anyhow::anyhow!("Invalid hybrid query: {}", e))?;
 
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		if !table_ops.table_exists(B::TABLE_NAME).await? {
 			return Ok(Vec::new());
 		}
@@ -1223,7 +1195,7 @@ impl Store {
 					.rerank(reranker);
 
 				if let Some(lang) = query.language_filter.as_deref() {
-					vq = vq.only_if(format!("language = '{}'", lang));
+					vq = vq.only_if(format!("language = '{}'", escape_single_quotes(lang)));
 				}
 
 				vq = VectorOptimizer::optimize_query(vq, &table, B::TABLE_NAME)
@@ -1305,7 +1277,7 @@ impl Store {
 					.limit(limit);
 
 				if let Some(lang) = query.language_filter.as_deref() {
-					q = q.only_if(format!("language = '{}'", lang));
+					q = q.only_if(format!("language = '{}'", escape_single_quotes(lang)));
 				}
 
 				let mut stream = q.execute().await?;
@@ -1326,7 +1298,7 @@ impl Store {
 	/// Called after data is stored so the index covers all current rows.
 	/// Safe to call repeatedly — skips creation if index already exists.
 	pub async fn ensure_fts_index(&self, table_name: &str) -> Result<()> {
-		let table_ops = TableOperations::new(&self.db);
+		let table_ops = self.table_ops();
 		table_ops.create_fts_index(table_name).await
 	}
 }

--- a/src/store/sql.rs
+++ b/src/store/sql.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers for building safe LanceDB / DataFusion filter predicates.
+//!
+//! LanceDB evaluates `only_if` / `delete` / `update` predicates as DataFusion
+//! SQL. String literals are single-quoted, and a single quote inside the value
+//! must be doubled (`''`) — standard SQL escaping. Without this, any value
+//! containing an apostrophe (file paths like `src/it's.rs`, symbol names, graph
+//! node IDs) produces a malformed predicate. In the best case the query errors;
+//! in the worst case (a `delete`) it silently matches nothing and leaves stale
+//! rows in the database. Every predicate built from a runtime string MUST route
+//! its values through [`escape_single_quotes`].
+
+/// Escape a string for safe interpolation inside a single-quoted SQL literal by
+/// doubling embedded single quotes. The returned value is the *inner* content —
+/// callers still wrap it in quotes, e.g. `format!("path = '{}'", escape_single_quotes(p))`.
+pub fn escape_single_quotes(value: &str) -> String {
+	value.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn no_quotes_unchanged() {
+		assert_eq!(escape_single_quotes("src/main.rs"), "src/main.rs");
+	}
+
+	#[test]
+	fn single_quote_is_doubled() {
+		assert_eq!(escape_single_quotes("src/it's.rs"), "src/it''s.rs");
+	}
+
+	#[test]
+	fn multiple_quotes_all_doubled() {
+		assert_eq!(escape_single_quotes("a'b'c"), "a''b''c");
+		assert_eq!(escape_single_quotes("''"), "''''");
+	}
+
+	#[test]
+	fn empty_string() {
+		assert_eq!(escape_single_quotes(""), "");
+	}
+
+	#[test]
+	fn produces_balanced_predicate() {
+		// A path with an apostrophe must yield a syntactically valid predicate.
+		let p = "weird/o'brien.rs";
+		let predicate = format!("path = '{}'", escape_single_quotes(p));
+		assert_eq!(predicate, "path = 'weird/o''brien.rs'");
+	}
+}

--- a/src/store/table_ops.rs
+++ b/src/store/table_ops.rs
@@ -27,6 +27,8 @@ use lancedb::{
 	Connection,
 };
 
+use crate::store::sql::escape_single_quotes;
+
 /// Generic table operations for LanceDB
 pub struct TableOperations<'a> {
 	pub db: &'a Connection,
@@ -118,7 +120,7 @@ impl<'a> TableOperations<'a> {
 		// Use a more efficient query to check existence
 		let mut results = table
 			.query()
-			.only_if(format!("hash = '{}'", hash))
+			.only_if(format!("hash = '{}'", escape_single_quotes(hash)))
 			.limit(1) // We only need to know if one exists
 			.select(Select::Columns(vec!["hash".to_string()])) // Only select hash column
 			.execute()
@@ -144,7 +146,7 @@ impl<'a> TableOperations<'a> {
 		let table = self.db.open_table(table_name).execute().await?;
 
 		table
-			.delete(&format!("path = '{}'", file_path))
+			.delete(&format!("path = '{}'", escape_single_quotes(file_path)))
 			.await
 			.map_err(|e| anyhow::anyhow!("Failed to delete from {}: {}", table_name, e))?;
 
@@ -164,7 +166,10 @@ impl<'a> TableOperations<'a> {
 		let table = self.db.open_table(table_name).execute().await?;
 
 		// Create a filter for all hashes
-		let hash_filters: Vec<String> = hashes.iter().map(|h| format!("hash = '{}'", h)).collect();
+		let hash_filters: Vec<String> = hashes
+			.iter()
+			.map(|h| format!("hash = '{}'", escape_single_quotes(h)))
+			.collect();
 		let filter = hash_filters.join(" OR ");
 
 		// Delete rows matching any of the hashes
@@ -193,7 +198,7 @@ impl<'a> TableOperations<'a> {
 		// Query for blocks matching the file path, only selecting hash column
 		let mut results = table
 			.query()
-			.only_if(format!("path = '{}'", file_path))
+			.only_if(format!("path = '{}'", escape_single_quotes(file_path)))
 			.select(Select::Columns(vec!["hash".to_string()]))
 			.execute()
 			.await?;
@@ -272,25 +277,20 @@ impl<'a> TableOperations<'a> {
 
 	/// Store a record batch in a table (create table if it doesn't exist)
 	pub async fn store_batch(&self, table_name: &str, batch: RecordBatch) -> Result<()> {
-		// Check if table exists
+		use std::iter::once;
+
+		// Capture the schema before moving `batch` into the reader; the reader
+		// consumes a single owned batch, so there's no need to clone it.
+		let schema = batch.schema();
+		let batch_reader = arrow::record_batch::RecordBatchIterator::new(once(Ok(batch)), schema);
+
 		if self.table_exists(table_name).await? {
 			// Table exists, append data
 			let table = self.db.open_table(table_name).execute().await?;
-
-			// Use RecordBatchIterator instead of Vec<RecordBatch>
-			use std::iter::once;
-			let batches = once(Ok(batch.clone()));
-			let batch_reader =
-				arrow::record_batch::RecordBatchIterator::new(batches, batch.schema());
 			table.add(batch_reader).execute().await?;
 		} else {
 			// Table doesn't exist, create it with the batch
-			use std::iter::once;
-			let batches = once(Ok(batch.clone()));
-			let batch_reader =
-				arrow::record_batch::RecordBatchIterator::new(batches, batch.schema());
-			let _table = self
-				.db
+			self.db
 				.create_table(table_name, batch_reader)
 				.execute()
 				.await?;
@@ -400,102 +400,6 @@ impl<'a> TableOperations<'a> {
 			table_name,
 			duration.as_secs_f64()
 		);
-		Ok(())
-	}
-
-	/// Recreate vector index with new optimal parameters
-	pub async fn recreate_vector_index_optimized(
-		&self,
-		table_name: &str,
-		column_name: &str,
-		vector_dimension: usize,
-		use_quantization: bool,
-	) -> Result<()> {
-		if !self.table_exists(table_name).await? {
-			return Err(anyhow::anyhow!("Table {} does not exist", table_name));
-		}
-
-		let table = self.db.open_table(table_name).execute().await?;
-		let row_count = table.count_rows(None).await?;
-
-		tracing::info!(
-			"Recreating vector index for table '{}' with {} rows for better performance",
-			table_name,
-			row_count
-		);
-
-		// Drop existing index first
-		let existing_indices = table.list_indices().await?;
-		for index in existing_indices {
-			if index.columns == vec![column_name] {
-				tracing::debug!("Dropping existing index: {}", index.name);
-				// Note: LanceDB doesn't have a direct drop_index method in current version
-				// The index will be replaced when we create a new one
-				break;
-			}
-		}
-
-		// Calculate new optimal parameters
-		let index_params = super::vector_optimizer::VectorOptimizer::calculate_index_params(
-			row_count,
-			vector_dimension,
-			use_quantization,
-		);
-
-		if !index_params.should_create_index {
-			tracing::warn!("Dataset size no longer warrants an index, skipping recreation");
-			return Ok(());
-		}
-
-		// Create new optimized index based on quantization setting
-		let index_type_name = match index_params.index_type {
-			super::vector_optimizer::IndexType::IvfHnswSq => "IVF_HNSW_SQ",
-			super::vector_optimizer::IndexType::IvfRq => "IVF_RQ",
-		};
-
-		let start_time = std::time::Instant::now();
-
-		// Create the appropriate index type
-		match index_params.index_type {
-			super::vector_optimizer::IndexType::IvfHnswSq => {
-				table
-					.create_index(
-						&[column_name],
-						lancedb::index::Index::IvfHnswSq(
-							lancedb::index::vector::IvfHnswSqIndexBuilder::default()
-								.distance_type(index_params.distance_type)
-								.num_partitions(index_params.num_partitions)
-								.num_edges(index_params.num_edges)
-								.ef_construction(index_params.ef_construction),
-						),
-					)
-					.execute()
-					.await?;
-			}
-			super::vector_optimizer::IndexType::IvfRq => {
-				table
-					.create_index(
-						&[column_name],
-						lancedb::index::Index::IvfRq(
-							lancedb::index::vector::IvfRqIndexBuilder::default()
-								.distance_type(index_params.distance_type)
-								.num_partitions(index_params.num_partitions),
-						),
-					)
-					.execute()
-					.await?;
-			}
-		}
-
-		let duration = start_time.elapsed();
-		tracing::info!(
-			"Successfully recreated {} index for table '{}' in {:.2}s - {} partitions",
-			index_type_name,
-			table_name,
-			duration.as_secs_f64(),
-			index_params.num_partitions
-		);
-
 		Ok(())
 	}
 

--- a/src/store/vector_optimizer.rs
+++ b/src/store/vector_optimizer.rs
@@ -256,42 +256,6 @@ impl VectorOptimizer {
 		// This ensures optimal partition count as data grows
 		growth > 0.5
 	}
-
-	/// Check if index should be optimized based on dataset growth
-	///
-	/// This is a convenience method that combines growth detection with
-	/// index parameter validation. Used for incremental optimization.
-	///
-	/// # Arguments
-	/// * `current_rows` - Current number of rows in the table
-	/// * `_vector_dim` - Vector dimension (unused, kept for API compatibility)
-	/// * `check_growth` - Whether to check for growth (if false, returns false)
-	///
-	/// # Returns
-	/// True if the index should be recreated for better performance
-	pub fn should_optimize_for_growth(
-		_current_rows: usize,
-		_vector_dim: usize,
-		check_growth: bool,
-	) -> bool {
-		if !check_growth {
-			return false;
-		}
-
-		// For IVF_HNSW_SQ, we should recreate the index when:
-		// 1. Dataset has grown significantly (more than 2x since last optimization)
-		// 2. Or when crossing size thresholds (e.g., from 1K to 10K, 10K to 100K)
-		//
-		// Since we don't track when the index was created, we use heuristics:
-		// - Small datasets (< 10K): recreate at 2x growth
-		// - Medium datasets (10K-100K): recreate at 1.5x growth
-		// - Large datasets (> 100K): recreate at 1.25x growth
-
-		// This is a simplified check - in production, you'd want to track
-		// the row count when the index was created and compare
-		// For now, we return false and rely on manual optimization calls
-		false
-	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Introduce tables module for canonical table name constants
- Implement SQL single quote escaping to prevent injection attacks
- Apply escaping to file paths, node IDs, and hash filters
- Centralize operation delegate construction via helper methods
- Deduplicate commit marker and file metadata logic
- Remove redundant index growth checks and unused optimizer methods
- Optimize store_batch by removing unnecessary RecordBatch clones
- Add unit tests for SQL literal escaping and special character paths
- Fix typos in index creation warning logs