### PR TITLE
feat(config): implement atomic updates and v2 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4906,6 +4906,7 @@ dependencies = [
  "dirs",
  "dotenvy",
  "ec4rs",
+ "fs4",
  "futures",
  "globset",
  "http-body-util",
@@ -4932,6 +4933,7 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -7146,6 +7148,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ clap_complete = "4.5.66"
 notify = { version = "8.2.0", default-features = false, features = ["crossbeam-channel", "macos_fsevent"] }
 notify-debouncer-mini = "0.7.0"
 toml = "1.0.6"
+toml_edit = "0.25.13"
+fs4 = "0.8.4"
 lazy_static = "1.5.0"
 futures = { version = "0.3.32", default-features = false, features = ["std"] }
 globset = { version = "0.4.18", default-features = false }

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -1,7 +1,7 @@
 # Default configuration for Octocode
 # This file contains all default values and serves as the template for new installations
-# Version: 1 (for future migration support)
-version = 1
+# Version: 2
+version = 2
 
 [llm]
 # Model in provider:model format (e.g., "openai:gpt-4o-mini", "anthropic:claude-3-5-haiku-20241022")

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::path::PathBuf;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use crate::embedding::types::EmbeddingConfig;
 use crate::storage;
+
+mod migrations;
+
+const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../config-templates/default.toml");
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LLMConfig {
@@ -326,8 +332,7 @@ pub struct CommitsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-	/// Configuration version for future migrations
-	#[serde(default = "default_version")]
+	/// Configuration schema version
 	pub version: u32,
 
 	#[serde(default)]
@@ -349,91 +354,79 @@ pub struct Config {
 	pub commits: CommitsConfig,
 }
 
-fn default_version() -> u32 {
-	1
-}
-
 fn default_contextual_batch_size() -> usize {
 	10
 }
 
 impl Default for Config {
 	fn default() -> Self {
-		Self {
-			version: default_version(),
-			llm: LlmConfig::default(),
-			index: IndexConfig::default(),
-			search: SearchConfig::default(),
-			embedding: EmbeddingConfig::default(),
-			graphrag: GraphRAGConfig::default(),
-			commits: CommitsConfig::default(),
-		}
+		Self::load_from_template().expect("embedded default configuration must be valid")
 	}
 }
 
 impl Config {
 	pub fn load() -> Result<Self> {
 		let config_path = Self::get_config_path()?;
+		Self::load_from_path(&config_path)
+	}
 
-		let config = if config_path.exists() {
-			let content = fs::read_to_string(&config_path)?;
-			toml::from_str(&content)?
-		} else {
-			// Load from template first, then save to config path
-			let template_config = Self::load_from_template()?;
+	fn load_from_path(config_path: &Path) -> Result<Self> {
+		with_config_lock(config_path, || Self::load_from_path_locked(config_path))
+	}
 
-			// Ensure the parent directory exists
-			if let Some(parent) = config_path.parent() {
-				if !parent.exists() {
-					fs::create_dir_all(parent)?;
-				}
-			}
+	fn load_from_path_locked(config_path: &Path) -> Result<Self> {
+		if !config_path.exists() {
+			atomic_write(config_path, DEFAULT_CONFIG_TEMPLATE.as_bytes(), None)?;
+			return toml::from_str(DEFAULT_CONFIG_TEMPLATE)
+				.context("failed to parse embedded default configuration");
+		}
 
-			// Save template as the new config
-			let toml_content = toml::to_string_pretty(&template_config)?;
-			fs::write(&config_path, toml_content)?;
-			template_config
-		};
+		let original = fs::read_to_string(config_path).with_context(|| {
+			format!("failed to read configuration at {}", config_path.display())
+		})?;
+		let migration = migrations::migrate(&original, DEFAULT_CONFIG_TEMPLATE)?;
+		let content = migration
+			.as_ref()
+			.map_or(original.as_str(), |migration| migration.content.as_str());
 
-		// Environment variables are handled by octolib providers automatically
-		// No need to set API keys in config
+		// Validate the fully migrated document before changing the user's file.
+		let config: Config = toml::from_str(content).with_context(|| {
+			format!(
+				"failed to load configuration at {} after migration",
+				config_path.display()
+			)
+		})?;
+
+		if let Some(migration) = migration {
+			let permissions = fs::metadata(config_path)?.permissions();
+			write_backup_if_missing(
+				config_path,
+				migration.from_version,
+				original.as_bytes(),
+				permissions.clone(),
+			)?;
+			atomic_write(config_path, migration.content.as_bytes(), Some(permissions))?;
+			debug_assert_eq!(config.version, migration.to_version);
+		}
 
 		Ok(config)
 	}
 
 	/// Load configuration from the default template
 	pub fn load_from_template() -> Result<Self> {
-		// Try to load from embedded template first
-		let template_content = Self::get_default_template_content()?;
-		let config: Config = toml::from_str(&template_content)?;
+		let config: Config = toml::from_str(DEFAULT_CONFIG_TEMPLATE)?;
 		Ok(config)
-	}
-
-	/// Get the default template content
-	fn get_default_template_content() -> Result<String> {
-		// First try to read from config-templates/default.toml in the current directory
-		let template_path = std::path::Path::new("config-templates/default.toml");
-		if template_path.exists() {
-			return Ok(fs::read_to_string(template_path)?);
-		}
-
-		// If not found, use embedded template
-		Ok(include_str!("../config-templates/default.toml").to_string())
 	}
 
 	pub fn save(&self) -> Result<()> {
 		let config_path = Self::get_config_path()?;
-
-		// Ensure the parent directory exists
-		if let Some(parent) = config_path.parent() {
-			if !parent.exists() {
-				fs::create_dir_all(parent)?;
-			}
-		}
-
 		let toml_content = toml::to_string_pretty(self)?;
-		fs::write(config_path, toml_content)?;
-		Ok(())
+		with_config_lock(&config_path, || {
+			let permissions = fs::metadata(&config_path)
+				.ok()
+				.map(|metadata| metadata.permissions());
+			atomic_write(&config_path, toml_content.as_bytes(), permissions)
+		})
 	}
 
 	/// Get the active config file path.
@@ -470,14 +463,180 @@ impl Config {
 	}
 }
 
+fn with_config_lock<T>(config_path: &Path, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+	let parent = parent_directory(config_path)?;
+	fs::create_dir_all(parent)?;
+
+	let file_name = config_path.file_name().with_context(|| {
+		format!(
+			"configuration path has no file name: {}",
+			config_path.display()
+		)
+	})?;
+	let lock_path = config_path.with_file_name(format!("{}.lock", file_name.to_string_lossy()));
+	let lock_file = OpenOptions::new()
+		.read(true)
+		.write(true)
+		.create(true)
+		.truncate(false)
+		.open(&lock_path)
+		.with_context(|| format!("failed to open configuration lock {}", lock_path.display()))?;
+	FileExt::lock_exclusive(&lock_file)
+		.with_context(|| format!("failed to lock configuration at {}", config_path.display()))?;
+
+	operation()
+}
+
+fn write_backup_if_missing(
+	config_path: &Path,
+	version: u32,
+	content: &[u8],
+	permissions: fs::Permissions,
+) -> Result<()> {
+	let file_name = config_path.file_name().with_context(|| {
+		format!(
+			"configuration path has no file name: {}",
+			config_path.display()
+		)
+	})?;
+	let backup_path =
+		config_path.with_file_name(format!("{}.v{version}.bak", file_name.to_string_lossy()));
+
+	let mut backup = match OpenOptions::new()
+		.write(true)
+		.create_new(true)
+		.open(&backup_path)
+	{
+		Ok(file) => file,
+		Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
+		Err(error) => {
+			return Err(error).with_context(|| {
+				format!(
+					"failed to create configuration backup {}",
+					backup_path.display()
+				)
+			})
+		}
+	};
+
+	let result = (|| -> Result<()> {
+		backup.set_permissions(permissions)?;
+		backup.write_all(content)?;
+		backup.sync_all()?;
+		Ok(())
+	})();
+
+	if result.is_err() {
+		drop(backup);
+		let _ = fs::remove_file(&backup_path);
+	}
+
+	result
+}
+
+fn atomic_write(path: &Path, content: &[u8], permissions: Option<fs::Permissions>) -> Result<()> {
+	let parent = parent_directory(path)?;
+	fs::create_dir_all(parent)?;
+
+	let file_name = path
+		.file_name()
+		.with_context(|| format!("configuration path has no file name: {}", path.display()))?;
+	let temporary_path = parent.join(format!(
+		".{}.{}.tmp",
+		file_name.to_string_lossy(),
+		uuid::Uuid::new_v4()
+	));
+
+	let result = (|| -> Result<()> {
+		let mut temporary = OpenOptions::new()
+			.write(true)
+			.create_new(true)
+			.open(&temporary_path)?;
+		if let Some(permissions) = permissions {
+			temporary.set_permissions(permissions)?;
+		}
+		temporary.write_all(content)?;
+		temporary.sync_all()?;
+		drop(temporary);
+
+		fs::rename(&temporary_path, path).with_context(|| {
+			format!(
+				"failed to replace configuration at {} with migrated version",
+				path.display()
+			)
+		})?;
+
+		#[cfg(unix)]
+		OpenOptions::new().read(true).open(parent)?.sync_all()?;
+
+		Ok(())
+	})();
+
+	if result.is_err() {
+		let _ = fs::remove_file(&temporary_path);
+	}
+
+	result
+}
+
+fn parent_directory(path: &Path) -> Result<&Path> {
+	match path.parent() {
+		Some(parent) if parent.as_os_str().is_empty() => Ok(Path::new(".")),
+		Some(parent) => Ok(parent),
+		None => anyhow::bail!("configuration path has no parent: {}", path.display()),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::sync::Arc;
+
+	struct TempConfigDir {
+		path: PathBuf,
+	}
+
+	impl TempConfigDir {
+		fn new() -> Self {
+			let path =
+				std::env::temp_dir().join(format!("octocode-config-test-{}", uuid::Uuid::new_v4()));
+			fs::create_dir_all(&path).expect("temporary config directory should be created");
+			Self { path }
+		}
+
+		fn config_path(&self) -> PathBuf {
+			self.path.join("config.toml")
+		}
+	}
+
+	impl Drop for TempConfigDir {
+		fn drop(&mut self) {
+			let _ = fs::remove_dir_all(&self.path);
+		}
+	}
+
+	fn released_v1_config() -> String {
+		let mut document = DEFAULT_CONFIG_TEMPLATE
+			.parse::<toml_edit::DocumentMut>()
+			.expect("default template should be editable");
+		document["version"] = toml_edit::value(1);
+		let search = document["search"]
+			.as_table_mut()
+			.expect("template search config should be a table");
+		search.remove("reasoning");
+		let hybrid = search["hybrid"]
+			.as_table_mut()
+			.expect("template hybrid config should be a table");
+		hybrid.remove("rrf_k");
+		hybrid.remove("auto_weight");
+		hybrid["default_vector_weight"] = toml_edit::value(0.73);
+		document.to_string()
+	}
 
 	#[test]
 	fn test_default_config() {
 		let config = Config::load_from_template().expect("Failed to load template config");
-		assert_eq!(config.version, 1);
+		assert_eq!(config.version, 2);
 		assert_eq!(config.llm.model, "openrouter:openai/gpt-4o-mini");
 		assert_eq!(config.index.chunk_size, 2000);
 		assert_eq!(config.search.max_results, 20);
@@ -525,7 +684,7 @@ mod tests {
 		assert!(result.is_ok(), "Should be able to load from template");
 
 		let config = result.expect("Template config should load successfully");
-		assert_eq!(config.version, 1);
+		assert_eq!(config.version, 2);
 		assert_eq!(config.llm.model, "openrouter:openai/gpt-4o-mini");
 		assert_eq!(config.index.chunk_size, 2000);
 		assert_eq!(config.search.max_results, 20);
@@ -586,9 +745,104 @@ mod tests {
 	fn test_toml_missing_optional_sections_uses_defaults() {
 		// A config.toml that omits whole tables (legal TOML) must fall back to
 		// sane defaults instead of panicking via serde's #[serde(default)].
-		let minimal = "version = 1\n";
+		let minimal = "version = 2\n";
 		let config: Config = toml::from_str(minimal).expect("should deserialize with defaults");
 		assert_eq!(config.search.max_results, 20);
 		assert!(!config.graphrag.enabled);
+	}
+
+	#[test]
+	fn missing_config_is_exact_copy_of_current_template() {
+		let temp = TempConfigDir::new();
+		let config_path = temp.config_path();
+
+		let config = Config::load_from_path(&config_path).expect("config should be created");
+
+		assert_eq!(config.version, 2);
+		assert_eq!(
+			fs::read_to_string(&config_path).unwrap(),
+			DEFAULT_CONFIG_TEMPLATE
+		);
+		assert!(!config_path.with_file_name("config.toml.v1.bak").exists());
+	}
+
+	#[test]
+	fn load_migrates_v1_once_and_keeps_backup() {
+		let temp = TempConfigDir::new();
+		let config_path = temp.config_path();
+		let original = released_v1_config();
+		fs::write(&config_path, &original).unwrap();
+
+		let config = Config::load_from_path(&config_path).expect("v1 config should migrate");
+		let migrated = fs::read_to_string(&config_path).unwrap();
+
+		assert_eq!(config.version, 2);
+		assert_eq!(config.search.hybrid.default_vector_weight, 0.73);
+		assert_eq!(config.search.hybrid.rrf_k, 60.0);
+		assert!(!config.search.reasoning.enabled);
+		assert_eq!(
+			fs::read_to_string(config_path.with_file_name("config.toml.v1.bak")).unwrap(),
+			original
+		);
+
+		Config::load_from_path(&config_path).expect("v2 config should load unchanged");
+		assert_eq!(fs::read_to_string(&config_path).unwrap(), migrated);
+	}
+
+	#[test]
+	fn future_version_is_rejected_without_modifying_file() {
+		let temp = TempConfigDir::new();
+		let config_path = temp.config_path();
+		let future = DEFAULT_CONFIG_TEMPLATE.replacen("version = 2", "version = 3", 1);
+		fs::write(&config_path, &future).unwrap();
+
+		let error = Config::load_from_path(&config_path).expect_err("future config should fail");
+
+		assert!(error
+			.to_string()
+			.contains("newer than this octocode binary"));
+		assert_eq!(fs::read_to_string(&config_path).unwrap(), future);
+		assert!(!config_path.with_file_name("config.toml.v2.bak").exists());
+	}
+
+	#[test]
+	fn invalid_config_is_not_modified() {
+		let temp = TempConfigDir::new();
+		let config_path = temp.config_path();
+		let invalid = "version = 1\n[search\n";
+		fs::write(&config_path, invalid).unwrap();
+
+		assert!(Config::load_from_path(&config_path).is_err());
+		assert_eq!(fs::read_to_string(&config_path).unwrap(), invalid);
+		assert!(!config_path.with_file_name("config.toml.v1.bak").exists());
+	}
+
+	#[test]
+	fn concurrent_loaders_produce_one_valid_migration() {
+		let temp = TempConfigDir::new();
+		let config_path = Arc::new(temp.config_path());
+		fs::write(config_path.as_ref(), released_v1_config()).unwrap();
+
+		let threads: Vec<_> = (0..4)
+			.map(|_| {
+				let config_path = Arc::clone(&config_path);
+				std::thread::spawn(move || Config::load_from_path(&config_path))
+			})
+			.collect();
+
+		for thread in threads {
+			assert_eq!(
+				thread
+					.join()
+					.expect("loader should not panic")
+					.unwrap()
+					.version,
+				2
+			);
+		}
+
+		let migrated = fs::read_to_string(config_path.as_ref()).unwrap();
+		let config: Config = toml::from_str(&migrated).expect("final config should be valid");
+		assert_eq!(config.version, 2);
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,6 +371,19 @@ impl Config {
 	}
 
 	fn load_from_path(config_path: &Path) -> Result<Self> {
+		// Current configs are read-only. Acquire the write lock only when the file
+		// is missing or an actual migration is required.
+		if config_path.exists() {
+			let content = fs::read_to_string(config_path).with_context(|| {
+				format!("failed to read configuration at {}", config_path.display())
+			})?;
+			if migrations::migrate(&content, DEFAULT_CONFIG_TEMPLATE)?.is_none() {
+				return toml::from_str(&content).with_context(|| {
+					format!("failed to load configuration at {}", config_path.display())
+				});
+			}
+		}
+
 		with_config_lock(config_path, || Self::load_from_path_locked(config_path))
 	}
 
@@ -473,7 +486,7 @@ fn with_config_lock<T>(config_path: &Path, operation: impl FnOnce() -> Result<T>
 			config_path.display()
 		)
 	})?;
-	let lock_path = config_path.with_file_name(format!("{}.lock", file_name.to_string_lossy()));
+	let lock_path = config_path.with_file_name(format!(".{}.lock", file_name.to_string_lossy()));
 	let lock_file = OpenOptions::new()
 		.read(true)
 		.write(true)
@@ -508,7 +521,21 @@ fn write_backup_if_missing(
 		.open(&backup_path)
 	{
 		Ok(file) => file,
-		Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
+		Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+			let existing = fs::read(&backup_path).with_context(|| {
+				format!(
+					"failed to verify existing configuration backup {}",
+					backup_path.display()
+				)
+			})?;
+			if existing == content {
+				return Ok(());
+			}
+			anyhow::bail!(
+				"configuration backup {} already exists with different contents",
+				backup_path.display()
+			);
+		}
 		Err(error) => {
 			return Err(error).with_context(|| {
 				format!(
@@ -520,8 +547,9 @@ fn write_backup_if_missing(
 	};
 
 	let result = (|| -> Result<()> {
-		backup.set_permissions(permissions)?;
 		backup.write_all(content)?;
+		backup.sync_all()?;
+		backup.set_permissions(permissions)?;
 		backup.sync_all()?;
 		Ok(())
 	})();
@@ -552,11 +580,12 @@ fn atomic_write(path: &Path, content: &[u8], permissions: Option<fs::Permissions
 			.write(true)
 			.create_new(true)
 			.open(&temporary_path)?;
-		if let Some(permissions) = permissions {
-			temporary.set_permissions(permissions)?;
-		}
 		temporary.write_all(content)?;
 		temporary.sync_all()?;
+		if let Some(permissions) = permissions {
+			temporary.set_permissions(permissions)?;
+			temporary.sync_all()?;
+		}
 		drop(temporary);
 
 		fs::rename(&temporary_path, path).with_context(|| {
@@ -767,6 +796,18 @@ mod tests {
 	}
 
 	#[test]
+	fn current_config_load_does_not_create_write_lock() {
+		let temp = TempConfigDir::new();
+		let config_path = temp.config_path();
+		fs::write(&config_path, DEFAULT_CONFIG_TEMPLATE).unwrap();
+
+		let config = Config::load_from_path(&config_path).expect("current config should load");
+
+		assert_eq!(config.version, 2);
+		assert!(!config_path.with_file_name(".config.toml.lock").exists());
+	}
+
+	#[test]
 	fn load_migrates_v1_once_and_keeps_backup() {
 		let temp = TempConfigDir::new();
 		let config_path = temp.config_path();
@@ -815,6 +856,26 @@ mod tests {
 		assert!(Config::load_from_path(&config_path).is_err());
 		assert_eq!(fs::read_to_string(&config_path).unwrap(), invalid);
 		assert!(!config_path.with_file_name("config.toml.v1.bak").exists());
+	}
+
+	#[test]
+	fn conflicting_backup_prevents_migration_without_modifying_config() {
+		let temp = TempConfigDir::new();
+		let config_path = temp.config_path();
+		let backup_path = config_path.with_file_name("config.toml.v1.bak");
+		let original = released_v1_config();
+		fs::write(&config_path, &original).unwrap();
+		fs::write(&backup_path, "different previous backup").unwrap();
+
+		let error = Config::load_from_path(&config_path)
+			.expect_err("conflicting backup should stop migration");
+
+		assert!(error.to_string().contains("different contents"));
+		assert_eq!(fs::read_to_string(&config_path).unwrap(), original);
+		assert_eq!(
+			fs::read_to_string(&backup_path).unwrap(),
+			"different previous backup"
+		);
 	}
 
 	#[test]

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -1,0 +1,263 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{bail, Context, Result};
+use toml_edit::{value, DocumentMut, Item, Table};
+
+#[derive(Debug)]
+pub(super) struct Migration {
+	pub content: String,
+	pub from_version: u32,
+	pub to_version: u32,
+}
+
+/// Upgrade an existing configuration to the version declared by the embedded
+/// default template. Each migration advances exactly one version, making the
+/// chain deterministic and preventing later migrations from duplicating older
+/// work.
+pub(super) fn migrate(existing: &str, template: &str) -> Result<Option<Migration>> {
+	let mut document = parse_document(existing, "user configuration")?;
+	let template = parse_document(template, "embedded default configuration")?;
+
+	let from_version = document_version(&document, "user configuration")?;
+	let target_version = document_version(&template, "embedded default configuration")?;
+
+	if from_version > target_version {
+		bail!(
+			"configuration version {from_version} is newer than this octocode binary supports ({target_version})"
+		);
+	}
+
+	let mut version = from_version;
+	while version < target_version {
+		version = match version {
+			1 => {
+				migrate_v1_to_v2(&mut document, &template)?;
+				2
+			}
+			unsupported => {
+				bail!("no configuration migration exists from version {unsupported}")
+			}
+		};
+
+		document["version"] = value(i64::from(version));
+	}
+
+	if from_version == target_version {
+		return Ok(None);
+	}
+
+	Ok(Some(Migration {
+		content: document.to_string(),
+		from_version,
+		to_version: target_version,
+	}))
+}
+
+fn parse_document(content: &str, description: &str) -> Result<DocumentMut> {
+	content
+		.parse::<DocumentMut>()
+		.with_context(|| format!("failed to parse {description}"))
+}
+
+fn document_version(document: &DocumentMut, description: &str) -> Result<u32> {
+	let version = document
+		.get("version")
+		.and_then(Item::as_integer)
+		.with_context(|| format!("{description} must contain an integer 'version' field"))?;
+
+	u32::try_from(version)
+		.with_context(|| format!("{description} contains invalid version {version}"))
+}
+
+/// v1 is the schema shipped in octocode 0.18.1. v2 adds reasoning search and
+/// the RRF tuning fields. Existing values always win; only missing v2 fields
+/// are copied from the v2 template.
+fn migrate_v1_to_v2(document: &mut DocumentMut, template: &DocumentMut) -> Result<()> {
+	let template_search = required_table(template.as_table(), "search", "template")?;
+
+	if !document.as_table().contains_key("search") {
+		copy_item(document.as_table_mut(), template.as_table(), "search")?;
+		return Ok(());
+	}
+
+	let search = required_table_mut(document.as_table_mut(), "search", "user configuration")?;
+	let template_hybrid = required_table(template_search, "hybrid", "template search config")?;
+
+	if !search.contains_key("hybrid") {
+		copy_item(search, template_search, "hybrid")?;
+	} else {
+		let hybrid = required_table_mut(search, "hybrid", "user search config")?;
+		copy_missing_item(hybrid, template_hybrid, "rrf_k")?;
+		copy_missing_item(hybrid, template_hybrid, "auto_weight")?;
+	}
+
+	if !search.contains_key("reasoning") {
+		copy_item(search, template_search, "reasoning")?;
+	} else {
+		let reasoning = required_table_mut(search, "reasoning", "user search config")?;
+		let template_reasoning =
+			required_table(template_search, "reasoning", "template search config")?;
+		for key in [
+			"enabled",
+			"model",
+			"max_candidates",
+			"final_top_k",
+			"context_level",
+			"reasoning_weight",
+		] {
+			copy_missing_item(reasoning, template_reasoning, key)?;
+		}
+	}
+
+	Ok(())
+}
+
+fn required_table<'a>(table: &'a Table, key: &str, description: &str) -> Result<&'a Table> {
+	table
+		.get(key)
+		.and_then(Item::as_table)
+		.with_context(|| format!("{description} must contain a '{key}' table"))
+}
+
+fn required_table_mut<'a>(
+	table: &'a mut Table,
+	key: &str,
+	description: &str,
+) -> Result<&'a mut Table> {
+	table
+		.get_mut(key)
+		.and_then(Item::as_table_mut)
+		.with_context(|| format!("{description} must contain a '{key}' table"))
+}
+
+fn copy_missing_item(target: &mut Table, source: &Table, key: &str) -> Result<()> {
+	if target.contains_key(key) {
+		return Ok(());
+	}
+
+	copy_item(target, source, key)
+}
+
+fn copy_item(target: &mut Table, source: &Table, key: &str) -> Result<()> {
+	let (formatted_key, item) = source
+		.get_key_value(key)
+		.with_context(|| format!("embedded default configuration is missing '{key}'"))?;
+	target.insert_formatted(formatted_key, item.clone());
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const V1_SEARCH_CONFIG: &str = r#"# User values and comments must survive migration.
+version = 1
+
+[search]
+max_results = 17
+similarity_threshold = 0.72
+output_format = "markdown"
+max_files = 8
+context_lines = 5
+search_block_max_characters = 600
+graph_expansion = true
+
+[search.reranker]
+enabled = true
+model = "fastembed:jina-reranker-v2-base-multilingual"
+top_k_candidates = 40
+final_top_k = 8
+
+[search.hybrid]
+enabled = true
+default_vector_weight = 0.7
+default_keyword_weight = 0.3
+"#;
+
+	#[test]
+	fn migrates_released_v1_search_shape_to_v2() {
+		let migration = migrate(V1_SEARCH_CONFIG, super::super::DEFAULT_CONFIG_TEMPLATE)
+			.expect("v1 migration should succeed")
+			.expect("v1 should require migration");
+
+		assert_eq!(migration.from_version, 1);
+		assert_eq!(migration.to_version, 2);
+		assert!(migration
+			.content
+			.contains("# User values and comments must survive migration."));
+
+		let migrated: toml::Value =
+			toml::from_str(&migration.content).expect("migrated config should be valid TOML");
+		assert_eq!(migrated["version"].as_integer(), Some(2));
+		assert_eq!(
+			migrated["search"]["hybrid"]["default_vector_weight"].as_float(),
+			Some(0.7)
+		);
+		assert_eq!(migrated["search"]["hybrid"]["rrf_k"].as_float(), Some(60.0));
+		assert_eq!(
+			migrated["search"]["hybrid"]["auto_weight"].as_bool(),
+			Some(false)
+		);
+		assert_eq!(
+			migrated["search"]["reasoning"]["enabled"].as_bool(),
+			Some(false)
+		);
+	}
+
+	#[test]
+	fn preserves_existing_v2_field_values_during_v1_migration() {
+		let existing = format!(
+			"{V1_SEARCH_CONFIG}\n[search.reasoning]\nenabled = true\nmodel = \"openrouter:custom/model\"\n"
+		);
+		let migration = migrate(&existing, super::super::DEFAULT_CONFIG_TEMPLATE)
+			.expect("migration should succeed")
+			.expect("v1 should require migration");
+		let migrated: toml::Value = toml::from_str(&migration.content).unwrap();
+
+		assert_eq!(
+			migrated["search"]["reasoning"]["enabled"].as_bool(),
+			Some(true)
+		);
+		assert_eq!(
+			migrated["search"]["reasoning"]["model"].as_str(),
+			Some("openrouter:custom/model")
+		);
+		assert_eq!(
+			migrated["search"]["reasoning"]["max_candidates"].as_integer(),
+			Some(25)
+		);
+	}
+
+	#[test]
+	fn current_version_is_not_rewritten() {
+		assert!(migrate(
+			super::super::DEFAULT_CONFIG_TEMPLATE,
+			super::super::DEFAULT_CONFIG_TEMPLATE
+		)
+		.expect("current config should load")
+		.is_none());
+	}
+
+	#[test]
+	fn rejects_future_versions_without_migrating() {
+		let future =
+			super::super::DEFAULT_CONFIG_TEMPLATE.replacen("version = 2", "version = 3", 1);
+		let error = migrate(&future, super::super::DEFAULT_CONFIG_TEMPLATE)
+			.expect_err("future version should fail");
+		assert!(error
+			.to_string()
+			.contains("newer than this octocode binary"));
+	}
+}

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -197,6 +197,9 @@ default_keyword_weight = 0.3
 		assert!(migration
 			.content
 			.contains("# User values and comments must survive migration."));
+		assert!(migration
+			.content
+			.contains("# PageIndex-style reasoning retrieval"));
 
 		let migrated: toml::Value =
 			toml::from_str(&migration.content).expect("migrated config should be valid TOML");
@@ -237,6 +240,21 @@ default_keyword_weight = 0.3
 		assert_eq!(
 			migrated["search"]["reasoning"]["max_candidates"].as_integer(),
 			Some(25)
+		);
+	}
+
+	#[test]
+	fn migrates_v1_without_search_table() {
+		let migration = migrate("version = 1\n", super::super::DEFAULT_CONFIG_TEMPLATE)
+			.expect("minimal v1 config should migrate")
+			.expect("v1 should require migration");
+		let migrated: toml::Value = toml::from_str(&migration.content).unwrap();
+
+		assert_eq!(migrated["version"].as_integer(), Some(2));
+		assert_eq!(migrated["search"]["hybrid"]["rrf_k"].as_float(), Some(60.0));
+		assert_eq!(
+			migrated["search"]["reasoning"]["enabled"].as_bool(),
+			Some(false)
 		);
 	}
 


### PR DESCRIPTION
- Upgrade default configuration version to 2
- Implement automatic migration system from v1 to v2
- Add support for reasoning search and RRF tuning fields
- Preserve user values and comments during configuration upgrades
- Implement exclusive file locking and atomic write operations
- Add automatic backup creation before applying migrations
- Use temporary files and filesystem sync for data integrity
- Simplify default config loading via embedded templates
- Add toml_edit and fs4 dependencies for precise TOML manipulation
- Add comprehensive tests for migrations and concurrency cases