### PR TITLE
feat(mcp): implement advanced structural and symbol search

### DIFF
--- a/src/grep.rs
+++ b/src/grep.rs
@@ -20,7 +20,7 @@ use ast_grep_core::language::Language as AstGrepLanguage;
 use ast_grep_core::matcher::{KindMatcher, PatternBuilder, PatternNode};
 use ast_grep_core::source::Edit as AstEdit;
 use ast_grep_core::tree_sitter::{LanguageExt, StrDoc};
-use ast_grep_core::{Pattern, PatternError};
+use ast_grep_core::{Doc, Node, Pattern, PatternError};
 use std::path::Path;
 
 pub use ast_grep_core::MatchStrictness;
@@ -86,21 +86,103 @@ pub struct GrepMatch {
 	pub line: usize,
 	pub column: usize,
 	pub text: String,
+	/// Byte range of the matched node in its source file. Used for
+	/// `inside`/`has` containment filtering. (0, 0) for lexical fallback hits.
+	pub start_byte: usize,
+	pub end_byte: usize,
+	/// Enclosing named containers, outermost first
+	/// (e.g. "impl Store › fn flush"). None at file top level.
+	pub breadcrumb: Option<String>,
 }
 
-/// Collect (line, col, text) for every node match in a tree.
+/// Per-file match before the file path is attached.
+pub struct RawMatch {
+	pub line: usize,
+	pub column: usize,
+	pub text: String,
+	pub start_byte: usize,
+	pub end_byte: usize,
+	pub breadcrumb: Option<String>,
+}
+
+/// Metavariable constraint: captured variable name (without `$`) plus the
+/// regex its text must match for the overall match to be kept.
+pub type MetavarConstraint = (String, regex::Regex);
+
+fn is_identifier_kind(kind: &str) -> bool {
+	// Covers identifier/type_identifier/field_identifier/property_identifier
+	// (most grammars), `name` (PHP), `constant` (Ruby).
+	kind.contains("identifier") || kind == "name" || kind == "constant"
+}
+
+/// Display name of a definition-like node: `name` field, then `type`
+/// (Rust impl blocks), then `declarator` (C/C++), then first identifier child.
+fn node_def_name<D: Doc>(node: &Node<'_, D>) -> Option<String> {
+	if let Some(n) = node.field("name") {
+		return Some(n.text().to_string());
+	}
+	if let Some(n) = node.field("type") {
+		return Some(n.text().to_string());
+	}
+	if let Some(d) = node.field("declarator") {
+		if let Some(id) = d.dfs().find(|c| is_identifier_kind(&c.kind())) {
+			return Some(id.text().to_string());
+		}
+	}
+	node.children()
+		.find(|c| is_identifier_kind(&c.kind()))
+		.map(|c| c.text().to_string())
+}
+
+/// Build a breadcrumb of enclosing named containers, outermost first.
+fn breadcrumb_for<D: Doc>(node: &Node<'_, D>, containers: &[(&str, &str)]) -> Option<String> {
+	let mut parts: Vec<String> = Vec::new();
+	// ancestors() yields parent → … → root.
+	for anc in node.ancestors() {
+		let kind = anc.kind();
+		if let Some((_, label)) = containers.iter().find(|(k, _)| *k == kind.as_ref()) {
+			let name = node_def_name(&anc).unwrap_or_else(|| "_".to_string());
+			parts.push(format!("{} {}", label, name));
+		}
+	}
+	if parts.is_empty() {
+		return None;
+	}
+	parts.reverse();
+	Some(parts.join(" › "))
+}
+
+/// Collect a RawMatch for every node match in a tree, applying metavariable
+/// constraints and attaching enclosing-symbol breadcrumbs.
 fn collect_matches<L: LanguageExt + AstGrepLanguage + Clone, M: ast_grep_core::Matcher>(
 	grep: &ast_grep_core::AstGrep<StrDoc<L>>,
 	matcher: &M,
-) -> Vec<(usize, usize, String)> {
+	containers: &[(&str, &str)],
+	constraints: &[MetavarConstraint],
+) -> Vec<RawMatch> {
 	grep.root()
 		.find_all(matcher)
+		.filter(|m| {
+			constraints.iter().all(|(var, re)| {
+				m.get_env()
+					.get_match(var)
+					.map(|n| re.is_match(&n.text()))
+					.unwrap_or(false)
+			})
+		})
 		.map(|m| {
 			let text = m.text().to_string();
 			let pos = m.start_pos();
-			let line = pos.line() + 1; // 0-based → 1-based
-			let col = pos.byte_point().1;
-			(line, col, text)
+			let node = m.get_node();
+			let range = node.range();
+			RawMatch {
+				line: pos.line() + 1, // 0-based → 1-based
+				column: pos.byte_point().1,
+				text,
+				start_byte: range.start,
+				end_byte: range.end,
+				breadcrumb: breadcrumb_for(node, containers),
+			}
 		})
 		.collect()
 }
@@ -111,12 +193,14 @@ fn search_file_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
 	source: &str,
 	pattern_str: &str,
 	strictness: MatchStrictness,
-) -> Result<Vec<(usize, usize, String)>> {
+	containers: &[(&str, &str)],
+	constraints: &[MetavarConstraint],
+) -> Result<Vec<RawMatch>> {
 	let grep = lang.ast_grep(source);
 	let pattern = Pattern::try_new(pattern_str, lang)
 		.map_err(|e| anyhow::anyhow!("Invalid pattern: {}", e))?
 		.with_strictness(strictness);
-	Ok(collect_matches(&grep, &pattern))
+	Ok(collect_matches(&grep, &pattern, containers, constraints))
 }
 
 /// Search a single file using a KindMatcher (pattern interpreted as AST node kind).
@@ -124,11 +208,12 @@ fn search_kind_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
 	lang: L,
 	source: &str,
 	kind_str: &str,
-) -> Result<Vec<(usize, usize, String)>> {
+	containers: &[(&str, &str)],
+) -> Result<Vec<RawMatch>> {
 	let grep = lang.ast_grep(source);
 	let kind = KindMatcher::try_new(kind_str, lang)
 		.map_err(|e| anyhow::anyhow!("Invalid AST kind '{}': {}", kind_str, e))?;
-	Ok(collect_matches(&grep, &kind))
+	Ok(collect_matches(&grep, &kind, containers, &[]))
 }
 
 /// Search a single file with a contextual pattern (wraps `pattern` in `context`,
@@ -138,11 +223,13 @@ fn search_contextual_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
 	source: &str,
 	context_src: &str,
 	selector: &str,
-) -> Result<Vec<(usize, usize, String)>> {
+	containers: &[(&str, &str)],
+	constraints: &[MetavarConstraint],
+) -> Result<Vec<RawMatch>> {
 	let grep = lang.ast_grep(source);
 	let pattern = Pattern::contextual(context_src, selector, lang)
 		.map_err(|e| anyhow::anyhow!("Invalid contextual pattern: {}", e))?;
-	Ok(collect_matches(&grep, &pattern))
+	Ok(collect_matches(&grep, &pattern, containers, constraints))
 }
 
 /// Inspect the root AST kind a pattern parses to, plus parse-error flag and metavars.
@@ -188,12 +275,342 @@ pub fn language_from_extension(path: &Path) -> Option<&'static str> {
 		| "ccm" | "cxxm" => Some("cpp"),
 		"php" => Some("php"),
 		"rb" => Some("ruby"),
+		"swift" => Some("swift"),
 		"lua" => Some("lua"),
 		"sh" | "bash" | "zsh" => Some("bash"),
 		"css" | "scss" => Some("css"),
 		"json" => Some("json"),
 		_ => None,
 	}
+}
+
+/// (tree-sitter kind, short display label) pairs that form symbol breadcrumbs
+/// for the given language. Resolved by language string before generic dispatch.
+pub fn container_kinds(language: &str) -> &'static [(&'static str, &'static str)] {
+	match language {
+		"rust" => &[
+			("function_item", "fn"),
+			("impl_item", "impl"),
+			("trait_item", "trait"),
+			("struct_item", "struct"),
+			("enum_item", "enum"),
+			("mod_item", "mod"),
+		],
+		"python" => &[
+			("function_definition", "def"),
+			("class_definition", "class"),
+		],
+		"javascript" | "typescript" => &[
+			("function_declaration", "function"),
+			("generator_function_declaration", "function"),
+			("method_definition", "method"),
+			("class_declaration", "class"),
+			("interface_declaration", "interface"),
+			("enum_declaration", "enum"),
+		],
+		"go" => &[
+			("function_declaration", "func"),
+			("method_declaration", "method"),
+			("type_declaration", "type"),
+		],
+		"java" => &[
+			("class_declaration", "class"),
+			("interface_declaration", "interface"),
+			("enum_declaration", "enum"),
+			("method_declaration", "method"),
+			("constructor_declaration", "constructor"),
+		],
+		"cpp" => &[
+			("function_definition", "fn"),
+			("class_specifier", "class"),
+			("struct_specifier", "struct"),
+			("namespace_definition", "namespace"),
+		],
+		"php" => &[
+			("function_definition", "function"),
+			("method_declaration", "method"),
+			("class_declaration", "class"),
+			("interface_declaration", "interface"),
+			("trait_declaration", "trait"),
+		],
+		"ruby" => &[
+			("method", "def"),
+			("singleton_method", "def"),
+			("class", "class"),
+			("module", "module"),
+		],
+		"lua" => &[("function_declaration", "function")],
+		"bash" => &[("function_definition", "function")],
+		"swift" => &[
+			("function_declaration", "func"),
+			("class_declaration", "class"),
+			("protocol_declaration", "protocol"),
+		],
+		_ => &[],
+	}
+}
+
+/// Tree-sitter kinds that define named symbols, per language. Used by the
+/// `symbol` search mode to find definitions without a hand-written pattern.
+pub fn definition_kinds(language: &str) -> &'static [&'static str] {
+	match language {
+		"rust" => &[
+			"function_item",
+			"struct_item",
+			"enum_item",
+			"trait_item",
+			"impl_item",
+			"mod_item",
+			"const_item",
+			"static_item",
+			"type_item",
+			"union_item",
+			"macro_definition",
+		],
+		"javascript" => &[
+			"function_declaration",
+			"generator_function_declaration",
+			"class_declaration",
+			"method_definition",
+			"variable_declarator",
+		],
+		"typescript" => &[
+			"function_declaration",
+			"generator_function_declaration",
+			"class_declaration",
+			"abstract_class_declaration",
+			"method_definition",
+			"interface_declaration",
+			"type_alias_declaration",
+			"enum_declaration",
+			"variable_declarator",
+		],
+		"python" => &["function_definition", "class_definition"],
+		"go" => &[
+			"function_declaration",
+			"method_declaration",
+			"type_spec",
+			"const_spec",
+			"var_spec",
+		],
+		"java" => &[
+			"class_declaration",
+			"interface_declaration",
+			"enum_declaration",
+			"record_declaration",
+			"method_declaration",
+			"constructor_declaration",
+		],
+		"cpp" => &[
+			"function_definition",
+			"class_specifier",
+			"struct_specifier",
+			"enum_specifier",
+			"namespace_definition",
+			"type_definition",
+		],
+		"php" => &[
+			"function_definition",
+			"method_declaration",
+			"class_declaration",
+			"interface_declaration",
+			"trait_declaration",
+		],
+		"ruby" => &["method", "singleton_method", "class", "module"],
+		"lua" => &["function_declaration"],
+		"bash" => &["function_definition"],
+		"swift" => &[
+			"function_declaration",
+			"class_declaration",
+			"protocol_declaration",
+		],
+		_ => &[],
+	}
+}
+
+/// Name filter for symbol queries. `*` in the spec is a wildcard
+/// (e.g. `handle_*`, `*_test`); anything else matches exactly.
+pub enum NameMatcher {
+	Exact(String),
+	Wildcard(regex::Regex),
+}
+
+impl NameMatcher {
+	pub fn new(spec: &str) -> Result<Self> {
+		if spec.contains('*') {
+			let re = format!(
+				"^{}$",
+				spec.split('*')
+					.map(regex::escape)
+					.collect::<Vec<_>>()
+					.join(".*")
+			);
+			Ok(NameMatcher::Wildcard(regex::Regex::new(&re)?))
+		} else {
+			Ok(NameMatcher::Exact(spec.to_string()))
+		}
+	}
+
+	pub fn matches(&self, name: &str) -> bool {
+		match self {
+			NameMatcher::Exact(s) => s == name,
+			NameMatcher::Wildcard(re) => re.is_match(name),
+		}
+	}
+
+	/// Longest literal fragment of the spec — used as a content prefilter token.
+	pub fn literal_fragment(&self) -> Option<String> {
+		match self {
+			NameMatcher::Exact(s) => Some(s.clone()),
+			NameMatcher::Wildcard(_) => None,
+		}
+	}
+}
+
+/// Find symbol definitions by name in a single file (no pattern required).
+fn find_defs_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
+	lang: L,
+	source: &str,
+	name: &NameMatcher,
+	def_kinds: &[&str],
+	containers: &[(&str, &str)],
+) -> Vec<RawMatch> {
+	let grep = lang.ast_grep(source);
+	let root = grep.root();
+	let mut out = Vec::new();
+	for node in root.dfs() {
+		let kind = node.kind();
+		if !def_kinds.contains(&kind.as_ref()) {
+			continue;
+		}
+		let Some(def_name) = node_def_name(&node) else {
+			continue;
+		};
+		if !name.matches(&def_name) {
+			continue;
+		}
+		let pos = node.start_pos();
+		let range = node.range();
+		out.push(RawMatch {
+			line: pos.line() + 1,
+			column: pos.byte_point().1,
+			text: node.text().to_string(),
+			start_byte: range.start,
+			end_byte: range.end,
+			breadcrumb: breadcrumb_for(&node, containers),
+		});
+	}
+	out
+}
+
+/// Find references (identifier usages) by name in a single file. Each hit
+/// reports the full trimmed source line; definition sites are tagged `[def]`.
+fn find_refs_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
+	lang: L,
+	source: &str,
+	name: &NameMatcher,
+	def_kinds: &[&str],
+	containers: &[(&str, &str)],
+) -> Vec<RawMatch> {
+	let grep = lang.ast_grep(source);
+	let root = grep.root();
+	let lines: Vec<&str> = source.lines().collect();
+	let mut out = Vec::new();
+	for node in root.dfs() {
+		if !node.is_named_leaf() {
+			continue;
+		}
+		let kind = node.kind();
+		if !is_identifier_kind(&kind) {
+			continue;
+		}
+		let text = node.text();
+		if !name.matches(&text) {
+			continue;
+		}
+		let pos = node.start_pos();
+		let range = node.range();
+		let line_text = lines
+			.get(pos.line())
+			.map(|l| l.trim().to_string())
+			.unwrap_or_default();
+		let is_def = node
+			.parent()
+			.map(|p| {
+				def_kinds.contains(&p.kind().as_ref())
+					&& p.field("name").map(|n| n.range() == range).unwrap_or(false)
+			})
+			.unwrap_or(false);
+		out.push(RawMatch {
+			line: pos.line() + 1,
+			column: pos.byte_point().1,
+			text: if is_def {
+				format!("[def] {}", line_text)
+			} else {
+				line_text
+			},
+			start_byte: range.start,
+			end_byte: range.end,
+			breadcrumb: breadcrumb_for(&node, containers),
+		});
+	}
+	out
+}
+
+/// Extract concrete identifier tokens from a pattern, excluding metavariables.
+/// Every token must appear verbatim in any file the pattern can match, so the
+/// result is safe to use as an AND content prefilter. Sorted longest-first.
+pub fn literal_tokens(pattern: &str) -> Vec<String> {
+	let chars: Vec<char> = pattern.chars().collect();
+	let mut tokens: Vec<String> = Vec::new();
+	let mut i = 0;
+	while i < chars.len() {
+		let c = chars[i];
+		if c == '_' || c.is_ascii_alphabetic() {
+			let start = i;
+			while i < chars.len() && (chars[i] == '_' || chars[i].is_ascii_alphanumeric()) {
+				i += 1;
+			}
+			// Skip metavariable names: preceded by an expando char ($, µ, #).
+			let prev = if start > 0 {
+				Some(chars[start - 1])
+			} else {
+				None
+			};
+			let is_metavar = matches!(prev, Some('$') | Some('µ') | Some('#'));
+			if !is_metavar && i - start >= 2 {
+				tokens.push(chars[start..i].iter().collect());
+			}
+		} else {
+			i += 1;
+		}
+	}
+	tokens.sort_by(|a, b| b.len().cmp(&a.len()).then(a.cmp(b)));
+	tokens.dedup();
+	tokens
+}
+
+/// Plain-text line scan for `token`. Last-resort fallback when no structural
+/// strategy matched — results are not AST-verified.
+pub fn lexical_scan(file_path: &str, source: &str, token: &str, max: usize) -> Vec<GrepMatch> {
+	let mut out = Vec::new();
+	for (i, line) in source.lines().enumerate() {
+		if out.len() >= max {
+			break;
+		}
+		if let Some(col) = line.find(token) {
+			out.push(GrepMatch {
+				file: file_path.to_string(),
+				line: i + 1,
+				column: col,
+				text: line.trim().to_string(),
+				start_byte: 0,
+				end_byte: 0,
+				breadcrumb: None,
+			});
+		}
+	}
+	out
 }
 
 /// What a parsed pattern looks like — used to build diagnostics when a search
