### PR TITLE
refactor(mcp): remove hardcoded tool definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -4754,6 +4755,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "time",
  "tokio",
  "toml",
  "tracing",
@@ -6719,11 +6721,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.48"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6733,15 +6736,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.28"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -19,6 +19,11 @@ embeddings_batch_size = 16  # 16 files per batch - table.add() every 16 files fo
 embeddings_max_tokens_per_batch = 100000  # Keep existing token limit
 flush_frequency = 2  # Flush every 2 batches = every 32 files for coordinated persistence
 require_git = true  # Require git repository for indexing
+# When true, the MCP server runs background indexing + a file watcher to keep the index
+# fresh while serving. When false (default), MCP serves search, view_signatures, and
+# structural_search over the EXISTING index read-only and never (re)indexes in-process.
+# The `index` CLI command is unaffected — this gates only the in-process MCP indexer.
+mcp_index = false
 quantization = true  # Enable RaBitQ quantization (32x compression) vs IVF_HNSW_SQ (4x compression)
 # Contextual chunk enrichment: use LLM to generate natural language descriptions
 # of code chunks at indexing time. Descriptions are prepended to chunk content before

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,14 @@ pub struct IndexConfig {
 	/// Number of code chunks per LLM description batch (default: 10)
 	#[serde(default = "default_contextual_batch_size")]
 	pub contextual_batch_size: usize,
+
+	/// When `true`, the MCP server runs background indexing + a file watcher to keep
+	/// the index fresh while serving. When `false` (default), MCP serves search,
+	/// `view_signatures`, and `structural_search` over the EXISTING index in read-only
+	/// mode and never (re)indexes in-process. The `index` CLI command is unaffected —
+	/// this gates only the in-process MCP indexer.
+	#[serde(default)]
+	pub mcp_index: bool,
 }
 
 impl Default for IndexConfig {
@@ -133,6 +141,7 @@ impl Default for IndexConfig {
 			contextual_descriptions: false,
 			contextual_model: "openrouter:openai/gpt-4o-mini".to_string(),
 			contextual_batch_size: 10,
+			mcp_index: false,
 		}
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,6 @@ pub struct IndexConfig {
 	/// `view_signatures`, and `structural_search` over the EXISTING index in read-only
 	/// mode and never (re)indexes in-process. The `index` CLI command is unaffected —
 	/// this gates only the in-process MCP indexer.
-	#[serde(default)]
 	pub mcp_index: bool,
 }
 

--- a/src/mcp/graphrag.rs
+++ b/src/mcp/graphrag.rs
@@ -20,7 +20,7 @@ use crate::config::Config;
 use crate::indexer::branch::BranchManifest;
 use crate::indexer::graphrag::find_node_id;
 use crate::indexer::{self, graphrag::GraphRAG};
-use crate::mcp::types::{McpError, McpTool};
+use crate::mcp::types::McpError;
 
 #[derive(Debug, Clone)]
 pub enum GraphRAGOperation {
@@ -93,57 +93,6 @@ impl GraphRagProvider {
 			})
 		} else {
 			None
-		}
-	}
-
-	/// Get the tool definition for graphrag
-	pub fn get_tool_definition() -> McpTool {
-		McpTool {
-			name: "graphrag".to_string(),
-			description: "Knowledge graph operations over the indexed codebase. Use for architectural queries: component relationships, dependency chains, data flows. For simple code lookup use semantic_search instead.".to_string(),
-			input_schema: json!({
-				"type": "object",
-				"properties": {
-					"operation": {
-						"type": "string",
-						"enum": ["search", "get-node", "get-relationships", "find-path", "overview"],
-						"description": "'search' (semantic node search), 'get-node' (node details), 'get-relationships' (node connections), 'find-path' (path between two nodes), 'overview' (graph stats)"
-					},
-					"query": {
-						"type": "string",
-						"description": "Search query for 'search' operation",
-						"minLength": 10,
-						"maxLength": 1000
-					},
-					"node_id": {
-						"type": "string",
-						"description": "Node ID for 'get-node'/'get-relationships' (format: 'path/to/file', e.g. 'src/main.rs')"
-					},
-					"source_id": {
-						"type": "string",
-						"description": "Source node ID for 'find-path'"
-					},
-					"target_id": {
-						"type": "string",
-						"description": "Target node ID for 'find-path'"
-					},
-					"max_depth": {
-						"type": "integer",
-						"description": "Max path depth for 'find-path' (default: 3)",
-						"minimum": 1,
-						"maximum": 10,
-						"default": 3
-					},
-					"format": {
-						"type": "string",
-						"enum": ["text", "json", "markdown"],
-						"description": "Output format (default: 'text')",
-						"default": "text"
-					},
-				},
-				"required": ["operation"],
-				"additionalProperties": false
-			}),
 		}
 	}
 

