### PR TITLE
docs: explain OpenAI-compatible LLM setup

### DIFF
--- a/doc/API_KEYS.md
+++ b/doc/API_KEYS.md
@@ -213,6 +213,40 @@ octocode config --model "deepseek:deepseek-chat"
 - `deepseek:deepseek-chat` - General purpose
 - `deepseek:deepseek-coder` - Code-specialized
 
+### OpenAI-Compatible Endpoints
+
+Octocode's generic `local:` LLM provider works with OpenAI-compatible Chat
+Completions endpoints, including LM Studio, vLLM, LocalAI, and remote services.
+`LOCAL_API_URL` must be the full `/v1/chat/completions` URL. The model ID
+after `local:` is passed through unchanged, including IDs that contain
+slashes.
+
+```bash
+# Local LM Studio example
+export LOCAL_API_URL="http://127.0.0.1:1234/v1/chat/completions"
+export LOCAL_API_KEY="optional-local-key"
+octocode config --model "local:google/gemma-4-12b-qat"
+```
+
+Remote endpoints use the same configuration shape. For example, AI Router is
+an independently operated hosted service that requires bearer authentication:
+
+```bash
+export LOCAL_API_URL="https://api.ai-router.dev/v1/chat/completions"
+export LOCAL_API_KEY="your-ai-router-api-key"
+octocode config --model "local:<model-id-enabled-for-your-account>"
+```
+
+See the [AI Router site](https://ai-router.dev) for service-specific account
+and API information. This example was submitted by the service operator; it is
+not an Octocode default or endorsement.
+
+The same `local:<model-id>` format can be used for `[llm].model`,
+`[index].contextual_model`, and the model fields under `[graphrag.llm]`.
+Contextual indexing and GraphRAG require structured-output support, so an
+otherwise compatible endpoint can still be rejected when the selected model's
+capabilities are not recognized.
+
 ## Platform Limitations
 
 ### Feature-Gated Providers

--- a/doc/API_KEYS.md
+++ b/doc/API_KEYS.md
@@ -215,34 +215,39 @@ octocode config --model "deepseek:deepseek-chat"
 
 ### OpenAI-Compatible Endpoints
 
-Octocode's generic `local:` LLM provider works with OpenAI-compatible Chat
-Completions endpoints, including LM Studio, vLLM, LocalAI, and remote services.
-`LOCAL_API_URL` must be the full `/v1/chat/completions` URL. The model ID
-after `local:` is passed through unchanged, including IDs that contain
-slashes.
+Octocode's generic `local:` LLM provider works with any OpenAI-compatible Chat
+Completions endpoint, whether it runs locally or remotely. `LOCAL_API_URL` must
+be the full request URL, including `/v1/chat/completions`. The model ID after
+`local:` is sent to the endpoint unchanged, including IDs that contain slashes.
 
 ```bash
-# Local LM Studio example
-export LOCAL_API_URL="http://127.0.0.1:1234/v1/chat/completions"
-export LOCAL_API_KEY="optional-local-key"
-octocode config --model "local:google/gemma-4-12b-qat"
+# Endpoint without authentication
+export LOCAL_API_URL="http://127.0.0.1:8000/v1/chat/completions"
+octocode config --model "local:<model-id>"
 ```
 
-Remote endpoints use the same configuration shape. For example, AI Router is
-an independently operated hosted service that requires bearer authentication:
+If the endpoint requires bearer authentication, also set `LOCAL_API_KEY`:
 
 ```bash
-export LOCAL_API_URL="https://api.ai-router.dev/v1/chat/completions"
-export LOCAL_API_KEY="your-ai-router-api-key"
-octocode config --model "local:<model-id-enabled-for-your-account>"
+export LOCAL_API_URL="https://llm.example.com/v1/chat/completions"
+export LOCAL_API_KEY="your-api-key"
+octocode config --model "local:<model-id>"
 ```
 
-See the [AI Router site](https://ai-router.dev) for service-specific account
-and API information. This example was submitted by the service operator; it is
-not an Octocode default or endorsement.
+Use the same model format wherever Octocode accepts an LLM model:
 
-The same `local:<model-id>` format can be used for `[llm].model`,
-`[index].contextual_model`, and the model fields under `[graphrag.llm]`.
+```toml
+[llm]
+model = "local:<model-id>"
+
+[index]
+contextual_model = "local:<model-id>"
+
+[graphrag.llm]
+description_model = "local:<model-id>"
+relationship_model = "local:<model-id>"
+```
+
 Contextual indexing and GraphRAG require structured-output support, so an
 otherwise compatible endpoint can still be rejected when the selected model's
 capabilities are not recognized.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -158,8 +158,9 @@ fastembed:multilingual-e5-small                       # 384 dim, supports multip
 export OPENROUTER_API_KEY="your-openrouter-api-key"
 
 # Generic OpenAI-compatible LLM endpoint. Use the full Chat Completions URL.
-export LOCAL_API_URL="http://127.0.0.1:1234/v1/chat/completions"
-export LOCAL_API_KEY="optional-api-key"
+export LOCAL_API_URL="http://127.0.0.1:8000/v1/chat/completions"
+# Optional: set only when the endpoint requires bearer authentication.
+export LOCAL_API_KEY="your-api-key"
 
 # Cloud embedding providers (if using)
 export JINA_API_KEY="your-jina-key"
@@ -199,13 +200,13 @@ max_tokens = 4000
 - `deepseek:` - DeepSeek models
 - `local:` - Any OpenAI-compatible Chat Completions endpoint configured with `LOCAL_API_URL`
 
-**API Keys:** Set via environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, LOCAL_API_KEY, etc.)
+**API Keys:** Set via environment variables (`OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `LOCAL_API_KEY`, etc.).
 
 For `local:`, `LOCAL_API_URL` must point to the full
-`/v1/chat/completions` endpoint. `LOCAL_API_KEY` is optional for local
-servers and can hold the required bearer key for authenticated remote
-endpoints. See the [API Keys guide](API_KEYS.md#openai-compatible-endpoints) for
-local and remote examples.
+`/v1/chat/completions` endpoint. `LOCAL_API_KEY` is optional; when set, it is
+sent as a bearer token. See the [API Keys guide](API_KEYS.md#openai-compatible-endpoints)
+for unauthenticated and authenticated examples.
 
 ### [embedding]
 Core embedding configuration.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -157,6 +157,10 @@ fastembed:multilingual-e5-small                       # 384 dim, supports multip
 # OpenRouter for AI features
 export OPENROUTER_API_KEY="your-openrouter-api-key"
 
+# Generic OpenAI-compatible LLM endpoint. Use the full Chat Completions URL.
+export LOCAL_API_URL="http://127.0.0.1:1234/v1/chat/completions"
+export LOCAL_API_KEY="optional-api-key"
+
 # Cloud embedding providers (if using)
 export JINA_API_KEY="your-jina-key"
 export VOYAGE_API_KEY="your-voyage-key"
@@ -193,8 +197,15 @@ max_tokens = 4000
 - `anthropic:` - Anthropic Claude models
 - `google:` - Google Gemini models
 - `deepseek:` - DeepSeek models
+- `local:` - Any OpenAI-compatible Chat Completions endpoint configured with `LOCAL_API_URL`
 
-**API Keys:** Set via environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, etc.)
+**API Keys:** Set via environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, LOCAL_API_KEY, etc.)
+
+For `local:`, `LOCAL_API_URL` must point to the full
+`/v1/chat/completions` endpoint. `LOCAL_API_KEY` is optional for local
+servers and can hold the required bearer key for authenticated remote
+endpoints. See the [API Keys guide](API_KEYS.md#openai-compatible-endpoints) for
+local and remote examples.
 
 ### [embedding]
 Core embedding configuration.


### PR DESCRIPTION
## Summary

- document the existing `local:` provider for OpenAI-compatible Chat Completions endpoints
- clarify that `LOCAL_API_URL` is the full `/v1/chat/completions` URL and that `LOCAL_API_KEY` is an optional bearer token
- explain that model IDs are passed through unchanged
- show the same `local:<model-id>` format for primary, contextual, and GraphRAG LLM settings
- document the structured-output capability requirement for contextual indexing and GraphRAG
- include neutral examples for unauthenticated and authenticated endpoints

Closes #72.

## Validation

- `git diff --check`
- compared the documented URL, authentication, model parsing, and capability behavior with the `octolib` 0.26.1 source used by this branch
- confirmed that the documentation diff contains no service-specific hosted endpoint or product link

No runtime code changed, so the Rust test suite was not run.