@@ -289,13 +706,16 @@ macro_rules! dispatch_lang {
 	};
 }
 
-fn wrap_matches(file_path: &str, raw: Vec<(usize, usize, String)>) -> Vec<GrepMatch> {
+fn wrap_matches(file_path: &str, raw: Vec<RawMatch>) -> Vec<GrepMatch> {
 	raw.into_iter()
-		.map(|(line, column, text)| GrepMatch {
+		.map(|r| GrepMatch {
 			file: file_path.to_string(),
-			line,
-			column,
-			text,
+			line: r.line,
+			column: r.column,
+			text: r.text,
+			start_byte: r.start_byte,
+			end_byte: r.end_byte,
+			breadcrumb: r.breadcrumb,
 		})
 		.collect()
 }
@@ -320,8 +740,27 @@ pub fn search_file_strict(
 	language: &str,
 	strictness: MatchStrictness,
 ) -> Result<Vec<GrepMatch>> {
+	search_file_constrained(file_path, source, pattern, language, strictness, &[])
+}
+
+/// Search a single file with explicit strictness and metavariable constraints.
+/// Each constraint is (var name without `$`, regex the captured text must match).
+pub fn search_file_constrained(
+	file_path: &str,
+	source: &str,
+	pattern: &str,
+	language: &str,
+	strictness: MatchStrictness,
+	constraints: &[MetavarConstraint],
+) -> Result<Vec<GrepMatch>> {
+	let containers = container_kinds(language);
 	let raw = dispatch_lang!(language, |lang| search_file_with_lang(
-		lang, source, pattern, strictness
+		lang,
+		source,
+		pattern,
+		strictness,
+		containers,
+		constraints
 	))?;
 	Ok(wrap_matches(file_path, raw))
 }
@@ -335,7 +774,10 @@ pub fn search_file_by_kind(
 	kind: &str,
 	language: &str,
 ) -> Result<Vec<GrepMatch>> {
-	let raw = dispatch_lang!(language, |lang| search_kind_with_lang(lang, source, kind))?;
+	let containers = container_kinds(language);
+	let raw = dispatch_lang!(language, |lang| search_kind_with_lang(
+		lang, source, kind, containers
+	))?;
 	Ok(wrap_matches(file_path, raw))
 }
 
@@ -350,12 +792,149 @@ pub fn search_file_contextual(
 	selector: &str,
 	language: &str,
 ) -> Result<Vec<GrepMatch>> {
+	search_file_contextual_constrained(file_path, source, context_src, selector, language, &[])
+}
+
+/// Contextual search with metavariable constraints.
+pub fn search_file_contextual_constrained(
+	file_path: &str,
+	source: &str,
+	context_src: &str,
+	selector: &str,
+	language: &str,
+	constraints: &[MetavarConstraint],
+) -> Result<Vec<GrepMatch>> {
+	let containers = container_kinds(language);
 	let raw = dispatch_lang!(language, |lang| search_contextual_with_lang(
 		lang,
 		source,
 		context_src,
-		selector
+		selector,
+		containers,
+		constraints
 	))?;
+	Ok(wrap_matches(file_path, raw))
+}
+
+/// Find symbol definitions by name in a single file (no pattern required).
+/// Matches the per-language definition kinds (functions, types, classes, …)
+/// whose name satisfies the matcher. Supports `*` wildcards via NameMatcher.
+pub fn find_symbol_defs(
+	file_path: &str,
+	source: &str,
+	name: &NameMatcher,
+	language: &str,
+) -> Result<Vec<GrepMatch>> {
+	let def_kinds = definition_kinds(language);
+	let containers = container_kinds(language);
+	let raw: Vec<RawMatch> = dispatch_lang!(language, |lang| Ok(find_defs_with_lang(
+		lang, source, name, def_kinds, containers
+	)))?;
+	Ok(wrap_matches(file_path, raw))
+}
+
+/// One strategy to evaluate against a single shared parse of a file.
+/// Used by the smart-search pipeline to avoid re-parsing per strategy.
+pub enum SearchSpec {
+	/// ast-grep pattern with explicit strictness.
+	Pattern {
+		pattern: String,
+		strictness: MatchStrictness,
+	},
+	/// Bare tree-sitter kind name.
+	Kind { kind: String },
+	/// Contextual pattern (context source + selector kind).
+	Contextual {
+		context_src: String,
+		selector: String,
+	},
+	/// Kind name if valid in the grammar, else ast-grep pattern.
+	/// Used for `inside`/`has` relational specs where either shape is accepted.
+	KindOrPattern { spec: String },
+}
+
+/// Evaluate every spec against ONE parse of the source. Per-spec errors
+/// (invalid kind, unparseable pattern) yield an empty bucket rather than
+/// failing the whole call — the primary pattern is validated separately.
+fn search_multi_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
+	lang: L,
+	source: &str,
+	specs: &[SearchSpec],
+	containers: &[(&str, &str)],
+	constraints: &[MetavarConstraint],
+) -> Vec<Vec<RawMatch>> {
+	let grep = lang.ast_grep(source); // single parse shared by all specs
+	specs
+		.iter()
+		.map(|spec| match spec {
+			SearchSpec::Pattern {
+				pattern,
+				strictness,
+			} => Pattern::try_new(pattern, lang.clone())
+				.map(|p| {
+					collect_matches(
+						&grep,
+						&p.with_strictness(strictness.clone()),
+						containers,
+						constraints,
+					)
+				})
+				.unwrap_or_default(),
+			SearchSpec::Kind { kind } => KindMatcher::try_new(kind, lang.clone())
+				.map(|k| collect_matches(&grep, &k, containers, &[]))
+				.unwrap_or_default(),
+			SearchSpec::Contextual {
+				context_src,
+				selector,
+			} => Pattern::contextual(context_src, selector, lang.clone())
+				.map(|p| collect_matches(&grep, &p, containers, constraints))
+				.unwrap_or_default(),
+			SearchSpec::KindOrPattern { spec } => match KindMatcher::try_new(spec, lang.clone()) {
+				Ok(k) => collect_matches(&grep, &k, containers, &[]),
+				Err(_) => Pattern::try_new(spec, lang.clone())
+					.map(|p| collect_matches(&grep, &p, containers, &[]))
+					.unwrap_or_default(),
+			},
+		})
+		.collect()
+}
+
+/// Evaluate multiple search strategies against a single parse of one file.
+/// Returns one bucket of matches per spec, in input order.
+pub fn search_file_multi(
+	file_path: &str,
+	source: &str,
+	language: &str,
+	specs: &[SearchSpec],
+	constraints: &[MetavarConstraint],
+) -> Result<Vec<Vec<GrepMatch>>> {
+	let containers = container_kinds(language);
+	let raw = dispatch_lang!(language, |lang| Ok(search_multi_with_lang(
+		lang,
+		source,
+		specs,
+		containers,
+		constraints
+	)))?;
+	Ok(raw
+		.into_iter()
+		.map(|v| wrap_matches(file_path, v))
+		.collect())
+}
+
+/// Find symbol references (identifier usages) by name in a single file.
+/// Each hit reports the trimmed source line; definition sites are tagged `[def]`.
+pub fn find_symbol_refs(
+	file_path: &str,
+	source: &str,
+	name: &NameMatcher,
+	language: &str,
+) -> Result<Vec<GrepMatch>> {
+	let def_kinds = definition_kinds(language);
+	let containers = container_kinds(language);
+	let raw: Vec<RawMatch> = dispatch_lang!(language, |lang| Ok(find_refs_with_lang(
+		lang, source, name, def_kinds, containers
+	)))?;
 	Ok(wrap_matches(file_path, raw))
 }
 
@@ -590,7 +1169,12 @@ pub fn format_matches_grouped(matches: &[GrepMatch]) -> String {
 		output.push('\n');
 		for m in file_matches {
 			let text = truncate_match_text(&m.text, 4);
-			output.push_str(&format!("{}:{}:  {}\n", m.line, m.column, text));
+			match &m.breadcrumb {
+				Some(bc) => {
+					output.push_str(&format!("{}:{} [{}]:  {}\n", m.line, m.column, bc, text))
+				}
+				None => output.push_str(&format!("{}:{}:  {}\n", m.line, m.column, text)),
+			}
 		}
 		output.push('\n');
 	}
@@ -619,6 +1203,9 @@ pub fn format_matches_with_context(
 		if let Some(source) = source_map.get(*file) {
 			let lines: Vec<&str> = source.lines().collect();
 			for m in file_matches {
+				if let Some(bc) = &m.breadcrumb {
+					output.push_str(&format!("» {}\n", bc));
+				}
 				let start = m.line.saturating_sub(context + 1);
 				let end = (m.line + context).min(lines.len());
 				for (i, line) in lines.iter().enumerate().take(end).skip(start) {
@@ -630,7 +1217,12 @@ pub fn format_matches_with_context(
 		} else {
 			for m in file_matches {
 				let text = truncate_match_text(&m.text, 4);
-				output.push_str(&format!("{}:{}:  {}\n", m.line, m.column, text));
+				match &m.breadcrumb {
+					Some(bc) => {
+						output.push_str(&format!("{}:{} [{}]:  {}\n", m.line, m.column, bc, text))
+					}
+					None => output.push_str(&format!("{}:{}:  {}\n", m.line, m.column, text)),
+				}
 			}
 		}
 		output.push('\n');
@@ -850,18 +1442,27 @@ func bar() error {
 				line: 10,
 				column: 5,
 				text: "foo.unwrap()".to_string(),
+				start_byte: 0,
+				end_byte: 0,
+				breadcrumb: None,
 			},
 			GrepMatch {
 				file: "src/a.rs".to_string(),
 				line: 20,
 				column: 3,
 				text: "bar.unwrap()".to_string(),
+				start_byte: 0,
+				end_byte: 0,
+				breadcrumb: None,
 			},
 			GrepMatch {
 				file: "src/b.rs".to_string(),
 				line: 5,
 				column: 1,
 				text: "baz.unwrap()".to_string(),
+				start_byte: 0,
+				end_byte: 0,
+				breadcrumb: None,
 			},
 		];
 
@@ -1632,6 +2233,9 @@ const x = 1;
 			line: 1,
 			column: 0,
 			text: long,
+			start_byte: 0,
+			end_byte: 0,
+			breadcrumb: None,
 		}];
 		let out = format_matches_grouped(&matches);
 		assert!(out.contains("line1"));
@@ -1650,5 +2254,254 @@ const x = 1;
 		let canonical = canonical_kind("function", "python").unwrap();
 		let matches = search_file_by_kind("a.py", source, canonical, "python").unwrap();
 		assert_eq!(matches.len(), 2);
+	}
+
+	// ---- literal token prefilter extraction ----
+
+	#[test]
+	fn test_literal_tokens_excludes_metavars() {
+		let tokens = literal_tokens("$X.unwrap()");
+		assert_eq!(tokens, vec!["unwrap".to_string()]);
+		let tokens = literal_tokens("fn $NAME($$$ARGS) { $$$ }");
+		assert_eq!(tokens, vec!["fn".to_string()]);
+	}
+
+	#[test]
+	fn test_literal_tokens_sorted_longest_first_and_deduped() {
+		let tokens = literal_tokens("foo.bar_baz(foo)");
+		assert_eq!(
+			tokens,
+			vec!["bar_baz".to_string(), "foo".to_string()],
+			"longest first, duplicates removed"
+		);
+	}
+
+	#[test]
+	fn test_literal_tokens_skips_single_chars() {
+		let tokens = literal_tokens("a + bb");
+		assert_eq!(tokens, vec!["bb".to_string()]);
+	}
+
+	// ---- breadcrumbs ----
+
+	#[test]
+	fn test_breadcrumb_rust_impl_fn() {
+		let source = "impl Store {\n    fn flush(&self) { self.x.unwrap(); }\n}\n";
+		let matches = search_file("a.rs", source, "$X.unwrap()", "rust").unwrap();
+		assert_eq!(matches.len(), 1);
+		let bc = matches[0].breadcrumb.as_deref().expect("breadcrumb");
+		assert_eq!(bc, "impl Store › fn flush");
+	}
+
+	#[test]
+	fn test_breadcrumb_python_class_method() {
+		let source = "class Store:\n    def flush(self):\n        do_it()\n";
+		let matches = search_file("a.py", source, "do_it()", "python").unwrap();
+		assert_eq!(matches.len(), 1);
+		let bc = matches[0].breadcrumb.as_deref().expect("breadcrumb");
+		assert_eq!(bc, "class Store › def flush");
+	}
+
+	#[test]
+	fn test_breadcrumb_none_at_top_level() {
+		let source = "use std::fs;\n";
+		let matches = search_file("a.rs", source, "use $PATH;", "rust").unwrap();
+		assert_eq!(matches.len(), 1);
+		assert!(matches[0].breadcrumb.is_none());
+	}
+
+	#[test]
+	fn test_match_byte_ranges_populated() {
+		let source = "fn main() { foo.unwrap(); }";
+		let matches = search_file("a.rs", source, "$X.unwrap()", "rust").unwrap();
+		assert_eq!(matches.len(), 1);
+		let m = &matches[0];
+		assert!(m.end_byte > m.start_byte);
+		assert_eq!(&source[m.start_byte..m.end_byte], "foo.unwrap()");
+	}
+
+	// ---- metavariable constraints ----
+
+	#[test]
+	fn test_search_file_constrained_filters_by_regex() {
+		let source = "fn handle_get() {}\nfn handle_post() {}\nfn other() {}\n";
+		let re = regex::Regex::new("^handle_").unwrap();
+		let constraints = vec![("NAME".to_string(), re)];
+		let matches = search_file_constrained(
+			"a.rs",
+			source,
+			"fn $NAME($$$) { $$$ }",
+			"rust",
+			MatchStrictness::Smart,
+			&constraints,
+		)
+		.unwrap();
+		assert_eq!(matches.len(), 2);
+		assert!(matches.iter().all(|m| m.text.contains("handle_")));
+	}
+
+	#[test]
+	fn test_search_file_constrained_unbound_var_drops_match() {
+		// Constraint on a metavar the pattern never captures — nothing survives.
+		let source = "fn handle_get() {}\n";
+		let re = regex::Regex::new(".*").unwrap();
+		let constraints = vec![("MISSING".to_string(), re)];
+		let matches = search_file_constrained(
+			"a.rs",
+			source,
+			"fn $NAME($$$) { $$$ }",
+			"rust",
+			MatchStrictness::Smart,
+			&constraints,
+		)
+		.unwrap();
+		assert!(matches.is_empty());
+	}
+
+	// ---- symbol definitions / references ----
+
+	#[test]
+	fn test_find_symbol_defs_exact() {
+		let source = "pub fn flush() {}\npub struct Flush;\nfn other() {}\n";
+		let name = NameMatcher::new("flush").unwrap();
+		let matches = find_symbol_defs("a.rs", source, &name, "rust").unwrap();
+		assert_eq!(matches.len(), 1, "exact match is case-sensitive");
+		assert_eq!(matches[0].line, 1);
+	}
+
+	#[test]
+	fn test_find_symbol_defs_wildcard() {
+		let source = "fn handle_get() {}\nfn handle_post() {}\nfn other() {}\n";
+		let name = NameMatcher::new("handle_*").unwrap();
+		let matches = find_symbol_defs("a.rs", source, &name, "rust").unwrap();
+		assert_eq!(matches.len(), 2);
+	}
+
+	#[test]
+	fn test_find_symbol_defs_typescript_interface() {
+		let source = "interface Config { a: string }\nclass ConfigImpl {}\n";
+		let name = NameMatcher::new("Config").unwrap();
+		let matches = find_symbol_defs("a.ts", source, &name, "typescript").unwrap();
+		assert_eq!(matches.len(), 1);
+		assert!(matches[0].text.contains("interface"));
+	}
+
+	#[test]
+	fn test_find_symbol_refs_tags_definitions() {
+		let source = "fn flush() {}\nfn main() { flush(); }\n";
+		let name = NameMatcher::new("flush").unwrap();
+		let matches = find_symbol_refs("a.rs", source, &name, "rust").unwrap();
+		assert_eq!(matches.len(), 2);
+		assert!(matches[0].text.starts_with("[def]"), "{}", matches[0].text);
+		assert!(!matches[1].text.starts_with("[def]"));
+		assert!(matches[1]
+			.breadcrumb
+			.as_deref()
+			.unwrap()
+			.contains("fn main"));
+	}
+
+	#[test]
+	fn test_name_matcher_shapes() {
+		assert!(NameMatcher::new("foo").unwrap().matches("foo"));
+		assert!(!NameMatcher::new("foo").unwrap().matches("foobar"));
+		assert!(NameMatcher::new("foo*").unwrap().matches("foobar"));
+		assert!(NameMatcher::new("*bar").unwrap().matches("foobar"));
+		assert!(NameMatcher::new("f*r").unwrap().matches("foobar"));
+		assert!(!NameMatcher::new("f*z").unwrap().matches("foobar"));
+	}
+
+	// ---- single-parse multi-strategy evaluation ----
+
+	#[test]
+	fn test_search_file_multi_buckets_in_order() {
+		let source = "fn main() { foo.unwrap(); }\nfn other() {}\n";
+		let specs = vec![
+			SearchSpec::Pattern {
+				pattern: "$X.unwrap()".to_string(),
+				strictness: MatchStrictness::Smart,
+			},
+			SearchSpec::Kind {
+				kind: "function_item".to_string(),
+			},
+			SearchSpec::Kind {
+				kind: "not_a_real_kind".to_string(),
+			},
+		];
+		let buckets = search_file_multi("a.rs", source, "rust", &specs, &[]).unwrap();
+		assert_eq!(buckets.len(), 3);
+		assert_eq!(buckets[0].len(), 1, "pattern bucket");
+		assert_eq!(buckets[1].len(), 2, "kind bucket");
+		assert!(
+			buckets[2].is_empty(),
+			"invalid kind yields empty, not error"
+		);
+	}
+
+	#[test]
+	fn test_search_spec_kind_or_pattern() {
+		let source = "fn main() { foo.unwrap(); }\n";
+		// Valid kind resolves as kind; non-kind falls back to pattern.
+		let specs = vec![
+			SearchSpec::KindOrPattern {
+				spec: "function_item".to_string(),
+			},
+			SearchSpec::KindOrPattern {
+				spec: "$X.unwrap()".to_string(),
+			},
+		];
+		let buckets = search_file_multi("a.rs", source, "rust", &specs, &[]).unwrap();
+		assert_eq!(buckets[0].len(), 1);
+		assert_eq!(buckets[1].len(), 1);
+	}
+
+	// ---- lexical fallback scan ----
+
+	#[test]
+	fn test_lexical_scan_finds_lines() {
+		let source = "// frobnicate here\nlet x = 1;\nfrobnicate();\n";
+		let matches = lexical_scan("a.rs", source, "frobnicate", 10);
+		assert_eq!(matches.len(), 2);
+		assert_eq!(matches[0].line, 1);
+		assert_eq!(matches[1].line, 3);
+		assert!(matches[0].breadcrumb.is_none());
+	}
+
+	#[test]
+	fn test_lexical_scan_respects_cap() {
+		let source = "tok\ntok\ntok\ntok\n";
+		let matches = lexical_scan("a.rs", source, "tok", 2);
+		assert_eq!(matches.len(), 2);
+	}
+
+	// ---- swift extension mapping ----
+
+	#[test]
+	fn test_language_from_extension_swift() {
+		assert_eq!(
+			language_from_extension(Path::new("App.swift")),
+			Some("swift")
+		);
+	}
+
+	// ---- formatter shows breadcrumbs ----
+
+	#[test]
+	fn test_format_matches_grouped_with_breadcrumb() {
+		let matches = vec![GrepMatch {
+			file: "a.rs".to_string(),
+			line: 3,
+			column: 4,
+			text: "foo.unwrap()".to_string(),
+			start_byte: 0,
+			end_byte: 0,
+			breadcrumb: Some("impl Store › fn flush".to_string()),
+		}];
+		let out = format_matches_grouped(&matches);
+		assert!(
+			out.contains("[impl Store › fn flush]"),
+			"breadcrumb shown: {}",
+			out
+		);
 	}
 }

--- a/src/grep.rs
+++ b/src/grep.rs
@@ -827,9 +827,9 @@ pub fn find_symbol_defs(
 ) -> Result<Vec<GrepMatch>> {
 	let def_kinds = definition_kinds(language);
 	let containers = container_kinds(language);
-	let raw: Vec<RawMatch> = dispatch_lang!(language, |lang| Ok(find_defs_with_lang(
-		lang, source, name, def_kinds, containers
-	)))?;
+	let raw: Vec<RawMatch> = dispatch_lang!(language, |lang| Ok::<_, anyhow::Error>(
+		find_defs_with_lang(lang, source, name, def_kinds, containers)
+	))?;
 	Ok(wrap_matches(file_path, raw))
 }
 
@@ -909,13 +909,9 @@ pub fn search_file_multi(
 	constraints: &[MetavarConstraint],
 ) -> Result<Vec<Vec<GrepMatch>>> {
 	let containers = container_kinds(language);
-	let raw = dispatch_lang!(language, |lang| Ok(search_multi_with_lang(
-		lang,
-		source,
-		specs,
-		containers,
-		constraints
-	)))?;
+	let raw = dispatch_lang!(language, |lang| Ok::<_, anyhow::Error>(
+		search_multi_with_lang(lang, source, specs, containers, constraints)
+	))?;
 	Ok(raw
 		.into_iter()
 		.map(|v| wrap_matches(file_path, v))
@@ -932,9 +928,9 @@ pub fn find_symbol_refs(
 ) -> Result<Vec<GrepMatch>> {
 	let def_kinds = definition_kinds(language);
 	let containers = container_kinds(language);
-	let raw: Vec<RawMatch> = dispatch_lang!(language, |lang| Ok(find_refs_with_lang(
-		lang, source, name, def_kinds, containers
-	)))?;
+	let raw: Vec<RawMatch> = dispatch_lang!(language, |lang| Ok::<_, anyhow::Error>(
+		find_refs_with_lang(lang, source, name, def_kinds, containers)
+	))?;
 	Ok(wrap_matches(file_path, raw))
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -25,6 +25,7 @@ pub mod lsp;
 pub mod multi;
 pub mod semantic_code;
 pub mod server;
+pub mod structural;
 pub mod types;
 pub mod watcher;
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -123,12 +123,35 @@ pub struct StructuralSearchParams {
 	/// AST pattern, kind name, or literal snippet. `$X` = single node, `$$$` = sequence.
 	/// Examples: `$X.unwrap()`, `if err != nil { $$$ }`, `function_item`, `import_statement`.
 	/// Pattern must be valid standalone code in the target language.
-	pub pattern: String,
-	/// Language to search (required: rust, javascript, typescript, python, go, java, cpp, php, ruby, lua, bash, css, json)
+	/// Provide exactly one of `pattern`, `symbol`, or `references`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub pattern: Option<String>,
+	/// Find symbol DEFINITIONS by name — no pattern needed. Supports `*` wildcards
+	/// (e.g. `flush_cache`, `handle_*`, `*Config`). Matches functions, types,
+	/// classes, traits, etc. for the language.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub symbol: Option<String>,
+	/// Find symbol REFERENCES (identifier usages) by name. Supports `*` wildcards.
+	/// Each hit shows the source line and enclosing symbol; definition sites are tagged `[def]`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub references: Option<String>,
+	/// Language to search (required: rust, javascript, typescript, python, go, java, cpp, php, ruby, swift, lua, bash, css, json)
 	pub language: String,
 	/// File paths or glob patterns to search (default: current directory)
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub paths: Option<Vec<String>>,
+	/// Only keep matches INSIDE a node matching this kind name or pattern
+	/// (e.g. `function_item`, `class _ { $$$ }`). Applies per file.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub inside: Option<String>,
+	/// Only keep matches that CONTAIN a node matching this kind name or pattern
+	/// (e.g. find functions that contain `$X.unwrap()`).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub has: Option<String>,
+	/// Regex constraints on captured metavariables, e.g. {"NAME": "^handle_"}.
+	/// Keys are metavariable names without `$`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub constraints: Option<std::collections::HashMap<String, String>>,
 	/// Number of context lines around matches
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[schemars(range(min = 0, max = 10))]
@@ -137,7 +160,11 @@ pub struct StructuralSearchParams {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[schemars(range(min = 1, max = 200), extend("default" = 50))]
 	pub max_results: Option<usize>,
-	/// Rewrite template with metavariable substitution (e.g. '$VAR.expect("reason")'). When provided, matched code is rewritten.
+	/// Pagination offset into the full result set (default: 0). The response
+	/// footer reports the total and the next offset when truncated.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub offset: Option<usize>,
+	/// Rewrite template with metavariable substitution (e.g. '$VAR.expect("reason")'). When provided, matched code is rewritten. Requires `pattern`.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub rewrite: Option<String>,
 	/// Apply rewrites to files in-place. When false or absent, returns a diff preview. Requires rewrite parameter.
@@ -226,6 +253,10 @@ pub struct McpServer {
 	lsp: Option<Arc<Mutex<crate::mcp::lsp::LspProvider>>>,
 	indexer_enabled: bool,
 	tool_router: ToolRouter<Self>,
+	/// Single-entry cache of the last structural_search evaluation. Serves
+	/// repeat and paginated queries without re-parsing while the candidate
+	/// file set is unchanged (fingerprint + repo stamp validated per call).
+	structural_cache: Arc<parking_lot::RwLock<Option<crate::mcp::structural::QueryCache>>>,
 }
 
 /// Tool execution error -> CallToolResult with is_error=true (MCP spec).
@@ -412,10 +443,13 @@ impl McpServer {
 	// --- Structural search tool ---
 
 	#[tool(
-		description = "Search or rewrite code by AST structure. Pattern accepts three shapes (tried in order): \
-		(1) ast-grep pattern with metavariables — `$X` matches one node, `$$$` matches a sequence; \
-		(2) a bare tree-sitter kind name like `function_item`, `call_expression`, `import_statement` to match all nodes of that kind; \
-		(3) a literal code snippet. \
+		description = "Search or rewrite code by AST structure, or look up real symbols by name. Three query modes (provide exactly one): \
+		`pattern` — ast-grep pattern (`$X` = one node, `$$$` = sequence), bare tree-sitter kind name (`function_item`), or literal snippet; \
+		`symbol` — find symbol DEFINITIONS by name, `*` wildcards supported (e.g. `handle_*`) — use this to locate where a function/type/class is defined; \
+		`references` — find all usages of a name, grouped by enclosing symbol, definition sites tagged `[def]`. \
+		\n\nEvery match carries an enclosing-symbol breadcrumb (e.g. `[impl Store › fn flush]`). \
+		Refine with: `inside` (only matches inside a kind/pattern), `has` (only matches containing a kind/pattern), \
+		`constraints` (regex per metavariable, e.g. {\"NAME\": \"^handle_\"}), `offset` (pagination). \
 		\n\nCommon LLM traps to avoid: \
 		(a) Decorators/attributes are children of the item — `pub struct $N { $$$ }` will NOT match `#[derive(...)] pub struct ...`. Either include the decorator (`#[derive($$$)] pub struct $N { $$$ }`) or use the bare kind (`struct_item`). \
 		(b) Method patterns need a receiver — write `$X.map_err($$$)`, not `.map_err($$$)`. \
@@ -426,99 +460,230 @@ impl McpServer {
 		JS/TS kinds: function_declaration, class_declaration, method_definition, import_statement, call_expression. \
 		Python kinds: function_definition, class_definition, import_statement, import_from_statement, decorated_definition. \
 		Go kinds: function_declaration, method_declaration, type_declaration, call_expression, if_statement. \
-		\n\nWhen a pattern returns zero matches the tool auto-retries with relaxed strictness and language-aware context wrapping, then emits a short diagnostic. Use `rewrite` to apply a template with metavariable substitution. Use `semantic_search` for meaning-based lookups instead of this tool."
+		\n\nWhen a pattern returns zero matches the tool auto-retries with relaxed strictness, kind broadening, and language-aware context wrapping, then falls back to labeled plain-text hits plus a diagnostic — it never silently returns nothing relevant. Use `rewrite` to apply a template with metavariable substitution. Use `semantic_search` for meaning-based lookups instead of this tool."
 	)]
 	async fn structural_search(
 		&self,
 		Parameters(params): Parameters<StructuralSearchParams>,
 	) -> Result<String, String> {
-		debug!(
-			"Executing structural_search with pattern: {} lang: {}",
-			params.pattern, params.language
-		);
-
-		let current_dir = self.working_directory.clone();
-		let max_results = params.max_results.unwrap_or(50);
-		let context = params.context.unwrap_or(0);
-
-		// Collect matching files
-		let walker = ignore::WalkBuilder::new(&current_dir)
-			.git_ignore(true)
-			.git_global(true)
-			.git_exclude(true)
-			.hidden(true)
-			.build();
-
-		let mut files = Vec::new();
-		for entry in walker.flatten() {
-			if !entry.file_type().is_some_and(|ft| ft.is_file()) {
-				continue;
-			}
-			let path = entry.path();
-			if crate::grep::language_from_extension(path) != Some(params.language.as_str()) {
-				continue;
-			}
-			if let Some(ref filter_paths) = params.paths {
-				let rel = path
-					.strip_prefix(&current_dir)
-					.unwrap_or(path)
-					.to_string_lossy();
-				if !filter_paths.iter().any(|p| rel.contains(p)) {
-					continue;
-				}
-			}
-			files.push(path.to_path_buf());
+		// Exactly one query mode.
+		let modes = [
+			params.pattern.is_some(),
+			params.symbol.is_some(),
+			params.references.is_some(),
+		]
+		.iter()
+		.filter(|m| **m)
+		.count();
+		if modes != 1 {
+			return Err("Provide exactly one of `pattern`, `symbol`, or `references`.".to_string());
+		}
+		if params.rewrite.is_some() && params.pattern.is_none() {
+			return Err("`rewrite` requires `pattern`.".to_string());
 		}
 
-		// Branch: rewrite mode vs search mode
+		let language = params.language.clone();
+		debug!(
+			"Executing structural_search lang={} pattern={:?} symbol={:?} references={:?}",
+			language, params.pattern, params.symbol, params.references
+		);
+
+		// Compile metavariable constraints up front (clear error on bad regex).
+		let mut constraints: Vec<crate::grep::MetavarConstraint> = Vec::new();
+		if let Some(map) = &params.constraints {
+			for (var, re_src) in map {
+				let re = regex::Regex::new(re_src)
+					.map_err(|e| format!("Invalid regex for ${}: {}", var, e))?;
+				constraints.push((var.trim_start_matches('$').to_string(), re));
+			}
+			constraints.sort_by(|a, b| a.0.cmp(&b.0));
+		}
+
+		// Literal prefilter tokens: files lacking them can never match the
+		// pattern/symbol, so they get scanned but never parsed.
+		let prefilter_tokens: Vec<String> = if let Some(p) = &params.pattern {
+			crate::grep::literal_tokens(p)
+		} else {
+			let name = params
+				.symbol
+				.as_deref()
+				.or(params.references.as_deref())
+				.unwrap_or("");
+			name.split('*')
+				.filter(|t| t.len() >= 2)
+				.max_by_key(|t| t.len())
+				.map(|t| vec![t.to_string()])
+				.unwrap_or_default()
+		};
+
+		let current_dir = self.working_directory.clone();
+		let (files, stamp) = crate::mcp::structural::collect_file_data(
+			&current_dir,
+			&language,
+			params.paths.as_deref(),
+			&prefilter_tokens,
+		);
+
+		// Rewrite mode: separate path, no caching.
 		if let Some(ref rewrite_template) = params.rewrite {
 			return self.structural_rewrite(
 				&files,
-				&current_dir,
-				&params.pattern,
+				params.pattern.as_deref().unwrap_or_default(),
 				rewrite_template,
-				&params.language,
+				&language,
 				params.update_all.unwrap_or(false),
 			);
 		}
 
-		let outcome = smart_search_all_files(
-			&files,
-			&current_dir,
-			&params.pattern,
-			&params.language,
-			max_results,
-			context > 0,
-		);
+		let max_results = params.max_results.unwrap_or(50);
+		let offset = params.offset.unwrap_or(0);
+		let context = params.context.unwrap_or(0);
 
-		if outcome.matches.is_empty() {
-			return Ok(outcome
-				.diagnostic
-				.unwrap_or_else(|| "No matches found.".to_string()));
+		// Cache key: everything that defines the result set (not pagination).
+		let constraint_key = constraints
+			.iter()
+			.map(|(k, re)| format!("{}={}", k, re.as_str()))
+			.collect::<Vec<_>>()
+			.join(";");
+		let paths_key = params.paths.clone().unwrap_or_default().join(";");
+		let fp = crate::mcp::structural::fingerprint_request(&[
+			params.pattern.as_deref().unwrap_or(""),
+			params.symbol.as_deref().unwrap_or(""),
+			params.references.as_deref().unwrap_or(""),
+			&language,
+			params.inside.as_deref().unwrap_or(""),
+			params.has.as_deref().unwrap_or(""),
+			&constraint_key,
+			&paths_key,
+		]);
+
+		// Serve repeat/paginated queries from the cache — skips all parsing
+		// and strategy evaluation while the candidate file set is unchanged.
+		{
+			let cache = self.structural_cache.read();
+			if let Some(qc) = cache.as_ref() {
+				if qc.fingerprint == fp && qc.stamp == stamp {
+					return Ok(format_structural_response(
+						&qc.matches,
+						qc.note.as_deref(),
+						qc.diagnostic.as_deref(),
+						offset,
+						max_results,
+						context,
+						&files,
+					));
+				}
+			}
 		}
 
-		let output = if context > 0 {
-			crate::grep::format_matches_with_context(&outcome.matches, &outcome.source_map, context)
+		let outcome = if let Some(pattern) = &params.pattern {
+			crate::mcp::structural::smart_search(
+				&files,
+				pattern,
+				&language,
+				&constraints,
+				params.inside.as_deref(),
+				params.has.as_deref(),
+			)
+		} else if let Some(symbol) = &params.symbol {
+			crate::mcp::structural::symbol_search(&files, symbol, &language, false)
 		} else {
-			crate::grep::format_matches_grouped(&outcome.matches)
+			let name = params.references.as_deref().unwrap_or_default();
+			crate::mcp::structural::symbol_search(&files, name, &language, true)
 		};
 
-		// Note is self-describing (each strategy emits its own bracketed prefix),
-		// so we don't wrap it. Strategy 1 (default Smart pattern) emits no note
-		// — direct matches need no annotation.
-		let header = outcome
-			.note
-			.as_deref()
-			.map(|n| format!("{}\n", n))
-			.unwrap_or_default();
+		let response = format_structural_response(
+			&outcome.matches,
+			outcome.note.as_deref(),
+			outcome.diagnostic.as_deref(),
+			offset,
+			max_results,
+			context,
+			&files,
+		);
 
-		Ok(format!(
-			"{}{}\n\n{} matches found.",
-			header,
-			output,
-			outcome.matches.len()
-		))
+		*self.structural_cache.write() = Some(crate::mcp::structural::QueryCache {
+			fingerprint: fp,
+			stamp,
+			matches: outcome.matches,
+			note: outcome.note,
+			diagnostic: outcome.diagnostic,
+		});
+
+		Ok(response)
 	}
+}
+
+/// Render the final structural_search response: optional strategy note,
+/// formatted match page, steering footer with totals and the next offset,
+/// optional diagnostic. Truncation always tells the LLM how to continue.
+fn format_structural_response(
+	matches: &[crate::grep::GrepMatch],
+	note: Option<&str>,
+	diagnostic: Option<&str>,
+	offset: usize,
+	max_results: usize,
+	context: usize,
+	files: &[crate::mcp::structural::FileData],
+) -> String {
+	if matches.is_empty() {
+		return diagnostic.unwrap_or("No matches found.").to_string();
+	}
+	let total = matches.len();
+	if offset >= total {
+		return format!(
+			"Offset {} is beyond the result set ({} total matches).",
+			offset, total
+		);
+	}
+	let end = (offset + max_results).min(total);
+	let page = &matches[offset..end];
+
+	let body = if context > 0 {
+		let mut source_map = std::collections::HashMap::new();
+		for fd in files {
+			if page.iter().any(|m| m.file == fd.display) {
+				source_map.insert(fd.display.clone(), fd.content.clone());
+			}
+		}
+		crate::grep::format_matches_with_context(page, &source_map, context)
+	} else {
+		crate::grep::format_matches_grouped(page)
+	};
+
+	let mut out = String::new();
+	if let Some(n) = note {
+		out.push_str(n);
+		out.push('\n');
+	}
+	out.push_str(&body);
+	if total > end || offset > 0 {
+		let capped = if total >= crate::mcp::structural::MAX_TOTAL_MATCHES {
+			"+"
+		} else {
+			""
+		};
+		out.push_str(&format!(
+			"\n\nShowing {}–{} of {}{} matches.",
+			offset + 1,
+			end,
+			total,
+			capped
+		));
+		if end < total {
+			out.push_str(&format!(
+				" Next page: offset={}. Narrow with `paths`, `inside`, `has`, or metavariable `constraints`.",
+				end
+			));
+		}
+	} else {
+		out.push_str(&format!("\n\n{} matches found.", total));
+	}
+	if let Some(d) = diagnostic {
+		out.push_str("\n\n");
+		out.push_str(d);
+	}
+	out
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -544,8 +709,7 @@ impl ServerHandler for McpServer {
 impl McpServer {
 	fn structural_rewrite(
 		&self,
-		files: &[std::path::PathBuf],
-		current_dir: &std::path::Path,
+		files: &[crate::mcp::structural::FileData],
 		pattern: &str,
 		rewrite_template: &str,
 		language: &str,
@@ -554,31 +718,23 @@ impl McpServer {
 		let mut results = Vec::new();
 		let mut total_replacements = 0;
 
-		for path in files {
-			let source = match std::fs::read_to_string(path) {
-				Ok(s) => s,
-				Err(_) => continue,
-			};
-			let display_path = path
-				.strip_prefix(current_dir)
-				.unwrap_or(path)
-				.to_string_lossy()
-				.to_string();
-
+		// Prefilter-missed files cannot contain the pattern's literal tokens,
+		// so they cannot match — skip without parsing.
+		for fd in files.iter().filter(|f| f.prefilter_hit) {
 			match crate::grep::rewrite_file(
-				&display_path,
-				&source,
+				&fd.display,
+				&fd.content,
 				pattern,
 				rewrite_template,
 				language,
 			) {
 				Ok(Some(result)) => {
 					total_replacements += result.replacements;
-					results.push((path.clone(), result));
+					results.push((fd.path.clone(), result));
 				}
 				Ok(None) => {}
 				Err(e) => {
-					debug!("Error rewriting {}: {}", display_path, e);
+					debug!("Error rewriting {}: {}", fd.display, e);
 				}
 			}
 		}
@@ -648,6 +804,7 @@ impl McpServer {
 			lsp: None,
 			indexer_enabled: true,
 			tool_router,
+			structural_cache: Arc::new(parking_lot::RwLock::new(None)),
 		}
 	}
 
@@ -802,6 +959,7 @@ impl McpServer {
 			lsp,
 			indexer_enabled: should_start_indexer,
 			tool_router,
+			structural_cache: Arc::new(parking_lot::RwLock::new(None)),
 		};
 
 		// Start background services (watcher + indexing)
@@ -904,530 +1062,6 @@ impl McpServer {
 			});
 		}
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Smart structural-search orchestration
-// ---------------------------------------------------------------------------
-
-/// Result of a multi-strategy structural search across a file list.
-struct SmartSearchOutcome {
-	matches: Vec<crate::grep::GrepMatch>,
-	source_map: std::collections::HashMap<String, String>,
-	/// When a non-default strategy yielded the matches, describes which one.
-	note: Option<String>,
-	/// Human-readable explanation of why zero matches were found. Only set when
-	/// `matches` is empty; intended to guide an LLM toward a better next attempt.
-	diagnostic: Option<String>,
-}
-
-/// Run the user pattern against `files` using a chain of strategies. Each step
-/// fires only when the previous one produced zero matches; the first step that
-/// yields anything wins. On total failure the result carries a short diagnostic.
-///
-/// Strategy order (tuned against LLM mis-pattern modes observed in practice):
-///   1. Smart-strictness ast-grep pattern (the default)
-///   2. Relaxed-strictness pattern — only when root_kind is None or pattern has
-///      no item-keyword (avoids false positives like `pub mod` matching
-///      `pub struct $N { $$$ }`)
-///   3. Item-keyword broadening — `pub struct …` → `struct_item` kind, etc.
-///   4. KindMatcher with raw pattern
-///   5. Canonical kind mapping (LLM intent dictionary)
-///   6. Language-aware contextual fallback (Rust types, Go calls, TS fields, JSON pairs)
-fn smart_search_all_files(
-	files: &[std::path::PathBuf],
-	current_dir: &std::path::Path,
-	pattern: &str,
-	language: &str,
-	max_results: usize,
-	want_source: bool,
-) -> SmartSearchOutcome {
-	// Parse the pattern once — needed for diagnostics and to gate Relaxed.
-	let info = crate::grep::pattern_info(pattern, language).ok();
-	let metavars: Vec<String> = info
-		.as_ref()
-		.map(|i| i.defined_vars.clone())
-		.unwrap_or_default();
-
-	let finalize = |mut out: StrategyOutput, note: Option<String>| -> SmartSearchOutcome {
-		rerank_matches(&mut out.0, &metavars);
-		out.0.truncate(max_results);
-		SmartSearchOutcome {
-			matches: out.0,
-			source_map: out.1,
-			note,
-			diagnostic: None,
-		}
-	};
-
-	// Strategy 1 — default pattern + Smart strictness
-	let r1 = run_strategy_pattern(
-		files,
-		current_dir,
-		pattern,
-		language,
-		crate::grep::MatchStrictness::Smart,
-		max_results,
-		want_source,
-	);
-	if !r1.0.is_empty() {
-		return finalize(r1, None);
-	}
-
-	// Strategy 2 — Relaxed strictness, but ONLY when the pattern is
-	// kind-ambiguous. For typed item patterns (struct_item, function_item, …)
-	// Relaxed has been observed to leak false positives (e.g. matching
-	// `pub mod foo;` against `pub struct $N { $$$ }`), so we skip it there.
-	let relaxed_safe = info
-		.as_ref()
-		.map(|i| i.root_kind.is_none() && !i.has_error)
-		.unwrap_or(false);
-	if relaxed_safe {
-		let r2 = run_strategy_pattern(
-			files,
-			current_dir,
-			pattern,
-			language,
-			crate::grep::MatchStrictness::Relaxed,
-			max_results,
-			want_source,
-		);
-		if !r2.0.is_empty() {
-			return finalize(r2, Some("[strictness: relaxed]".to_string()));
-		}
-	}
-
-	// Strategy 3 — Item-keyword broadening. The single most common LLM trap
-	// is writing `pub struct $N { $$$ }` for code that's `#[derive(...)] pub struct ...`.
-	// Smart can't match (decorator is a child of struct_item), but the *intent*
-	// is clearly "find structs". Fall back to the corresponding kind matcher.
-	if let Some((kind, desc)) = item_keyword_kind(pattern, language) {
-		let r3a = run_strategy_kind(files, current_dir, kind, language, max_results, want_source);
-		if !r3a.0.is_empty() {
-			return finalize(
-				r3a,
-				Some(format!(
-					"[kind: {}] broadened from `{}` (returns ALL {} — your pattern likely missed due to decorators or signature shape)",
-					kind,
-					pattern.trim(),
-					desc
-				)),
-			);
-		}
-	}
-
-	// Strategy 4 — KindMatcher with the raw pattern (when LLM passed a kind name)
-	let r3 = run_strategy_kind(
-		files,
-		current_dir,
-		pattern,
-		language,
-		max_results,
-		want_source,
-	);
-	if !r3.0.is_empty() {
-		return finalize(r3, Some(format!("[kind: {}]", pattern)));
-	}
-
-	// Strategy 5 — canonical kind mapping (rescues LLM naming mismatches)
-	if let Some(canonical) = crate::grep::canonical_kind(pattern, language) {
-		if canonical != pattern {
-			let r3b = run_strategy_kind(
-				files,
-				current_dir,
-				canonical,
-				language,
-				max_results,
-				want_source,
-			);
-			if !r3b.0.is_empty() {
-				return finalize(
-					r3b,
-					Some(format!(
-						"[kind: {}] (canonical {} kind for `{}`)",
-						canonical, language, pattern
-					)),
-				);
-			}
-		}
-	}
-
-	// Strategy 6 — language-aware contextual fallback
-	for (desc, selector, context_src) in auto_contexts(language, pattern) {
-		let r4 = run_strategy_contextual(
-			files,
-			current_dir,
-			&context_src,
-			selector,
-			language,
-			max_results,
-			want_source,
-		);
-		if !r4.0.is_empty() {
-			return finalize(r4, Some(format!("[context wrap: {}]", desc)));
-		}
-	}
-
-	// All strategies exhausted — build diagnostic
-	SmartSearchOutcome {
-		matches: Vec::new(),
-		source_map: std::collections::HashMap::new(),
-		note: None,
-		diagnostic: Some(build_diagnostic(pattern, language)),
-	}
-}
-
-/// Light reranking: hoist matches whose file path mentions any metavariable
-/// name (case-insensitive). Stable within the priority class so per-file
-/// match order is preserved.
-fn rerank_matches(matches: &mut [crate::grep::GrepMatch], metavars: &[String]) {
-	if metavars.is_empty() {
-		return;
-	}
-	let needles: Vec<String> = metavars.iter().map(|n| n.to_ascii_lowercase()).collect();
-	matches.sort_by_key(|m| {
-		let path_lower = m.file.to_ascii_lowercase();
-		let hit = needles
-			.iter()
-			.any(|n| !n.is_empty() && path_lower.contains(n));
-		// Lower key sorts first — boost (0) goes ahead of non-boost (1).
-		(if hit { 0u8 } else { 1u8 }, m.file.clone(), m.line)
-	});
-}
-
-type StrategyOutput = (
-	Vec<crate::grep::GrepMatch>,
-	std::collections::HashMap<String, String>,
-);
-
-fn run_strategy_pattern(
-	files: &[std::path::PathBuf],
-	current_dir: &std::path::Path,
-	pattern: &str,
-	language: &str,
-	strictness: crate::grep::MatchStrictness,
-	max_results: usize,
-	want_source: bool,
-) -> StrategyOutput {
-	let mut matches = Vec::new();
-	let mut source_map = std::collections::HashMap::new();
-	for path in files {
-		if matches.len() >= max_results {
-			break;
-		}
-		let source = match std::fs::read_to_string(path) {
-			Ok(s) => s,
-			Err(_) => continue,
-		};
-		let display_path = path
-			.strip_prefix(current_dir)
-			.unwrap_or(path)
-			.to_string_lossy()
-			.to_string();
-		if let Ok(found) = crate::grep::search_file_strict(
-			&display_path,
-			&source,
-			pattern,
-			language,
-			strictness.clone(),
-		) {
-			if !found.is_empty() {
-				if want_source {
-					source_map.insert(display_path.clone(), source);
-				}
-				matches.extend(found);
-			}
-		}
-	}
-	matches.truncate(max_results);
-	(matches, source_map)
-}
-
-fn run_strategy_kind(
-	files: &[std::path::PathBuf],
-	current_dir: &std::path::Path,
-	kind: &str,
-	language: &str,
-	max_results: usize,
-	want_source: bool,
-) -> StrategyOutput {
-	let mut matches = Vec::new();
-	let mut source_map = std::collections::HashMap::new();
-	for path in files {
-		if matches.len() >= max_results {
-			break;
-		}
-		let source = match std::fs::read_to_string(path) {
-			Ok(s) => s,
-			Err(_) => continue,
-		};
-		let display_path = path
-			.strip_prefix(current_dir)
-			.unwrap_or(path)
-			.to_string_lossy()
-			.to_string();
-		if let Ok(found) = crate::grep::search_file_by_kind(&display_path, &source, kind, language)
-		{
-			if !found.is_empty() {
-				if want_source {
-					source_map.insert(display_path.clone(), source);
-				}
-				matches.extend(found);
-			}
-		}
-	}
-	matches.truncate(max_results);
-	(matches, source_map)
-}
-
-fn run_strategy_contextual(
-	files: &[std::path::PathBuf],
-	current_dir: &std::path::Path,
-	context_src: &str,
-	selector: &str,
-	language: &str,
-	max_results: usize,
-	want_source: bool,
-) -> StrategyOutput {
-	let mut matches = Vec::new();
-	let mut source_map = std::collections::HashMap::new();
-	for path in files {
-		if matches.len() >= max_results {
-			break;
-		}
-		let source = match std::fs::read_to_string(path) {
-			Ok(s) => s,
-			Err(_) => continue,
-		};
-		let display_path = path
-			.strip_prefix(current_dir)
-			.unwrap_or(path)
-			.to_string_lossy()
-			.to_string();
-		if let Ok(found) = crate::grep::search_file_contextual(
-			&display_path,
-			&source,
-			context_src,
-			selector,
-			language,
-		) {
-			if !found.is_empty() {
-				if want_source {
-					source_map.insert(display_path.clone(), source);
-				}
-				matches.extend(found);
-			}
-		}
-	}
-	matches.truncate(max_results);
-	(matches, source_map)
-}
-
-/// Per-language scaffolds for the contextual fallback. Each entry returns
-/// (description, selector, full-context-source) where `pattern` is embedded
-/// at the cursor position so the parser sees it in an unambiguous context.
-///
-/// These cover the documented parsing traps:
-///   • Go — `fmt.Println($A)` parses as type_conversion unless wrapped in a func body
-///   • TS/JS — `name = value` parses as assignment unless wrapped in a class body
-///   • JSON — `"key": $V` doesn't parse standalone; needs an object wrapper
-fn auto_contexts(language: &str, pattern: &str) -> Vec<(&'static str, &'static str, String)> {
-	match language {
-		"rust" => {
-			// Rust type-expressions like `Arc<Mutex<$T>>` don't parse standalone
-			// (top-level isn't a type). Wrap as a type alias to disambiguate.
-			let looks_like_type = pattern.contains('<')
-				&& pattern.contains('>')
-				&& !pattern.contains('{')
-				&& !pattern.contains(';')
-				&& !pattern.contains(" fn ")
-				&& !pattern.contains("fn ");
-			if looks_like_type {
-				vec![(
-					"Rust type alias context, generic_type selector",
-					"generic_type",
-					format!("type _ = {};", pattern),
-				)]
-			} else {
-				Vec::new()
-			}
-		}
-		"go" => vec![(
-			"Go func body, call_expression selector",
-			"call_expression",
-			format!("package _\nfunc _() {{ {} }}", pattern),
-		)],
-		"typescript" | "javascript" => vec![
-			(
-				"class body, field_definition selector",
-				"field_definition",
-				format!("class _ {{ {} }}", pattern),
-			),
-			(
-				"class body, method_definition selector",
-				"method_definition",
-				format!("class _ {{ {} }}", pattern),
-			),
-		],
-		"json" => vec![(
-			"object body, pair selector",
-			"pair",
-			format!("{{ {} }}", pattern),
-		)],
-		_ => Vec::new(),
-	}
-}
-
-/// If `pattern` starts with a recognized item-level keyword in `language`,
-/// return the corresponding tree-sitter kind plus a human label. Used to
-/// broaden a failed structural pattern to "find all items of this kind",
-/// rescuing the common case where the LLM omitted attributes / return types
-/// / signature shape that the real source has.
-fn item_keyword_kind(pattern: &str, language: &str) -> Option<(&'static str, &'static str)> {
-	let trimmed = pattern.trim_start();
-	let starts = |kw: &str| {
-		trimmed.starts_with(kw)
-			&& trimmed[kw.len()..]
-				.chars()
-				.next()
-				.map(|c| c.is_whitespace())
-				.unwrap_or(false)
-	};
-	match language {
-		"rust" => {
-			if starts("pub struct") || starts("struct") {
-				Some(("struct_item", "struct definitions"))
-			} else if starts("pub enum") || starts("enum") {
-				Some(("enum_item", "enum definitions"))
-			} else if starts("pub trait") || starts("trait") {
-				Some(("trait_item", "trait definitions"))
-			} else if starts("impl") {
-				Some(("impl_item", "impl blocks"))
-			} else if starts("pub fn")
-				|| starts("pub async fn")
-				|| starts("async fn")
-				|| starts("fn")
-				|| starts("pub const fn")
-				|| starts("const fn")
-				|| starts("pub unsafe fn")
-				|| starts("unsafe fn")
-			{
-				Some(("function_item", "function definitions"))
-			} else if starts("pub use") || starts("use") {
-				Some(("use_declaration", "use imports"))
-			} else if starts("pub mod") || starts("mod") {
-				Some(("mod_item", "module declarations"))
-			} else if starts("pub type") || starts("type") {
-				Some(("type_item", "type aliases"))
-			} else {
-				None
-			}
-		}
-		"javascript" | "typescript" => {
-			if starts("class") || starts("export class") {
-				Some(("class_declaration", "class declarations"))
-			} else if starts("function") || starts("async function") || starts("export function") {
-				Some(("function_declaration", "function declarations"))
-			} else if starts("interface") || starts("export interface") {
-				Some(("interface_declaration", "interface declarations"))
-			} else if starts("import") {
-				Some(("import_statement", "import statements"))
-			} else {
-				None
-			}
-		}
-		"python" => {
-			if starts("def") || starts("async def") {
-				Some(("function_definition", "function definitions"))
-			} else if starts("class") {
-				Some(("class_definition", "class definitions"))
-			} else if starts("from") {
-				Some(("import_from_statement", "from-imports"))
-			} else if starts("import") {
-				Some(("import_statement", "imports"))
-			} else if starts("@") {
-				Some(("decorated_definition", "decorated definitions"))
-			} else {
-				None
-			}
-		}
-		"go" => {
-			if starts("func") {
-				Some(("function_declaration", "function declarations"))
-			} else if starts("type") {
-				Some(("type_declaration", "type declarations"))
-			} else if starts("import") {
-				Some(("import_declaration", "import declarations"))
-			} else {
-				None
-			}
-		}
-		_ => None,
-	}
-}
-
-/// Short diagnostic for when no strategy matched. Just the signals the LLM
-/// needs to retry — parsed kind, parse-error flag, metavars, and one or two
-/// targeted hints. Worked examples and language tips live in the tool
-/// description (read once), not duplicated per failure.
-fn build_diagnostic(pattern: &str, language: &str) -> String {
-	let mut out = String::new();
-	out.push_str(&format!("No matches: {}\n", pattern));
-
-	match crate::grep::pattern_info(pattern, language) {
-		Ok(info) => {
-			let kind = info.root_kind.as_deref().unwrap_or("(bare $metavar)");
-			let vars = if info.defined_vars.is_empty() {
-				"none".to_string()
-			} else {
-				info.defined_vars
-					.iter()
-					.map(|v| format!("${}", v))
-					.collect::<Vec<_>>()
-					.join(",")
-			};
-			out.push_str(&format!(
-				"Parsed: kind={}, parse_error={}, metavars={}\n",
-				kind, info.has_error, vars
-			));
-
-			// One-shot retargeted hint, chosen by what we observed.
-			if info.has_error {
-				out.push_str(&format!(
-					"Hint: pattern doesn't parse as standalone {}. \
-					   For type expressions try kind 'generic_type'; for code fragments \
-					   wrap in a valid context. See tool description for shapes.\n",
-					language
-				));
-			} else if let Some((kind_name, label)) = item_keyword_kind(pattern, language) {
-				out.push_str(&format!(
-					"Hint: for finding all {} regardless of decorators/signature, \
-					   pass `{}` as the pattern (a tree-sitter kind name).\n",
-					label, kind_name
-				));
-			} else if let Some(canonical) = crate::grep::canonical_kind(pattern, language) {
-				if canonical != pattern {
-					out.push_str(&format!(
-						"Hint: canonical {} kind for this intent is '{}'.\n",
-						language, canonical
-					));
-				}
-			} else {
-				out.push_str(
-					"Hint: see tool description for valid pattern shapes per language. \
-					   For meaning-based lookups, use semantic_search.\n",
-				);
-			}
-		}
-		Err(e) => {
-			out.push_str(&format!("Parse error: {}\n", e));
-			out.push_str(
-				"Hint: pattern must be syntactically valid in the target language. \
-				   See tool description for valid shapes.\n",
-			);
-		}
-	}
-	out
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/structural.rs
+++ b/src/mcp/structural.rs
@@ -1,0 +1,1105 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Smart structural-search pipeline for the MCP `structural_search` tool.
+//!
+//! Execution model (zero standing index):
+//!   1. A parallel gitignore-aware walk collects candidate files for the
+//!      target language, reading contents and evaluating a literal-token
+//!      prefilter inline (a pattern's concrete tokens must appear verbatim
+//!      in any file it can match, so failing files are never parsed).
+//!   2. Pass A parses ONLY prefilter-surviving files — once per file — and
+//!      runs the pattern strategies (Smart, Relaxed) plus the `inside`/`has`
+//!      relational specs against that single shared parse.
+//!   3. Pass B (only when Pass A found nothing) parses every candidate file
+//!      once and runs the kind/contextual fallback strategies the same way.
+//!   4. When everything misses, a labeled lexical line scan answers instead
+//!      of returning empty-handed, alongside the structural diagnostic.
+//!
+//! A single-entry query cache (request fingerprint + repo stamp) makes
+//! repeat and pagination calls skip parsing entirely.
+
+use crate::grep::{self, GrepMatch, MetavarConstraint};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::SystemTime;
+
+/// Hard cap on matches kept per file (protects against e.g. kind=identifier).
+const MAX_PER_FILE_MATCHES: usize = 500;
+/// Hard cap on total matches kept per query. The steering footer reports
+/// when this cap was hit so the LLM knows the count is a floor.
+pub const MAX_TOTAL_MATCHES: usize = 10_000;
+/// Caps for the lexical fallback scan.
+const LEXICAL_PER_FILE: usize = 20;
+const LEXICAL_TOTAL: usize = 200;
+/// Files larger than this are skipped (generated bundles, vendored blobs).
+const MAX_FILE_SIZE: u64 = 5_000_000;
+
+/// A candidate file loaded into memory by the parallel walk.
+pub struct FileData {
+	pub path: PathBuf,
+	pub display: String,
+	pub content: String,
+	/// True when the content contains every literal prefilter token.
+	pub prefilter_hit: bool,
+}
+
+/// Stamp of the candidate file set, used for cache staleness checks.
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
+pub struct RepoStamp {
+	pub file_count: usize,
+	pub total_size: u64,
+	pub max_mtime: Option<SystemTime>,
+}
+
+/// Single-entry cache of the last fully evaluated query. Serving repeat or
+/// paginated requests from it skips all parsing and strategy evaluation.
+pub struct QueryCache {
+	pub fingerprint: u64,
+	pub stamp: RepoStamp,
+	pub matches: Vec<GrepMatch>,
+	pub note: Option<String>,
+	pub diagnostic: Option<String>,
+}
+
+/// Result of a multi-strategy structural search across a file list.
+pub struct SmartSearchOutcome {
+	pub matches: Vec<GrepMatch>,
+	/// When a non-default strategy yielded the matches, describes which one.
+	pub note: Option<String>,
+	/// Explanation of why structural matching failed. Set alongside lexical
+	/// fallback matches, or alone when nothing at all was found.
+	pub diagnostic: Option<String>,
+}
+
+/// Hash the request-defining fields into a cache fingerprint.
+pub fn fingerprint_request(parts: &[&str]) -> u64 {
+	use std::hash::{Hash, Hasher};
+	let mut h = std::collections::hash_map::DefaultHasher::new();
+	for p in parts {
+		p.hash(&mut h);
+	}
+	h.finish()
+}
+
+/// Collect candidate files via a parallel gitignore-aware walk. Reads file
+/// contents (needed by every later stage) and evaluates the literal-token
+/// prefilter inline. Returns files sorted by display path plus the repo stamp.
+pub fn collect_file_data(
+	root: &Path,
+	language: &str,
+	paths_filter: Option<&[String]>,
+	prefilter_tokens: &[String],
+) -> (Vec<FileData>, RepoStamp) {
+	let acc: parking_lot::Mutex<(Vec<FileData>, RepoStamp)> =
+		parking_lot::Mutex::new((Vec::new(), RepoStamp::default()));
+
+	let walker = ignore::WalkBuilder::new(root)
+		.git_ignore(true)
+		.git_global(true)
+		.git_exclude(true)
+		.hidden(true)
+		.build_parallel();
+
+	let acc_ref = &acc;
+	walker.run(|| {
+		Box::new(move |result| {
+			let entry = match result {
+				Ok(e) => e,
+				Err(_) => return ignore::WalkState::Continue,
+			};
+			if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+				return ignore::WalkState::Continue;
+			}
+			let path = entry.path();
+			if grep::language_from_extension(path) != Some(language) {
+				return ignore::WalkState::Continue;
+			}
+			let display = path
+				.strip_prefix(root)
+				.unwrap_or(path)
+				.to_string_lossy()
+				.to_string();
+			if let Some(filter) = paths_filter {
+				if !filter.iter().any(|p| display.contains(p)) {
+					return ignore::WalkState::Continue;
+				}
+			}
+			let (size, mtime) = entry
+				.metadata()
+				.map(|m| (m.len(), m.modified().ok()))
+				.unwrap_or((0, None));
+			if size > MAX_FILE_SIZE {
+				return ignore::WalkState::Continue;
+			}
+			let content = match std::fs::read_to_string(path) {
+				Ok(c) => c,
+				Err(_) => return ignore::WalkState::Continue,
+			};
+			let prefilter_hit = prefilter_tokens.is_empty()
+				|| prefilter_tokens
+					.iter()
+					.all(|t| content.contains(t.as_str()));
+
+			let mut guard = acc_ref.lock();
+			guard.1.file_count += 1;
+			guard.1.total_size += size;
+			if let Some(mt) = mtime {
+				if guard.1.max_mtime.map(|cur| mt > cur).unwrap_or(true) {
+					guard.1.max_mtime = Some(mt);
+				}
+			}
+			guard.0.push(FileData {
+				path: path.to_path_buf(),
+				display,
+				content,
+				prefilter_hit,
+			});
+			ignore::WalkState::Continue
+		})
+	});
+
+	let (mut files, stamp) = acc.into_inner();
+	files.sort_by(|a, b| a.display.cmp(&b.display));
+	(files, stamp)
+}
+
+/// Map `work` over (a filtered subset of) files on all cores, preserving
+/// input file order in the returned vec.
+fn parallel_file_map<T: Send>(
+	files: &[FileData],
+	only_prefilter_hits: bool,
+	work: impl Fn(&FileData) -> Option<T> + Sync,
+) -> Vec<T> {
+	let cursor = AtomicUsize::new(0);
+	let collected: parking_lot::Mutex<Vec<(usize, T)>> = parking_lot::Mutex::new(Vec::new());
+	let workers = std::thread::available_parallelism()
+		.map(|n| n.get())
+		.unwrap_or(4)
+		.min(16)
+		.min(files.len().max(1));
+
+	std::thread::scope(|s| {
+		for _ in 0..workers {
+			s.spawn(|| {
+				let mut local: Vec<(usize, T)> = Vec::new();
+				loop {
+					let i = cursor.fetch_add(1, Ordering::Relaxed);
+					if i >= files.len() {
+						break;
+					}
+					let fd = &files[i];
+					if only_prefilter_hits && !fd.prefilter_hit {
+						continue;
+					}
+					if let Some(v) = work(fd) {
+						local.push((i, v));
+					}
+				}
+				collected.lock().extend(local);
+			});
+		}
+	});
+
+	let mut v = collected.into_inner();
+	v.sort_by_key(|(i, _)| *i);
+	v.into_iter().map(|(_, t)| t).collect()
+}
+
+/// A prepared set of specs to evaluate per file: `n_strategies` strategy
+/// buckets (with display notes) plus optional `inside`/`has` relational specs.
+struct SpecSet {
+	specs: Vec<grep::SearchSpec>,
+	notes: Vec<Option<String>>,
+	n_strategies: usize,
+	inside_idx: Option<usize>,
+	has_idx: Option<usize>,
+}
+
+fn build_spec_set(
+	strategies: Vec<(Option<String>, grep::SearchSpec)>,
+	inside: Option<&str>,
+	has: Option<&str>,
+) -> SpecSet {
+	let n_strategies = strategies.len();
+	let mut specs = Vec::with_capacity(n_strategies + 2);
+	let mut notes = Vec::with_capacity(n_strategies);
+	for (note, spec) in strategies {
+		notes.push(note);
+		specs.push(spec);
+	}
+	let inside_idx = inside.map(|s| {
+		specs.push(grep::SearchSpec::KindOrPattern {
+			spec: s.to_string(),
+		});
+		specs.len() - 1
+	});
+	let has_idx = has.map(|s| {
+		specs.push(grep::SearchSpec::KindOrPattern {
+			spec: s.to_string(),
+		});
+		specs.len() - 1
+	});
+	SpecSet {
+		specs,
+		notes,
+		n_strategies,
+		inside_idx,
+		has_idx,
+	}
+}
+
+/// Keep a match only when the relational constraints hold:
+/// `inside` — some inside-match range strictly contains the match;
+/// `has` — the match strictly contains some has-match range.
+fn filter_by_containment(
+	matches: Vec<GrepMatch>,
+	inside_ranges: Option<&[(usize, usize)]>,
+	has_ranges: Option<&[(usize, usize)]>,
+) -> Vec<GrepMatch> {
+	matches
+		.into_iter()
+		.filter(|m| {
+			let mr = (m.start_byte, m.end_byte);
+			if let Some(ranges) = inside_ranges {
+				if !ranges
+					.iter()
+					.any(|r| r.0 <= mr.0 && mr.1 <= r.1 && *r != mr)
+				{
+					return false;
+				}
+			}
+			if let Some(ranges) = has_ranges {
+				if !ranges
+					.iter()
+					.any(|r| mr.0 <= r.0 && r.1 <= mr.1 && *r != mr)
+				{
+					return false;
+				}
+			}
+			true
+		})
+		.collect()
+}
+
+/// Evaluate a spec set across files (single parse per file), apply the
+/// relational filters, and merge into one global bucket per strategy.
+fn run_specs_over_files(
+	files: &[FileData],
+	only_prefilter_hits: bool,
+	language: &str,
+	set: &SpecSet,
+	constraints: &[MetavarConstraint],
+) -> Vec<Vec<GrepMatch>> {
+	let per_file = parallel_file_map(files, only_prefilter_hits, |fd| {
+		let buckets =
+			grep::search_file_multi(&fd.display, &fd.content, language, &set.specs, constraints)
+				.ok()?;
+		if buckets.iter().take(set.n_strategies).all(|b| b.is_empty()) {
+			return None;
+		}
+		let inside_ranges: Option<Vec<(usize, usize)>> = set.inside_idx.map(|i| {
+			buckets[i]
+				.iter()
+				.map(|m| (m.start_byte, m.end_byte))
+				.collect()
+		});
+		let has_ranges: Option<Vec<(usize, usize)>> = set.has_idx.map(|i| {
+			buckets[i]
+				.iter()
+				.map(|m| (m.start_byte, m.end_byte))
+				.collect()
+		});
+		let mut out: Vec<Vec<GrepMatch>> = Vec::with_capacity(set.n_strategies);
+		for bucket in buckets.into_iter().take(set.n_strategies) {
+			let mut filtered =
+				filter_by_containment(bucket, inside_ranges.as_deref(), has_ranges.as_deref());
+			filtered.truncate(MAX_PER_FILE_MATCHES);
+			out.push(filtered);
+		}
+		Some(out)
+	});
+
+	let mut merged: Vec<Vec<GrepMatch>> = (0..set.n_strategies).map(|_| Vec::new()).collect();
+	for file_buckets in per_file {
+		for (i, bucket) in file_buckets.into_iter().enumerate() {
+			if merged[i].len() < MAX_TOTAL_MATCHES {
+				merged[i].extend(bucket);
+			}
+		}
+	}
+	for bucket in &mut merged {
+		bucket.truncate(MAX_TOTAL_MATCHES);
+	}
+	merged
+}
+
+/// Deterministic base order regardless of parallel completion order.
+fn sort_matches(matches: &mut [GrepMatch]) {
+	matches.sort_by(|a, b| {
+		a.file
+			.cmp(&b.file)
+			.then(a.line.cmp(&b.line))
+			.then(a.column.cmp(&b.column))
+	});
+}
+
+/// Boost matches whose file path mentions one of the pattern's metavariable
+/// names (weak relevance signal an LLM tends to encode in variable naming).
+/// Stable sort: within boost/non-boost groups the base order is preserved.
+fn rerank_matches(matches: &mut [GrepMatch], metavars: &[String]) {
+	if metavars.is_empty() {
+		return;
+	}
+	let needles: Vec<String> = metavars.iter().map(|n| n.to_ascii_lowercase()).collect();
+	matches.sort_by_key(|m| {
+		let path_lower = m.file.to_ascii_lowercase();
+		let hit = needles
+			.iter()
+			.any(|n| !n.is_empty() && path_lower.contains(n));
+		// Lower key sorts first — boost (0) goes ahead of non-boost (1).
+		(if hit { 0u8 } else { 1u8 }, m.file.clone(), m.line)
+	});
+}
+
+fn finalize(
+	mut matches: Vec<GrepMatch>,
+	note: Option<String>,
+	metavars: &[String],
+) -> SmartSearchOutcome {
+	sort_matches(&mut matches);
+	rerank_matches(&mut matches, metavars);
+	SmartSearchOutcome {
+		matches,
+		note,
+		diagnostic: None,
+	}
+}
+
+/// Run the pattern against `files` using a chain of strategies, two passes:
+///
+/// Pass A (prefilter-surviving files only, one parse each):
+///   1. Smart-strictness ast-grep pattern (the default)
+///   2. Relaxed-strictness pattern — only when root_kind is None or pattern
+///      has no item-keyword (avoids false positives like `pub mod` matching
+///      `pub struct $N { $$$ }`)
+///
+/// Pass B (all candidate files, one parse each; only when Pass A is empty):
+///   3. Item-keyword broadening — `pub struct …` → `struct_item` kind, etc.
+///   4. KindMatcher with raw pattern
+///   5. Canonical kind mapping (LLM intent dictionary)
+///   6. Language-aware contextual fallback (Rust types, Go calls, TS fields,
+///      JSON pairs)
+///
+/// Fallback: labeled lexical line scan, so the tool never answers empty-handed
+/// when the pattern's tokens exist somewhere in the corpus.
+pub fn smart_search(
+	files: &[FileData],
+	pattern: &str,
+	language: &str,
+	constraints: &[MetavarConstraint],
+	inside: Option<&str>,
+	has: Option<&str>,
+) -> SmartSearchOutcome {
+	// Parse the pattern once — needed for diagnostics and to gate Relaxed.
+	let info = grep::pattern_info(pattern, language).ok();
+	let metavars: Vec<String> = info
+		.as_ref()
+		.map(|i| i.defined_vars.clone())
+		.unwrap_or_default();
+
+	// --- Pass A: pattern strategies on prefiltered files ---
+	let relaxed_safe = info
+		.as_ref()
+		.map(|i| i.root_kind.is_none() && !i.has_error)
+		.unwrap_or(false);
+
+	let mut strategies: Vec<(Option<String>, grep::SearchSpec)> = vec![(
+		None,
+		grep::SearchSpec::Pattern {
+			pattern: pattern.to_string(),
+			strictness: grep::MatchStrictness::Smart,
+		},
+	)];
+	if relaxed_safe {
+		strategies.push((
+			Some("[strictness: relaxed]".to_string()),
+			grep::SearchSpec::Pattern {
+				pattern: pattern.to_string(),
+				strictness: grep::MatchStrictness::Relaxed,
+			},
+		));
+	}
+	let set = build_spec_set(strategies, inside, has);
+	let buckets = run_specs_over_files(files, true, language, &set, constraints);
+	for (i, bucket) in buckets.into_iter().enumerate() {
+		if !bucket.is_empty() {
+			return finalize(bucket, set.notes[i].clone(), &metavars);
+		}
+	}
+
+	// --- Pass B: kind/contextual fallbacks on all candidate files ---
+	let mut strategies: Vec<(Option<String>, grep::SearchSpec)> = Vec::new();
+	if let Some((kind, desc)) = item_keyword_kind(pattern, language) {
+		strategies.push((
+			Some(format!(
+				"[kind: {}] broadened from `{}` (returns ALL {} — your pattern likely missed due to decorators or signature shape)",
+				kind,
+				pattern.trim(),
+				desc
+			)),
+			grep::SearchSpec::Kind {
+				kind: kind.to_string(),
+			},
+		));
+	}
+	strategies.push((
+		Some(format!("[kind: {}]", pattern)),
+		grep::SearchSpec::Kind {
+			kind: pattern.to_string(),
+		},
+	));
+	if let Some(canonical) = grep::canonical_kind(pattern, language) {
+		if canonical != pattern {
+			strategies.push((
+				Some(format!(
+					"[kind: {}] (canonical {} kind for `{}`)",
+					canonical, language, pattern
+				)),
+				grep::SearchSpec::Kind {
+					kind: canonical.to_string(),
+				},
+			));
+		}
+	}
+	for (desc, selector, context_src) in auto_contexts(language, pattern) {
+		strategies.push((
+			Some(format!("[context wrap: {}]", desc)),
+			grep::SearchSpec::Contextual {
+				context_src,
+				selector: selector.to_string(),
+			},
+		));
+	}
+	let set = build_spec_set(strategies, inside, has);
+	let buckets = run_specs_over_files(files, false, language, &set, constraints);
+	for (i, bucket) in buckets.into_iter().enumerate() {
+		if !bucket.is_empty() {
+			return finalize(bucket, set.notes[i].clone(), &metavars);
+		}
+	}
+
+	// --- Lexical fallback: never answer empty-handed when tokens exist ---
+	let tokens = grep::literal_tokens(pattern);
+	if let Some(token) = tokens.first() {
+		let mut lex: Vec<GrepMatch> = Vec::new();
+		for fd in files {
+			if lex.len() >= LEXICAL_TOTAL {
+				break;
+			}
+			lex.extend(grep::lexical_scan(
+				&fd.display,
+				&fd.content,
+				token,
+				LEXICAL_PER_FILE,
+			));
+		}
+		lex.truncate(LEXICAL_TOTAL);
+		if !lex.is_empty() {
+			sort_matches(&mut lex);
+			return SmartSearchOutcome {
+				matches: lex,
+				note: Some(format!(
+					"[lexical fallback] No structural matches; showing plain-text lines containing \"{}\" (not AST-verified).",
+					token
+				)),
+				diagnostic: Some(build_diagnostic(pattern, language)),
+			};
+		}
+	}
+
+	// All strategies exhausted — diagnostic only.
+	SmartSearchOutcome {
+		matches: Vec::new(),
+		note: None,
+		diagnostic: Some(build_diagnostic(pattern, language)),
+	}
+}
+
+/// Symbol-mode search: find definitions of (or references to) a named symbol
+/// without writing an AST pattern. Supports `*` wildcards in the name.
+pub fn symbol_search(
+	files: &[FileData],
+	symbol: &str,
+	language: &str,
+	references: bool,
+) -> SmartSearchOutcome {
+	let name = match grep::NameMatcher::new(symbol) {
+		Ok(n) => n,
+		Err(e) => {
+			return SmartSearchOutcome {
+				matches: Vec::new(),
+				note: None,
+				diagnostic: Some(format!("Invalid symbol spec `{}`: {}", symbol, e)),
+			}
+		}
+	};
+
+	let per_file = parallel_file_map(files, true, |fd| {
+		let found = if references {
+			grep::find_symbol_refs(&fd.display, &fd.content, &name, language)
+		} else {
+			grep::find_symbol_defs(&fd.display, &fd.content, &name, language)
+		};
+		match found {
+			Ok(v) if !v.is_empty() => {
+				let mut v = v;
+				v.truncate(MAX_PER_FILE_MATCHES);
+				Some(v)
+			}
+			_ => None,
+		}
+	});
+
+	let mut matches: Vec<GrepMatch> = Vec::new();
+	for v in per_file {
+		if matches.len() >= MAX_TOTAL_MATCHES {
+			break;
+		}
+		matches.extend(v);
+	}
+	matches.truncate(MAX_TOTAL_MATCHES);
+
+	if !matches.is_empty() {
+		sort_matches(&mut matches);
+		let mode = if references {
+			"references"
+		} else {
+			"definitions"
+		};
+		return SmartSearchOutcome {
+			matches,
+			note: Some(format!("[symbol {}: {}]", mode, symbol)),
+			diagnostic: None,
+		};
+	}
+
+	// Lexical fallback on the literal fragment of the name.
+	let token = symbol.replace('*', "");
+	if token.len() >= 2 {
+		let mut lex: Vec<GrepMatch> = Vec::new();
+		for fd in files {
+			if lex.len() >= LEXICAL_TOTAL {
+				break;
+			}
+			lex.extend(grep::lexical_scan(
+				&fd.display,
+				&fd.content,
+				&token,
+				LEXICAL_PER_FILE,
+			));
+		}
+		lex.truncate(LEXICAL_TOTAL);
+		if !lex.is_empty() {
+			sort_matches(&mut lex);
+			return SmartSearchOutcome {
+				matches: lex,
+				note: Some(format!(
+					"[lexical fallback] No {} found for `{}`; showing plain-text lines containing \"{}\" (not AST-verified).",
+					if references { "references" } else { "definitions" },
+					symbol,
+					token
+				)),
+				diagnostic: None,
+			};
+		}
+	}
+
+	SmartSearchOutcome {
+		matches: Vec::new(),
+		note: None,
+		diagnostic: Some(format!(
+			"No symbol {} for `{}` ({} files scanned, language: {}). \
+			 Hints: wildcards widen the match (`*{}*`); use `references` to find usages \
+			 or `symbol` for definitions; verify the `language` matches the file extensions.",
+			if references {
+				"references"
+			} else {
+				"definitions"
+			},
+			symbol,
+			files.len(),
+			language,
+			symbol.trim_matches('*')
+		)),
+	}
+}
+
+/// Per-language scaffolds for the contextual fallback. Each entry returns
+/// (description, selector, full-context-source) where `pattern` is embedded
+/// at the cursor position so the parser sees it in an unambiguous context.
+///
+/// These cover the documented parsing traps:
+///   • Go — `fmt.Println($A)` parses as type_conversion unless wrapped in a func body
+///   • TS/JS — `name = value` parses as assignment unless wrapped in a class body
+///   • JSON — `"key": $V` doesn't parse standalone; needs an object wrapper
+fn auto_contexts(language: &str, pattern: &str) -> Vec<(&'static str, &'static str, String)> {
+	match language {
+		"rust" => {
+			// Rust type-expressions like `Arc<Mutex<$T>>` don't parse standalone
+			// (top-level isn't a type). Wrap as a type alias to disambiguate.
+			let looks_like_type = pattern.contains('<')
+				&& pattern.contains('>')
+				&& !pattern.contains('{')
+				&& !pattern.contains(';')
+				&& !pattern.contains(" fn ")
+				&& !pattern.contains("fn ");
+			if looks_like_type {
+				vec![(
+					"Rust type alias context, generic_type selector",
+					"generic_type",
+					format!("type _ = {};", pattern),
+				)]
+			} else {
+				Vec::new()
+			}
+		}
+		"go" => vec![(
+			"Go func body, call_expression selector",
+			"call_expression",
+			format!("package _\nfunc _() {{ {} }}", pattern),
+		)],
+		"typescript" | "javascript" => vec![
+			(
+				"class body, field_definition selector",
+				"field_definition",
+				format!("class _ {{ {} }}", pattern),
+			),
+			(
+				"class body, method_definition selector",
+				"method_definition",
+				format!("class _ {{ {} }}", pattern),
+			),
+		],
+		"json" => vec![(
+			"object body, pair selector",
+			"pair",
+			format!("{{ {} }}", pattern),
+		)],
+		_ => Vec::new(),
+	}
+}
+
+/// If `pattern` starts with a recognized item-level keyword in `language`,
+/// return the corresponding tree-sitter kind plus a human label. Used to
+/// broaden a failed structural pattern to "find all items of this kind",
+/// rescuing the common case where the LLM omitted attributes / return types
+/// / signature shape that the real source has.
+fn item_keyword_kind(pattern: &str, language: &str) -> Option<(&'static str, &'static str)> {
+	let trimmed = pattern.trim_start();
+	let starts = |kw: &str| {
+		trimmed.starts_with(kw)
+			&& trimmed[kw.len()..]
+				.chars()
+				.next()
+				.map(|c| c.is_whitespace())
+				.unwrap_or(false)
+	};
+	match language {
+		"rust" => {
+			if starts("pub struct") || starts("struct") {
+				Some(("struct_item", "struct definitions"))
+			} else if starts("pub enum") || starts("enum") {
+				Some(("enum_item", "enum definitions"))
+			} else if starts("pub trait") || starts("trait") {
+				Some(("trait_item", "trait definitions"))
+			} else if starts("impl") {
+				Some(("impl_item", "impl blocks"))
+			} else if starts("pub fn")
+				|| starts("pub async fn")
+				|| starts("async fn")
+				|| starts("fn")
+				|| starts("pub const fn")
+				|| starts("const fn")
+				|| starts("pub unsafe fn")
+				|| starts("unsafe fn")
+			{
+				Some(("function_item", "function definitions"))
+			} else if starts("pub use") || starts("use") {
+				Some(("use_declaration", "use imports"))
+			} else if starts("pub mod") || starts("mod") {
+				Some(("mod_item", "module declarations"))
+			} else if starts("pub type") || starts("type") {
+				Some(("type_item", "type aliases"))
+			} else {
+				None
+			}
+		}
+		"javascript" | "typescript" => {
+			if starts("class") || starts("export class") {
+				Some(("class_declaration", "class declarations"))
+			} else if starts("function") || starts("async function") || starts("export function") {
+				Some(("function_declaration", "function declarations"))
+			} else if starts("interface") || starts("export interface") {
+				Some(("interface_declaration", "interface declarations"))
+			} else if starts("import") {
+				Some(("import_statement", "import statements"))
+			} else {
+				None
+			}
+		}
+		"python" => {
+			if starts("def") || starts("async def") {
+				Some(("function_definition", "function definitions"))
+			} else if starts("class") {
+				Some(("class_definition", "class definitions"))
+			} else if starts("from") {
+				Some(("import_from_statement", "from-imports"))
+			} else if starts("import") {
+				Some(("import_statement", "imports"))
+			} else if starts("@") {
+				Some(("decorated_definition", "decorated definitions"))
+			} else {
+				None
+			}
+		}
+		"go" => {
+			if starts("func") {
+				Some(("function_declaration", "function declarations"))
+			} else if starts("type") {
+				Some(("type_declaration", "type declarations"))
+			} else if starts("import") {
+				Some(("import_declaration", "import declarations"))
+			} else {
+				None
+			}
+		}
+		_ => None,
+	}
+}
+
+/// Short diagnostic for when no strategy matched. Just the signals the LLM
+/// needs to retry — parsed kind, parse-error flag, metavars, and one or two
+/// targeted hints. Worked examples and language tips live in the tool
+/// description (read once), not duplicated per failure.
+fn build_diagnostic(pattern: &str, language: &str) -> String {
+	let mut out = String::new();
+	out.push_str(&format!("No matches: {}\n", pattern));
+
+	match grep::pattern_info(pattern, language) {
+		Ok(info) => {
+			let kind = info.root_kind.as_deref().unwrap_or("(bare $metavar)");
+			let vars = if info.defined_vars.is_empty() {
+				"none".to_string()
+			} else {
+				info.defined_vars
+					.iter()
+					.map(|v| format!("${}", v))
+					.collect::<Vec<_>>()
+					.join(",")
+			};
+			out.push_str(&format!(
+				"Parsed: kind={}, parse_error={}, metavars={}\n",
+				kind, info.has_error, vars
+			));
+
+			// One-shot retargeted hint, chosen by what we observed.
+			if info.has_error {
+				out.push_str(&format!(
+					"Hint: pattern doesn't parse as standalone {}. \
+					   For type expressions try kind 'generic_type'; for code fragments \
+					   wrap in a valid context. See tool description for shapes.\n",
+					language
+				));
+			} else if let Some((kind_name, label)) = item_keyword_kind(pattern, language) {
+				out.push_str(&format!(
+					"Hint: for finding all {} regardless of decorators/signature, \
+					   pass `{}` as the pattern (a tree-sitter kind name).\n",
+					label, kind_name
+				));
+			} else if let Some(canonical) = grep::canonical_kind(pattern, language) {
+				if canonical != pattern {
+					out.push_str(&format!(
+						"Hint: canonical {} kind for this intent is '{}'.\n",
+						language, canonical
+					));
+				}
+			} else {
+				out.push_str(
+					"Hint: see tool description for valid pattern shapes per language. \
+					   For meaning-based lookups, use semantic_search.\n",
+				);
+			}
+		}
+		Err(e) => {
+			out.push_str(&format!("Parse error: {}\n", e));
+			out.push_str(
+				"Hint: pattern must be syntactically valid in the target language. \
+				   See tool description for valid shapes.\n",
+			);
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn fd(display: &str, content: &str, prefilter_hit: bool) -> FileData {
+		FileData {
+			path: PathBuf::from(display),
+			display: display.to_string(),
+			content: content.to_string(),
+			prefilter_hit,
+		}
+	}
+
+	#[test]
+	fn test_smart_search_basic_pattern() {
+		let files = vec![
+			fd("a.rs", "fn main() { let x = foo.unwrap(); }", true),
+			fd("b.rs", "fn run() { let y = bar.unwrap(); }", true),
+			fd("c.rs", "fn other() { let z = 1; }", false),
+		];
+		let out = smart_search(&files, "$X.unwrap()", "rust", &[], None, None);
+		assert_eq!(out.matches.len(), 2);
+		assert!(out.note.is_none());
+		assert!(out.diagnostic.is_none());
+		// Deterministic order: a.rs before b.rs.
+		assert_eq!(out.matches[0].file, "a.rs");
+	}
+
+	#[test]
+	fn test_smart_search_prefilter_skips_files() {
+		// File contains a match but is marked prefilter-missed — Pass A must
+		// skip it; Pass B (kind strategies) doesn't apply to this pattern, so
+		// the result falls through to lexical/diagnostic territory.
+		let files = vec![fd("a.rs", "fn main() { foo.unwrap(); }", false)];
+		let out = smart_search(&files, "$X.definitely_missing()", "rust", &[], None, None);
+		assert!(out.matches.is_empty());
+		assert!(out.diagnostic.is_some());
+	}
+
+	#[test]
+	fn test_smart_search_kind_broadening_pass_b() {
+		// `pub struct $N { $$$ }` misses decorated structs; Pass B broadens
+		// to struct_item and must find it with the explanatory note.
+		let files = vec![fd(
+			"s.rs",
+			"#[derive(Debug)]\npub struct Config {\n    pub key: String,\n}\n",
+			true,
+		)];
+		let out = smart_search(&files, "pub struct $N { $$$ }", "rust", &[], None, None);
+		assert_eq!(out.matches.len(), 1);
+		let note = out.note.expect("broadening note expected");
+		assert!(note.contains("[kind: struct_item]"), "note: {}", note);
+	}
+
+	#[test]
+	fn test_smart_search_inside_filter() {
+		let files = vec![fd(
+			"a.rs",
+			"const A: i32 = X.unwrap();\nfn main() { let x = foo.unwrap(); }\n",
+			true,
+		)];
+		// Without inside: both unwraps.
+		let all = smart_search(&files, "$X.unwrap()", "rust", &[], None, None);
+		assert_eq!(all.matches.len(), 2);
+		// With inside=function_item: only the one inside fn main.
+		let inside = smart_search(
+			&files,
+			"$X.unwrap()",
+			"rust",
+			&[],
+			Some("function_item"),
+			None,
+		);
+		assert_eq!(inside.matches.len(), 1);
+		assert_eq!(inside.matches[0].line, 2);
+	}
+
+	#[test]
+	fn test_smart_search_has_filter() {
+		let files = vec![fd(
+			"a.rs",
+			"fn with() { foo.unwrap(); }\nfn without() { let x = 1; }\n",
+			true,
+		)];
+		// Kind search for functions, keeping only those containing unwrap.
+		let out = smart_search(
+			&files,
+			"function_item",
+			"rust",
+			&[],
+			None,
+			Some("$X.unwrap()"),
+		);
+		assert_eq!(out.matches.len(), 1);
+		assert!(out.matches[0].text.contains("with"));
+	}
+
+	#[test]
+	fn test_smart_search_metavar_constraints() {
+		let files = vec![fd(
+			"a.rs",
+			"fn handle_request() { a(); }\nfn other_thing() { b(); }\n",
+			true,
+		)];
+		let re = regex::Regex::new("^handle_").unwrap();
+		let constraints = vec![("NAME".to_string(), re)];
+		let out = smart_search(
+			&files,
+			"fn $NAME($$$) { $$$ }",
+			"rust",
+			&constraints,
+			None,
+			None,
+		);
+		assert_eq!(out.matches.len(), 1);
+		assert!(out.matches[0].text.contains("handle_request"));
+	}
+
+	#[test]
+	fn test_smart_search_lexical_fallback() {
+		// Structurally absent (no such call), but the token appears in a
+		// comment — lexical fallback must surface it, labeled, with diagnostic.
+		let files = vec![fd(
+			"a.rs",
+			"// TODO: call frobnicate_widget here\nfn main() {}\n",
+			true,
+		)];
+		let out = smart_search(&files, "frobnicate_widget($$$)", "rust", &[], None, None);
+		assert_eq!(out.matches.len(), 1);
+		let note = out.note.expect("lexical fallback note expected");
+		assert!(note.contains("lexical fallback"), "note: {}", note);
+		assert!(out.diagnostic.is_some());
+	}
+
+	#[test]
+	fn test_smart_search_breadcrumbs_attached() {
+		let files = vec![fd(
+			"a.rs",
+			"impl Store {\n    fn flush(&self) { self.inner.unwrap(); }\n}\n",
+			true,
+		)];
+		let out = smart_search(&files, "$X.unwrap()", "rust", &[], None, None);
+		assert_eq!(out.matches.len(), 1);
+		let bc = out.matches[0].breadcrumb.as_deref().expect("breadcrumb");
+		assert!(bc.contains("impl Store"), "breadcrumb: {}", bc);
+		assert!(bc.contains("fn flush"), "breadcrumb: {}", bc);
+	}
+
+	#[test]
+	fn test_symbol_search_definitions() {
+		let files = vec![
+			fd("a.rs", "pub fn flush_cache() {}\npub fn other() {}\n", true),
+			fd("b.rs", "pub struct FlushConfig { pub a: u8 }\n", true),
+		];
+		let out = symbol_search(&files, "flush_cache", "rust", false);
+		assert_eq!(out.matches.len(), 1);
+		assert_eq!(out.matches[0].file, "a.rs");
+		assert!(out.note.unwrap().contains("definitions"));
+	}
+
+	#[test]
+	fn test_symbol_search_wildcard() {
+		let files = vec![fd(
+			"a.rs",
+			"fn handle_get() {}\nfn handle_post() {}\nfn other() {}\n",
+			true,
+		)];
+		let out = symbol_search(&files, "handle_*", "rust", false);
+		assert_eq!(out.matches.len(), 2);
+	}
+
+	#[test]
+	fn test_symbol_search_references() {
+		let files = vec![fd(
+			"a.rs",
+			"fn flush() {}\nfn main() { flush(); flush(); }\n",
+			true,
+		)];
+		let out = symbol_search(&files, "flush", "rust", true);
+		// 1 definition site + 2 call sites.
+		assert_eq!(out.matches.len(), 3);
+		let defs: Vec<_> = out
+			.matches
+			.iter()
+			.filter(|m| m.text.starts_with("[def]"))
+			.collect();
+		assert_eq!(defs.len(), 1);
+		assert_eq!(defs[0].line, 1);
+	}
+
+	#[test]
+	fn test_symbol_search_no_match_diagnostic() {
+		let files = vec![fd("a.rs", "fn main() {}\n", true)];
+		let out = symbol_search(&files, "zzz_missing", "rust", false);
+		assert!(out.matches.is_empty());
+		assert!(out.diagnostic.unwrap().contains("zzz_missing"));
+	}
+
+	#[test]
+	fn test_fingerprint_request_deterministic() {
+		let a = fingerprint_request(&["$X.unwrap()", "rust", "", ""]);
+		let b = fingerprint_request(&["$X.unwrap()", "rust", "", ""]);
+		let c = fingerprint_request(&["$X.unwrap()", "go", "", ""]);
+		assert_eq!(a, b);
+		assert_ne!(a, c);
+	}
+
+	#[test]
+	fn test_repo_stamp_equality() {
+		let now = SystemTime::now();
+		let s1 = RepoStamp {
+			file_count: 2,
+			total_size: 10,
+			max_mtime: Some(now),
+		};
+		let s2 = RepoStamp {
+			file_count: 2,
+			total_size: 10,
+			max_mtime: Some(now),
+		};
+		let s3 = RepoStamp {
+			file_count: 3,
+			total_size: 10,
+			max_mtime: Some(now),
+		};
+		assert_eq!(s1, s2);
+		assert_ne!(s1, s3);
+	}
+
+	#[test]
+	fn test_filter_by_containment() {
+		let m = |s: usize, e: usize| GrepMatch {
+			file: "a.rs".into(),
+			line: 1,
+			column: 0,
+			text: "x".into(),
+			start_byte: s,
+			end_byte: e,
+			breadcrumb: None,
+		};
+		// inside: match (5,10) is inside (0,20) but (30,40) is not.
+		let kept = filter_by_containment(vec![m(5, 10), m(30, 40)], Some(&[(0, 20)]), None);
+		assert_eq!(kept.len(), 1);
+		assert_eq!(kept[0].start_byte, 5);
+		// has: match (0,20) contains (5,10); match (30,40) contains nothing.
+		let kept = filter_by_containment(vec![m(0, 20), m(30, 40)], None, Some(&[(5, 10)]));
+		assert_eq!(kept.len(), 1);
+		assert_eq!(kept[0].start_byte, 0);
+	}
+}


### PR DESCRIPTION
- Add symbol definition and reference lookup with wildcard support
- Implement structural search with smart and relaxed strategies
- Add breadcrumb tracking for nested containers across languages
- Introduce metavariable constraints using regex and relational filters
- Implement literal token prefiltering and lexical fallback scanning
- Add gitignore-aware parallel file walking and byte range precision
- Support Swift language and language-specific contextual wrappers
- Add request caching and pagination for search queries
- Refactor search orchestration into a dedicated structural module
- Improve response formatting with navigation footers and diagnostics
- Add comprehensive unit tests for search strategies and filtering