--- a/src/mcp/lsp/provider.rs
+++ b/src/mcp/lsp/provider.rs
@@ -17,7 +17,6 @@
 use crate::mcp::types::McpError;
 use anyhow::Result;
 use lsp_types::*;
-use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -26,7 +25,6 @@ use tracing::{debug, error, info, warn};
 
 use super::client::LspClient;
 use super::protocol::{file_path_to_uri, LspNotification, LspRequest};
-use crate::mcp::types::McpTool;
 
 /// LSP provider that manages external LSP server and exposes capabilities via MCP tools
 pub struct LspProvider {
@@ -359,100 +357,6 @@ impl LspProvider {
 
 		debug!("Closed file in LSP: {}", relative_path);
 		Ok(())
-	}
-	pub fn get_tool_definitions() -> Vec<McpTool> {
-		vec![
-			McpTool {
-				name: "lsp_goto_definition".to_string(),
-				description: "Jump to the definition of a symbol via LSP.".to_string(),
-				input_schema: json!({
-					"type": "object",
-					"properties": {
-						"file_path": { "type": "string", "description": "Relative file path" },
-						"line": { "type": "integer", "minimum": 1, "description": "1-indexed line number" },
-						"symbol": { "type": "string", "description": "Symbol name on that line" }
-					},
-					"required": ["file_path", "line", "symbol"],
-					"additionalProperties": false
-				}),
-			},
-			McpTool {
-				name: "lsp_hover".to_string(),
-				description: "Get type info and documentation for a symbol via LSP.".to_string(),
-				input_schema: json!({
-					"type": "object",
-					"properties": {
-						"file_path": { "type": "string", "description": "Relative file path" },
-						"line": { "type": "integer", "minimum": 1, "description": "1-indexed line number" },
-						"symbol": { "type": "string", "description": "Symbol name on that line" }
-					},
-					"required": ["file_path", "line", "symbol"],
-					"additionalProperties": false
-				}),
-			},
-			McpTool {
-				name: "lsp_find_references".to_string(),
-				description: "Find all usages of a symbol across the workspace via LSP."
-					.to_string(),
-				input_schema: json!({
-					"type": "object",
-					"properties": {
-						"file_path": { "type": "string", "description": "Relative file path" },
-						"line": { "type": "integer", "minimum": 1, "description": "1-indexed line number" },
-						"symbol": { "type": "string", "description": "Symbol name on that line" },
-						"include_declaration": { "type": "boolean", "default": true, "description": "Include the declaration site in results" },
-						"include_declaration": { "type": "boolean", "default": true, "description": "Include the declaration site in results" }
-					},
-					"required": ["file_path", "line", "symbol"],
-					"additionalProperties": false
-				}),
-			},
-			McpTool {
-				name: "lsp_document_symbols".to_string(),
-				description:
-					"List all symbols (functions, types, variables) defined in a file via LSP."
-						.to_string(),
-				input_schema: json!({
-					"type": "object",
-					"properties": {
-						"file_path": { "type": "string", "description": "Relative file path" },
-						"file_path": { "type": "string", "description": "Relative file path" }
-					},
-					"required": ["file_path"],
-					"additionalProperties": false
-				}),
-			},
-			McpTool {
-				name: "lsp_workspace_symbols".to_string(),
-				description: "Search for symbols by name across the entire workspace via LSP."
-					.to_string(),
-				input_schema: json!({
-					"type": "object",
-					"properties": {
-						"query": { "type": "string", "minLength": 1, "description": "Symbol name or prefix to search" },
-						"query": { "type": "string", "minLength": 1, "description": "Symbol name or prefix to search" }
-					},
-					"required": ["query"],
-					"additionalProperties": false
-				}),
-			},
-			McpTool {
-				name: "lsp_completion".to_string(),
-				description: "Get code completion suggestions at a symbol position via LSP."
-					.to_string(),
-				input_schema: json!({
-					"type": "object",
-					"properties": {
-						"file_path": { "type": "string", "description": "Relative file path" },
-						"line": { "type": "integer", "minimum": 1, "description": "1-indexed line number" },
-						"symbol": { "type": "string", "description": "Partial symbol or prefix to complete" },
-						"symbol": { "type": "string", "description": "Partial symbol or prefix to complete" }
-					},
-					"required": ["file_path", "line", "symbol"],
-					"additionalProperties": false
-				}),
-			},
-		]
 	}
 
 	/// Find symbol position on a specific line

--- a/src/mcp/multi.rs
+++ b/src/mcp/multi.rs
@@ -151,7 +151,9 @@ impl MultiServer {
 		// keeps the first and drops the loser's background services. The initial
 		// index is lock-guarded, so the rare double-build is harmless.
 		let server = McpServer::new_repo_core(self.config.clone(), repo_path.clone());
-		let bg =
+		// Read-only unless the in-process indexer is enabled; otherwise serve the
+		// existing per-repo index without spawning a watcher/indexer.
+		let bg = if self.config.index.mcp_index {
 			McpServer::start_repo_services(self.config.clone(), repo_path, self.no_git, self.debug)
 				.await
 				.map_err(|e| {
@@ -159,7 +161,10 @@ impl MultiServer {
 						format!("Failed to start services for '{}': {}", project, e),
 						None,
 					)
-				})?;
+				})?
+		} else {
+			BackgroundServices::none()
+		};
 
 		let mut guard = self.instances.lock().await;
 		let inst = guard.entry(project.to_string()).or_insert(RepoInstance {

--- a/src/mcp/semantic_code.rs
+++ b/src/mcp/semantic_code.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::Value;
 use tracing::debug;
 
 use crate::config::Config;
@@ -22,7 +22,7 @@ use crate::indexer::search::{
 	DetailSearchOptions,
 };
 use crate::indexer::{extract_file_signatures, render_signatures_text, NoindexWalker, PathUtils};
-use crate::mcp::types::{McpError, McpTool};
+use crate::mcp::types::McpError;
 use octolib::embedding::constants::MAX_QUERIES;
 
 /// Semantic code search tool provider
@@ -37,94 +37,6 @@ impl SemanticCodeProvider {
 		Self {
 			config,
 			working_directory,
-		}
-	}
-
-	/// Get the tool definition for semantic_search
-	pub fn get_tool_definition() -> McpTool {
-		McpTool {
-			name: "semantic_search".to_string(),
-			description: "Search codebase by meaning — finds code by what it does, not exact symbol names. Prefer an array of related terms over a single query for broader coverage.".to_string(),
-			input_schema: json!({
-				"type": "object",
-				"properties": {
-					"query": {
-						"oneOf": [
-							{
-								"type": "string",
-								"description": "Descriptive phrase about what the code does (not a symbol name)",
-								"minLength": 10,
-								"maxLength": 500
-							},
-							{
-								"type": "array",
-								"items": {
-									"type": "string",
-									"minLength": 10,
-									"maxLength": 500
-								},
-								"minItems": 1,
-								"maxItems": 5,
-								"description": "Array of related search terms — finds all related code in one call"
-							}
-						],
-						"description": "String or array of strings describing functionality to find. Array preferred for comprehensive results."
-					},
-					"mode": {
-						"type": "string",
-						"description": "Content type filter: 'code' (functions/classes), 'text' (plain text), 'docs' (markdown/README), 'commits' (git commit history), 'all' (default, excludes commits)",
-						"enum": ["code", "text", "docs", "commits", "all"],
-						"default": "all"
-					},
-					"detail_level": {
-						"type": "string",
-						"description": "Result verbosity: 'signatures' (declarations only), 'partial' (truncated, default), 'full' (complete bodies)",
-						"enum": ["signatures", "partial", "full"],
-						"default": "partial"
-					},
-					"max_results": {
-						"type": "integer",
-						"description": "Max results to return (default: 3)",
-						"minimum": 1,
-						"maximum": 20,
-						"default": 3
-					},
-					"threshold": {
-						"type": "number",
-						"description": "Similarity cutoff 0.0–1.0 (higher = stricter match)",
-						"minimum": 0.0,
-						"maximum": 1.0
-					},
-					"language": {
-						"type": "string",
-						"description": "Filter code results by language (rust, python, typescript, go, etc.)"
-					},
-				},
-				"required": ["query"],
-				"additionalProperties": false
-			}),
-		}
-	}
-
-	/// Get the tool definition for view_signatures
-	pub fn get_view_signatures_tool_definition() -> McpTool {
-		McpTool {
-			name: "view_signatures".to_string(),
-			description: "Extract function signatures, class definitions, and declarations from files without implementation bodies. Supports Rust, JS/TS, Python, Go, C++, PHP, Ruby, Bash, JSON, CSS, Svelte, Swift, Markdown.".to_string(),
-			input_schema: json!({
-				"type": "object",
-				"properties": {
-					"files": {
-						"type": "array",
-						"description": "File paths or glob patterns (e.g. 'src/main.rs', '**/*.py', 'src/**/*.ts')",
-						"items": { "type": "string" },
-						"minItems": 1,
-						"maxItems": 100
-					},
-				},
-				"required": ["files"],
-				"additionalProperties": false
-			}),
 		}
 	}
 

--- a/src/mcp/semantic_code.rs
+++ b/src/mcp/semantic_code.rs
@@ -234,11 +234,37 @@ impl SemanticCodeProvider {
 		};
 
 		match results {
-			Ok(output) => Ok(output),
+			Ok(output) => Ok(self.steer_if_empty(output)),
 			Err(e) => Err(McpError::internal_error(
 				format!("Search operation failed: {}", e),
 				"semantic_search",
 			)),
+		}
+	}
+
+	/// In read-only mode (`index.mcp_index = false`) the index may be empty or stale,
+	/// so a no-match result is appended with a one-line nudge toward the structural
+	/// tools rather than leaving the model to retry semantic search fruitlessly.
+	fn steer_if_empty(&self, output: String) -> String {
+		if self.config.index.mcp_index {
+			return output;
+		}
+		let empty = matches!(
+			output.trim(),
+			"No results found."
+				| "No code results found."
+				| "No text results found."
+				| "No documentation results found."
+				| "No commit results found."
+		);
+		if empty {
+			format!(
+				"{output}\n\nThe semantic index is read-only here (index.mcp_index = false) and \
+				 may be empty or stale. Use `structural_search` for known symbols/patterns/usages \
+				 and `view_signatures` to map files, or fall back to grep."
+			)
+		} else {
+			output
 		}
 	}
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -258,6 +258,19 @@ pub struct BackgroundServices {
 	indexing_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
+impl BackgroundServices {
+	/// An inert handle bundle — no watcher, no indexing. Used when the in-process
+	/// MCP indexer is disabled (`index.mcp_index = false`) and the server serves
+	/// the existing index read-only.
+	pub(crate) fn none() -> Self {
+		Self {
+			watcher_handle: None,
+			index_handle: None,
+			indexing_handle: None,
+		}
+	}
+}
+
 impl Drop for BackgroundServices {
 	fn drop(&mut self) {
 		if let Some(h) = self.watcher_handle.take() {
@@ -730,7 +743,7 @@ impl ServerHandler for McpServer {
 		let instructions = if self.indexer_enabled {
 			"This server provides modular AI tools: semantic code search, view signatures, and GraphRAG (if available). Use 'semantic_search' for code/documentation searches and 'graphrag' (if enabled) for relationship queries."
 		} else {
-			"WARNING: Octocode indexer is disabled: not in a git repository root. Run with --no-git to enable indexing outside git repos. Tools available: semantic_search, view_signatures, graphrag (if enabled)."
+			"NOTE: in-process indexing is disabled — Octocode is serving an EXISTING index read-only, so the semantic index may be empty or stale. Prefer 'structural_search' (find known symbols, patterns, and usages) and 'view_signatures' (map a file's declarations before reading it), plus your own grep, to navigate the code. Use 'semantic_search' only for concept/behavior lookups where you don't know the symbol name — it may return nothing if the index is empty."
 		};
 
 		ServerInfo::new(capabilities)
@@ -812,6 +825,7 @@ impl McpServer {
 	/// repo lifecycle (indexing, watcher, cleanup, logging) and routes calls
 	/// here by the injected `project` argument.
 	pub(crate) fn new_repo_core(config: Config, working_directory: std::path::PathBuf) -> Self {
+		let mcp_index = config.index.mcp_index;
 		let semantic_code = SemanticCodeProvider::new(config.clone(), working_directory.clone());
 		let graphrag = GraphRagProvider::new(config, working_directory.clone());
 
@@ -838,7 +852,7 @@ impl McpServer {
 			semantic_code,
 			graphrag,
 			lsp: None,
-			indexer_enabled: true,
+			indexer_enabled: mcp_index,
 			tool_router,
 			structural_cache: Arc::new(parking_lot::RwLock::new(None)),
 		}
@@ -952,17 +966,23 @@ impl McpServer {
 			None
 		};
 
-		// Determine if indexer should start
-		let should_start_indexer = if !no_git && config.index.require_git {
-			indexer::git::is_git_repo_root(&working_directory)
-		} else {
-			true
-		};
+		// The in-process MCP indexer is opt-in via `index.mcp_index`. When disabled,
+		// MCP serves the existing index read-only; when enabled, the usual git gate
+		// still applies.
+		let should_start_indexer = config.index.mcp_index
+			&& (no_git
+				|| !config.index.require_git
+				|| indexer::git::is_git_repo_root(&working_directory));
 
-		if !should_start_indexer {
+		if !config.index.mcp_index {
 			warn!(
-				"Indexer not started: Not in a git repository and --no-git flag not set. \
-				 Use --no-git to enable indexing outside git repos."
+				"MCP indexer disabled (index.mcp_index = false): serving the existing index \
+				 read-only. Set index.mcp_index = true to index and watch in-process."
+			);
+		} else if !should_start_indexer {
+			warn!(
+				"MCP indexer enabled but not started: not in a git repository root and --no-git \
+				 not set. Use --no-git to index outside git repos."
 			);
 		}
 
@@ -1010,11 +1030,7 @@ impl McpServer {
 			)
 			.await?
 		} else {
-			BackgroundServices {
-				watcher_handle: None,
-				index_handle: None,
-				indexing_handle: None,
-			}
+			BackgroundServices::none()
 		};
 
 		info!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -61,7 +61,7 @@ const MCP_INDEX_TIMEOUT_MS: u64 = 300_000; // 5 minutes
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SemanticSearchParams {
-	/// String or array of strings describing functionality to find. Array preferred for comprehensive results.
+	/// Describe the code by what it does or the concept behind it, not its symbol name (e.g. 'retry failed network requests', not 'fn retry'). String or array of strings; an array of related phrasings widens recall.
 	pub query: serde_json::Value,
 	/// Max results to return (default: 3)
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -298,7 +298,7 @@ pub struct McpServer {
 #[tool_router]
 impl McpServer {
 	#[tool(
-		description = "Search codebase by meaning. Finds code by what it does, not exact symbol names. Prefer an array of related terms over a single query for broader coverage."
+		description = "Recall-oriented search by concept or behavior — finds relevant code even when its names don't match your words. Use this when you DON'T know the symbol name and are searching by intent: e.g. \"where is authentication handled\", \"code that retries failed requests\", \"rate-limiting logic\". It favors recall over precision, so expect some loosely related hits. For a KNOWN symbol, exact string, or call sites, use structural_search instead — it is precise and cheaper. Prefer an array of related terms over a single query for broader coverage."
 	)]
 	async fn semantic_search(
 		&self,
@@ -323,7 +323,7 @@ impl McpServer {
 	}
 
 	#[tool(
-		description = "Extract function signatures, class definitions, and declarations from files without implementation bodies. Supports Rust, JS/TS, Python, Go, C++, PHP, Ruby, Bash, JSON, CSS, Svelte, Swift, Markdown."
+		description = "Map a file or area structurally: extract function signatures, class/type definitions, and declarations without implementation bodies — the cheapest way to see what code exposes. Reach for this FIRST to orient in unfamiliar code before reading full bodies. Accepts file paths or glob patterns. Supports Rust, JS/TS, Python, Go, C++, PHP, Ruby, Bash, JSON, CSS, Svelte, Swift, Markdown."
 	)]
 	async fn view_signatures(
 		&self,
@@ -495,7 +495,8 @@ impl McpServer {
 		JS/TS kinds: function_declaration, class_declaration, method_definition, import_statement, call_expression. \
 		Python kinds: function_definition, class_definition, import_statement, import_from_statement, decorated_definition. \
 		Go kinds: function_declaration, method_declaration, type_declaration, call_expression, if_statement. \
-		\n\nWhen a pattern returns zero matches the tool auto-retries with relaxed strictness, kind broadening, and language-aware context wrapping, then falls back to labeled plain-text hits plus a diagnostic — it never silently returns nothing relevant. Use `rewrite` to apply a template with metavariable substitution. Use `semantic_search` for meaning-based lookups instead of this tool."
+		\n\nWhen a pattern returns zero matches the tool auto-retries with relaxed strictness, kind broadening, and language-aware context wrapping, then falls back to labeled plain-text hits plus a diagnostic — it never silently returns nothing relevant. Use `rewrite` to apply a template with metavariable substitution. \
+		\n\nThis is the PRECISE, low-noise way to find code you can name or describe by shape — prefer it whenever you know the symbol, pattern, or usage you're after. Only when you DON'T know the name and must search by concept or behavior, reach for `semantic_search` instead."
 	)]
 	async fn structural_search(
 		&self,

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
 /// MCP-compliant error builder for consistent error handling
 #[derive(Debug, Clone)]
 pub struct McpError {
@@ -68,12 +65,3 @@ impl std::fmt::Display for McpError {
 }
 
 impl std::error::Error for McpError {}
-
-/// MCP Tool definitions
-#[derive(Debug, Serialize, Deserialize)]
-pub struct McpTool {
-	pub name: String,
-	pub description: String,
-	#[serde(rename = "inputSchema")]
-	pub input_schema: Value,
-}


### PR DESCRIPTION
- Remove get_tool_definition methods from MCP providers
- Refine tool descriptions to improve LLM search intent guidance
- Clarify distinctions between semantic and structural search tools
- Clean up unused imports across provider modules