### PR TITLE
feat: document-level GraphRAG with markdown references

### DIFF
--- a/src/indexer/graphrag/builder.rs
+++ b/src/indexer/graphrag/builder.rs
@@ -723,6 +723,7 @@ impl GraphBuilder {
 				// last-path-segment matching in RelationshipDiscovery).
 				let new_keys: std::collections::HashSet<&str> = selected
 					.iter()
+					.filter(|n| n.language != "markdown")
 					.flat_map(|n| n.exports.iter().chain(n.symbols.iter()))
 					.map(|s| s.as_str())
 					.collect();

--- a/src/indexer/graphrag/database.rs
+++ b/src/indexer/graphrag/database.rs
@@ -234,7 +234,7 @@ impl<'a> DatabaseOperations<'a> {
 				let source = source_array.value(i);
 				let target = target_array.value(i);
 				let rel_type = type_array.value(i);
-				let key = (source.to_string(), target.to_string(), rel_type.to_string());
+				let key = (source, target, rel_type);
 				if !seen.insert(key) {
 					dedup_count += 1;
 					continue;

--- a/src/indexer/graphrag/database.rs
+++ b/src/indexer/graphrag/database.rs
@@ -226,22 +226,37 @@ impl<'a> DatabaseOperations<'a> {
 			let desc_array = extract_string_column(&rel_batch, "description")?;
 			let conf_array = extract_f32_column(&rel_batch, "confidence")?;
 
-			// Process each relationship
+			// Deduplicate relationships by (source, target, type) triple —
+			// batch writes can produce duplicates across incremental flushes
+			let mut seen = std::collections::HashSet::new();
+			let mut dedup_count = 0usize;
 			for i in 0..rel_batch.num_rows() {
+				let source = source_array.value(i);
+				let target = target_array.value(i);
+				let rel_type = type_array.value(i);
+				let key = (source.to_string(), target.to_string(), rel_type.to_string());
+				if !seen.insert(key) {
+					dedup_count += 1;
+					continue;
+				}
 				let relationship = CodeRelationship {
-					source: source_array.value(i).to_string(),
-					target: target_array.value(i).to_string(),
-					relation_type: type_array
-						.value(i)
+					source: source.to_string(),
+					target: target.to_string(),
+					relation_type: rel_type
 						.parse()
 						.unwrap_or(crate::indexer::graphrag::types::RelationType::Imports),
 					description: desc_array.value(i).to_string(),
 					confidence: conf_array.value(i),
-					weight: 1.0, // Default weight for legacy relationships
+					weight: 1.0,
 				};
-
-				// Add to graph
 				graph.relationships.push(relationship);
+			}
+			if dedup_count > 0 && !quiet {
+				println!(
+					"  Deduplicated {} → {} unique relationships",
+					rel_batch.num_rows(),
+					graph.relationships.len()
+				);
 			}
 		}
 

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -56,9 +56,9 @@ impl RelationshipDiscovery {
 
 		for source_file in new_files {
 			// 1. Import/Export relationships via pre-built index (O(1) per import)
-			if source_file.language == "markdown" {
-	Self::discover_import_relationships(source_file, all_nodes, &mut relationships);
-			} else {
+			// Markdown imports are paths, not symbols. They are resolved below by
+			// `resolve_import_relationships` and emitted only as References edges.
+			if source_file.language != "markdown" {
 				for import in &source_file.imports {
 					// Check both the raw import and cleaned versions
 					let candidates = Self::get_import_candidates(import, &symbol_index);
@@ -323,21 +323,24 @@ impl RelationshipDiscovery {
 							weight: 1.0,
 						});
 
-						// Create reverse export relationship if target exports to source
-						for export_item in &target_node.exports {
-							if import_path.contains(export_item) || export_item == "*" {
-								relationships.push(CodeRelationship {
-									source: target_node.id.clone(),
-									target: source_file.id.clone(),
-									relation_type:
-										crate::indexer::graphrag::types::RelationType::Imports,
-									description: format!(
-										"Exports {} to {}",
-										export_item, source_file.path
-									),
-									confidence: 0.9,
-									weight: 0.8,
-								});
+						// Code exports may imply a reverse edge. Markdown headings are
+						// not exports, so document links remain directional References.
+						if source_file.language != "markdown" {
+							for export_item in &target_node.exports {
+								if import_path.contains(export_item) || export_item == "*" {
+									relationships.push(CodeRelationship {
+										source: target_node.id.clone(),
+										target: source_file.id.clone(),
+										relation_type:
+											crate::indexer::graphrag::types::RelationType::Imports,
+										description: format!(
+											"Exports {} to {}",
+											export_item, source_file.path
+										),
+										confidence: 0.9,
+										weight: 0.8,
+									});
+								}
 							}
 						}
 					}

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -36,6 +36,12 @@ impl RelationshipDiscovery {
 		let mut symbol_index: std::collections::HashMap<&str, Vec<&str>> =
 			std::collections::HashMap::new();
 		for node in all_nodes {
+			// Markdown "exports" are section headings — generic prose like "Config"
+			// or "Overview". Indexing them as importable symbols makes every code
+			// import whose last segment matches a heading resolve to a document.
+			if node.language == "markdown" {
+				continue;
+			}
 			for sym in node.exports.iter().chain(node.symbols.iter()) {
 				symbol_index.entry(sym.as_str()).or_default().push(&node.id);
 			}

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -40,7 +40,6 @@ impl RelationshipDiscovery {
 				symbol_index.entry(sym.as_str()).or_default().push(&node.id);
 			}
 		}
-
 		// Pre-build path index for parent-child lookups
 		let all_node_ids: Vec<(&str, &str)> = all_nodes
 			.iter()
@@ -57,19 +56,24 @@ impl RelationshipDiscovery {
 
 		for source_file in new_files {
 			// 1. Import/Export relationships via pre-built index (O(1) per import)
-			for import in &source_file.imports {
-				// Check both the raw import and cleaned versions
-				let candidates = Self::get_import_candidates(import, &symbol_index);
-				for target_id in candidates {
-					if target_id != source_file.id {
-						relationships.push(CodeRelationship {
-							source: source_file.id.clone(),
-							target: target_id.to_string(),
-							relation_type: crate::indexer::graphrag::types::RelationType::Imports,
-							description: format!("Imports {} from {}", import, target_id),
-							confidence: 0.9,
-							weight: 1.0,
-						});
+			if source_file.language == "markdown" {
+				Self::discover_import_relationships(source_file, all_nodes, &mut relationships);
+			} else {
+				for import in &source_file.imports {
+					// Check both the raw import and cleaned versions
+					let candidates = Self::get_import_candidates(import, &symbol_index);
+					for target_id in candidates {
+						if target_id != source_file.id {
+							relationships.push(CodeRelationship {
+								source: source_file.id.clone(),
+								target: target_id.to_string(),
+								relation_type:
+									crate::indexer::graphrag::types::RelationType::Imports,
+								description: format!("Imports {} from {}", import, target_id),
+								confidence: 0.9,
+								weight: 1.0,
+							});
+						}
 					}
 				}
 			}

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -57,7 +57,7 @@ impl RelationshipDiscovery {
 		for source_file in new_files {
 			// 1. Import/Export relationships via pre-built index (O(1) per import)
 			if source_file.language == "markdown" {
-				Self::discover_import_relationships(source_file, all_nodes, &mut relationships);
+	Self::discover_import_relationships(source_file, all_nodes, &mut relationships);
 			} else {
 				for import in &source_file.imports {
 					// Check both the raw import and cleaned versions

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -296,16 +296,26 @@ impl RelationshipDiscovery {
 				{
 					// Find the target node
 					if let Some(target_node) = file_map.get(&resolved_path) {
-						// Create semantic import relationship
+						// Use References for markdown cross-links, Imports for code
+						let rel_type = if source_file.language == "markdown" {
+							crate::indexer::graphrag::types::RelationType::References
+						} else {
+							crate::indexer::graphrag::types::RelationType::Imports
+						};
+						let description_prefix = if source_file.language == "markdown" {
+							"References"
+						} else {
+							"Direct import"
+						};
 						relationships.push(CodeRelationship {
 							source: source_file.id.clone(),
 							target: target_node.id.clone(),
-							relation_type: crate::indexer::graphrag::types::RelationType::Imports,
+							relation_type: rel_type,
 							description: format!(
-								"Direct import: {} -> {}",
-								import_path, resolved_path
+								"{}: {} -> {}",
+								description_prefix, import_path, resolved_path
 							),
-							confidence: 0.95, // High confidence for resolved imports
+							confidence: 0.95,
 							weight: 1.0,
 						});
 
@@ -587,10 +597,9 @@ impl RelationshipDiscovery {
 			|| relative_path.contains(".test.")
 		{
 			"test_file".to_string()
-		} else if relative_path.ends_with(".md")
-			|| relative_path.ends_with(".txt")
-			|| relative_path.ends_with(".rst")
-		{
+		} else if relative_path.ends_with(".md") || relative_path.ends_with(".markdown") {
+			"document_file".to_string()
+		} else if relative_path.ends_with(".txt") || relative_path.ends_with(".rst") {
 			"documentation".to_string()
 		} else if relative_path.contains("/config") || relative_path.contains(".config") {
 			"config_file".to_string()

--- a/src/indexer/graphrag/tests.rs
+++ b/src/indexer/graphrag/tests.rs
@@ -1515,4 +1515,101 @@ function main(): void {
 			extract_imports_exports_recursive(child, contents, lang_impl, all_imports, all_exports);
 		}
 	}
+
+	/// Integration test: verify discover_relationships_efficiently produces
+	/// References edges for markdown nodes with file-path imports.
+	/// This is the exact code path used at runtime (not discover_import_relationships directly).
+	#[tokio::test]
+	async fn test_markdown_references_via_efficient_discovery() {
+		use crate::indexer::graphrag::types::RelationType;
+
+		// Source: adapters-integrations.md imports credit-suite.md and credit-accounts.md
+		let source = CodeNode {
+			id: "projects/docs/core/adapters-integrations.md".to_string(),
+			name: "adapters-integrations".to_string(),
+			kind: "document_file".to_string(),
+			path: "projects/docs/core/adapters-integrations.md".to_string(),
+			description: String::new(),
+			symbols: vec![],
+			imports: vec![
+				"credit-suite.md".to_string(),             // same-dir
+				"../intro/credit-accounts.md".to_string(),  // parent-dir
+			],
+			exports: vec!["Adapters".to_string()],
+			functions: vec![],
+			hash: "aaa".to_string(),
+			embedding: vec![],
+			size_lines: 50,
+			language: "markdown".to_string(),
+		};
+
+		let target1 = CodeNode {
+			id: "projects/docs/core/credit-suite.md".to_string(),
+			name: "credit-suite".to_string(),
+			kind: "document_file".to_string(),
+			path: "projects/docs/core/credit-suite.md".to_string(),
+			description: String::new(),
+			symbols: vec![],
+			imports: vec![],
+			exports: vec!["Credit Suite".to_string()],
+			functions: vec![],
+			hash: "bbb".to_string(),
+			embedding: vec![],
+			size_lines: 100,
+			language: "markdown".to_string(),
+		};
+
+		let target2 = CodeNode {
+			id: "projects/docs/intro/credit-accounts.md".to_string(),
+			name: "credit-accounts".to_string(),
+			kind: "document_file".to_string(),
+			path: "projects/docs/intro/credit-accounts.md".to_string(),
+			description: String::new(),
+			symbols: vec![],
+			imports: vec![],
+			exports: vec!["Credit Accounts".to_string()],
+			functions: vec![],
+			hash: "ccc".to_string(),
+			embedding: vec![],
+			size_lines: 80,
+			language: "markdown".to_string(),
+		};
+
+		let all_nodes = vec![source.clone(), target1.clone(), target2.clone()];
+		let new_files = vec![source.clone()];
+
+		// Call the SAME function used at runtime
+		let relationships = RelationshipDiscovery::discover_relationships_efficiently(
+			&new_files,
+			&all_nodes,
+		)
+		.await
+		.expect("relationship discovery should succeed");
+
+		// Find References relationships (not just sibling_module)
+		let refs: Vec<_> = relationships
+			.iter()
+			.filter(|r| r.relation_type == RelationType::References)
+			.collect();
+
+		assert!(
+			refs.len() >= 2,
+			"Expected at least 2 References relationships, got {}: {:?}",
+			refs.len(),
+			refs.iter().map(|r| format!("{} -> {}", r.source, r.target)).collect::<Vec<_>>()
+		);
+
+		// Verify specific edges
+		let has_suite = refs.iter().any(|r| {
+			r.source == "projects/docs/core/adapters-integrations.md"
+				&& r.target == "projects/docs/core/credit-suite.md"
+		});
+		assert!(has_suite, "Should have reference to credit-suite.md");
+
+		let has_accounts = refs.iter().any(|r| {
+			r.source == "projects/docs/core/adapters-integrations.md"
+				&& r.target == "projects/docs/intro/credit-accounts.md"
+		});
+		assert!(has_accounts, "Should have reference to credit-accounts.md");
+	}
 }

--- a/src/indexer/graphrag/tests.rs
+++ b/src/indexer/graphrag/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(test)]
 mod graphrag_relationship_tests {
 	use crate::indexer::graphrag::relationships::RelationshipDiscovery;
@@ -1533,7 +1547,7 @@ function main(): void {
 			symbols: vec![],
 			imports: vec![
 				"credit-suite.md".to_string(),             // same-dir
-				"../intro/credit-accounts.md".to_string(),  // parent-dir
+				"../intro/credit-accounts.md".to_string(), // parent-dir
 			],
 			exports: vec!["Adapters".to_string()],
 			functions: vec![],
@@ -1579,12 +1593,10 @@ function main(): void {
 		let new_files = vec![source.clone()];
 
 		// Call the SAME function used at runtime
-		let relationships = RelationshipDiscovery::discover_relationships_efficiently(
-			&new_files,
-			&all_nodes,
-		)
-		.await
-		.expect("relationship discovery should succeed");
+		let relationships =
+			RelationshipDiscovery::discover_relationships_efficiently(&new_files, &all_nodes)
+				.await
+				.expect("relationship discovery should succeed");
 
 		// Find References relationships (not just sibling_module)
 		let refs: Vec<_> = relationships
@@ -1596,7 +1608,9 @@ function main(): void {
 			refs.len() >= 2,
 			"Expected at least 2 References relationships, got {}: {:?}",
 			refs.len(),
-			refs.iter().map(|r| format!("{} -> {}", r.source, r.target)).collect::<Vec<_>>()
+			refs.iter()
+				.map(|r| format!("{} -> {}", r.source, r.target))
+				.collect::<Vec<_>>()
 		);
 
 		// Verify specific edges
@@ -1611,5 +1625,12 @@ function main(): void {
 				&& r.target == "projects/docs/intro/credit-accounts.md"
 		});
 		assert!(has_accounts, "Should have reference to credit-accounts.md");
+
+		assert!(
+			relationships
+				.iter()
+				.all(|relationship| relationship.relation_type != RelationType::Imports),
+			"Markdown links must not be emitted as code import relationships"
+		);
 	}
 }

--- a/src/indexer/graphrag/types.rs
+++ b/src/indexer/graphrag/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/indexer/graphrag/types.rs
+++ b/src/indexer/graphrag/types.rs
@@ -60,6 +60,8 @@ pub enum RelationType {
 	StrategyPattern,
 	/// Adapter pattern (interface adaptation)
 	AdapterPattern,
+	/// Document cross-reference via markdown link
+	References,
 
 	// Low importance - Organizational relationships (weight: 0.3)
 	/// Files in the same directory
@@ -85,6 +87,7 @@ impl RelationType {
 			| Self::ObserverPattern
 			| Self::StrategyPattern
 			| Self::AdapterPattern => 0.8,
+			Self::References => 0.6,
 
 			// Low importance - organizational structure
 			Self::SiblingModule | Self::ParentModule | Self::ChildModule => 0.3,
@@ -105,6 +108,7 @@ impl RelationType {
 			Self::ObserverPattern => "observer_pattern",
 			Self::StrategyPattern => "strategy_pattern",
 			Self::AdapterPattern => "adapter_pattern",
+			Self::References => "references",
 			Self::SiblingModule => "sibling_module",
 			Self::ParentModule => "parent_module",
 			Self::ChildModule => "child_module",
@@ -129,6 +133,7 @@ impl FromStr for RelationType {
 			"observer_pattern" => Self::ObserverPattern,
 			"strategy_pattern" => Self::StrategyPattern,
 			"adapter_pattern" => Self::AdapterPattern,
+			"references" => Self::References,
 			"sibling_module" => Self::SiblingModule,
 			"parent_module" => Self::ParentModule,
 			"child_module" => Self::ChildModule,
@@ -295,6 +300,9 @@ mod tests {
 		assert_eq!(RelationType::Uses.importance_weight(), 0.7);
 		assert_eq!(RelationType::FactoryCreates.importance_weight(), 0.8);
 
+		// Document references (between structural and organizational)
+		assert_eq!(RelationType::References.importance_weight(), 0.6);
+
 		// Low importance relationships
 		assert_eq!(RelationType::SiblingModule.importance_weight(), 0.3);
 		assert_eq!(RelationType::ParentModule.importance_weight(), 0.3);
@@ -321,6 +329,16 @@ mod tests {
 			RelationType::Calls.importance_weight()
 				> RelationType::ParentModule.importance_weight()
 		);
+
+		// Verify references sit between structural imports and organizational
+		assert!(
+			RelationType::Imports.importance_weight()
+				> RelationType::References.importance_weight()
+		);
+		assert!(
+			RelationType::References.importance_weight()
+				> RelationType::SiblingModule.importance_weight()
+		);
 	}
 
 	#[test]
@@ -345,6 +363,10 @@ mod tests {
 		assert_eq!(
 			"sibling_module".parse::<RelationType>().unwrap(),
 			RelationType::SiblingModule
+		);
+		assert_eq!(
+			"references".parse::<RelationType>().unwrap(),
+			RelationType::References
 		);
 
 		// Test unknown type defaults to Imports
@@ -374,6 +396,7 @@ mod tests {
 			RelationType::Imports,
 			RelationType::Calls,
 			RelationType::Uses,
+			RelationType::References,
 			RelationType::SiblingModule,
 		];
 

--- a/src/indexer/languages/markdown.rs
+++ b/src/indexer/languages/markdown.rs
@@ -216,6 +216,41 @@ Non-md links are ignored: [Image](./photo.png)
 	}
 
 	#[test]
+	fn test_resolve_with_deep_project_paths() {
+		let md = Markdown;
+		// Real-world paths from ai-assistant repo
+		let all_files = vec![
+			"projects/gearbox/autodocs-about/docs/core-architecture/credit-suite.md".to_string(),
+			"projects/gearbox/autodocs-about/docs/core-architecture/pool.md".to_string(),
+			"projects/gearbox/autodocs-about/docs/introduction/credit-accounts.md".to_string(),
+		];
+
+		// adapters-integrations.md links to credit-suite.md (same dir)
+		let resolved = md.resolve_import(
+			"credit-suite.md",
+			"projects/gearbox/autodocs-about/docs/core-architecture/adapters-integrations.md",
+			&all_files,
+		);
+		assert_eq!(
+			resolved,
+			Some("projects/gearbox/autodocs-about/docs/core-architecture/credit-suite.md".to_string()),
+			"Same-dir link should resolve"
+		);
+
+		// adapters-integrations.md links to ../introduction/credit-accounts.md
+		let resolved = md.resolve_import(
+			"../introduction/credit-accounts.md",
+			"projects/gearbox/autodocs-about/docs/core-architecture/adapters-integrations.md",
+			&all_files,
+		);
+		assert_eq!(
+			resolved,
+			Some("projects/gearbox/autodocs-about/docs/introduction/credit-accounts.md".to_string()),
+			"Parent-dir link should resolve"
+		);
+	}
+
+	#[test]
 	fn test_no_links_in_empty_doc() {
 		let link_re =
 			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();

--- a/src/indexer/languages/markdown.rs
+++ b/src/indexer/languages/markdown.rs
@@ -65,23 +65,72 @@ impl Language for Markdown {
 		"markdown headings"
 	}
 
-	// Markdown doesn't have traditional imports/exports
-	#[allow(dead_code)]
-	fn extract_imports_exports(&self, _node: Node, _contents: &str) -> (Vec<String>, Vec<String>) {
-		// Markdown files don't have imports or exports in the traditional sense
-		// Could potentially extract links to other markdown files, but that's not
-		// the same as code imports/exports
-		(Vec::new(), Vec::new())
+	fn extract_imports_exports(&self, node: Node, contents: &str) -> (Vec<String>, Vec<String>) {
+		// Only extract at the root node to avoid redundant passes during
+		// the recursive AST walk (the JSON placeholder parser produces
+		// multiple nodes, each receiving the same contents string).
+		if node.parent().is_some() {
+			return (Vec::new(), Vec::new());
+		}
+
+		let mut links = Vec::new();
+		// Match [text](path.md) — standard markdown links to .md files
+		// Skip external URLs (http:// or https://)
+		// Strip anchor fragments (#section)
+		let link_re =
+			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();
+		for cap in link_re.captures_iter(contents) {
+			if let Some(target) = cap.get(1) {
+				let path = target.as_str();
+				if !path.starts_with("http://") && !path.starts_with("https://") {
+					links.push(path.to_string());
+				}
+			}
+		}
+
+		// Deduplicate — a doc may link to the same target multiple times
+		links.sort();
+		links.dedup();
+
+		// Markdown "exports" are section headings
+		let exports = self.extract_symbols(node, contents);
+		(links, exports)
 	}
 
 	fn resolve_import(
 		&self,
-		_import_path: &str,
-		_source_file: &str,
-		_all_files: &[String],
+		import_path: &str,
+		source_file: &str,
+		all_files: &[String],
 	) -> Option<String> {
-		// Markdown doesn't have imports
-		None
+		use std::path::{Component, PathBuf};
+
+		let source_dir = PathBuf::from(source_file)
+			.parent()
+			.map(|p| p.to_path_buf())
+			.unwrap_or_default();
+		let joined = source_dir.join(import_path);
+
+		// Normalize path components (resolve ../ and ./)
+		let normalized =
+			joined
+				.components()
+				.fold(PathBuf::new(), |mut acc, c| {
+					match c {
+						Component::ParentDir => {
+							acc.pop();
+						}
+						Component::CurDir => {}
+						Component::Normal(os) => {
+							acc.push(os);
+						}
+						_ => {}
+					}
+					acc
+				});
+
+		let normalized_str = normalized.to_string_lossy().to_string();
+		all_files.iter().find(|f| **f == normalized_str).cloned()
 	}
 
 	fn get_file_extensions(&self) -> Vec<&'static str> {
@@ -90,3 +139,88 @@ impl Language for Markdown {
 }
 
 impl Markdown {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_extract_markdown_links() {
+		let content = r#"
+# Credit Accounts
+
+See [Credit Suite](../core-architecture/credit-suite.md) for details.
+Also check [Pool](../core-architecture/pool.md#liquidity) and
+[Adapters](./adapters.md).
+
+External links are ignored: [Docs](https://docs.example.com/guide.md)
+Non-md links are ignored: [Image](./photo.png)
+"#;
+
+		// Test the regex logic directly (can't easily create tree-sitter Node in unit tests)
+		let link_re =
+			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();
+		let mut links = Vec::new();
+		for cap in link_re.captures_iter(content) {
+			if let Some(target) = cap.get(1) {
+				let path = target.as_str();
+				if !path.starts_with("http://") && !path.starts_with("https://") {
+					links.push(path.to_string());
+				}
+			}
+		}
+
+		assert_eq!(links.len(), 3);
+		assert!(links.contains(&"../core-architecture/credit-suite.md".to_string()));
+		assert!(links.contains(&"../core-architecture/pool.md".to_string()));
+		assert!(links.contains(&"./adapters.md".to_string()));
+		assert!(!links.iter().any(|l| l.contains("https://")));
+		assert!(!links.iter().any(|l| l.contains(".png")));
+	}
+
+	#[test]
+	fn test_resolve_markdown_import() {
+		let md = Markdown;
+		let all_files = vec![
+			"core-architecture/credit-suite.md".to_string(),
+			"core-architecture/pool.md".to_string(),
+			"introduction/adapters.md".to_string(),
+		];
+
+		// Relative link: introduction/credit-accounts.md → ../core-architecture/credit-suite.md
+		let resolved = md.resolve_import(
+			"../core-architecture/credit-suite.md",
+			"introduction/credit-accounts.md",
+			&all_files,
+		);
+		assert_eq!(
+			resolved,
+			Some("core-architecture/credit-suite.md".to_string())
+		);
+
+		// Same-directory link
+		let resolved = md.resolve_import(
+			"./adapters.md",
+			"introduction/credit-accounts.md",
+			&all_files,
+		);
+		assert_eq!(resolved, Some("introduction/adapters.md".to_string()));
+
+		// Non-existent target
+		let resolved = md.resolve_import(
+			"../nonexistent.md",
+			"introduction/credit-accounts.md",
+			&all_files,
+		);
+		assert_eq!(resolved, None);
+	}
+
+	#[test]
+	fn test_no_links_in_empty_doc() {
+		let link_re =
+			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();
+		let content = "# Simple heading\nNo links here.";
+		let links: Vec<_> = link_re.captures_iter(content).collect();
+		assert!(links.is_empty());
+	}
+}

--- a/src/indexer/languages/markdown.rs
+++ b/src/indexer/languages/markdown.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,28 @@
 //! Extracts headings as signatures with smart content preview
 
 use super::Language;
+use regex::Regex;
+use std::sync::LazyLock;
 use tree_sitter::Node;
+
+static MARKDOWN_LINK_RE: LazyLock<Regex> = LazyLock::new(|| {
+	Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").expect("markdown link regex must be valid")
+});
+
+fn extract_markdown_links(contents: &str) -> Vec<String> {
+	let mut links = Vec::new();
+	for capture in MARKDOWN_LINK_RE.captures_iter(contents) {
+		if let Some(target) = capture.get(1) {
+			let path = target.as_str();
+			if !path.starts_with("http://") && !path.starts_with("https://") {
+				links.push(path.to_string());
+			}
+		}
+	}
+	links.sort_unstable();
+	links.dedup();
+	links
+}
 
 /// Markdown language implementation
 pub struct Markdown;
@@ -73,24 +94,10 @@ impl Language for Markdown {
 			return (Vec::new(), Vec::new());
 		}
 
-		let mut links = Vec::new();
 		// Match [text](path.md) — standard markdown links to .md files
 		// Skip external URLs (http:// or https://)
 		// Strip anchor fragments (#section)
-		let link_re =
-			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();
-		for cap in link_re.captures_iter(contents) {
-			if let Some(target) = cap.get(1) {
-				let path = target.as_str();
-				if !path.starts_with("http://") && !path.starts_with("https://") {
-					links.push(path.to_string());
-				}
-			}
-		}
-
-		// Deduplicate — a doc may link to the same target multiple times
-		links.sort();
-		links.dedup();
+		let links = extract_markdown_links(contents);
 
 		// Markdown "exports" are section headings
 		let exports = self.extract_symbols(node, contents);
@@ -103,34 +110,12 @@ impl Language for Markdown {
 		source_file: &str,
 		all_files: &[String],
 	) -> Option<String> {
-		use std::path::{Component, PathBuf};
+		use super::resolution_utils::resolve_relative_path;
+		use crate::utils::path::PathNormalizer;
 
-		let source_dir = PathBuf::from(source_file)
-			.parent()
-			.map(|p| p.to_path_buf())
-			.unwrap_or_default();
-		let joined = source_dir.join(import_path);
-
-		// Normalize path components (resolve ../ and ./)
-		let normalized =
-			joined
-				.components()
-				.fold(PathBuf::new(), |mut acc, c| {
-					match c {
-						Component::ParentDir => {
-							acc.pop();
-						}
-						Component::CurDir => {}
-						Component::Normal(os) => {
-							acc.push(os);
-						}
-						_ => {}
-					}
-					acc
-				});
-
-		let normalized_str = normalized.to_string_lossy().to_string();
-		all_files.iter().find(|f| **f == normalized_str).cloned()
+		let resolved = resolve_relative_path(source_file, import_path)?;
+		PathNormalizer::find_path_in_collection(&resolved.to_string_lossy(), all_files)
+			.map(str::to_string)
 	}
 
 	fn get_file_extensions(&self) -> Vec<&'static str> {
@@ -157,18 +142,7 @@ External links are ignored: [Docs](https://docs.example.com/guide.md)
 Non-md links are ignored: [Image](./photo.png)
 "#;
 
-		// Test the regex logic directly (can't easily create tree-sitter Node in unit tests)
-		let link_re =
-			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();
-		let mut links = Vec::new();
-		for cap in link_re.captures_iter(content) {
-			if let Some(target) = cap.get(1) {
-				let path = target.as_str();
-				if !path.starts_with("http://") && !path.starts_with("https://") {
-					links.push(path.to_string());
-				}
-			}
-		}
+		let links = extract_markdown_links(content);
 
 		assert_eq!(links.len(), 3);
 		assert!(links.contains(&"../core-architecture/credit-suite.md".to_string()));
@@ -233,7 +207,10 @@ Non-md links are ignored: [Image](./photo.png)
 		);
 		assert_eq!(
 			resolved,
-			Some("projects/gearbox/autodocs-about/docs/core-architecture/credit-suite.md".to_string()),
+			Some(
+				"projects/gearbox/autodocs-about/docs/core-architecture/credit-suite.md"
+					.to_string()
+			),
 			"Same-dir link should resolve"
 		);
 
@@ -245,17 +222,17 @@ Non-md links are ignored: [Image](./photo.png)
 		);
 		assert_eq!(
 			resolved,
-			Some("projects/gearbox/autodocs-about/docs/introduction/credit-accounts.md".to_string()),
+			Some(
+				"projects/gearbox/autodocs-about/docs/introduction/credit-accounts.md".to_string()
+			),
 			"Parent-dir link should resolve"
 		);
 	}
 
 	#[test]
 	fn test_no_links_in_empty_doc() {
-		let link_re =
-			regex::Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").unwrap();
 		let content = "# Simple heading\nNo links here.";
-		let links: Vec<_> = link_re.captures_iter(content).collect();
+		let links = extract_markdown_links(content);
 		assert!(links.is_empty());
 	}
 }

--- a/src/indexer/languages/markdown.rs
+++ b/src/indexer/languages/markdown.rs
@@ -21,7 +21,8 @@ use std::sync::LazyLock;
 use tree_sitter::Node;
 
 static MARKDOWN_LINK_RE: LazyLock<Regex> = LazyLock::new(|| {
-	Regex::new(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)").expect("markdown link regex must be valid")
+	Regex::new(r"\[[^\]]*\]\(([^)]+\.(?:md|markdown))(?:#[^)]*)?\)")
+		.expect("markdown link regex must be valid")
 });
 
 fn extract_markdown_links(contents: &str) -> Vec<String> {
@@ -140,14 +141,16 @@ Also check [Pool](../core-architecture/pool.md#liquidity) and
 
 External links are ignored: [Docs](https://docs.example.com/guide.md)
 Non-md links are ignored: [Image](./photo.png)
+Long extension is kept: [Long](./manual.markdown)
 "#;
 
 		let links = extract_markdown_links(content);
 
-		assert_eq!(links.len(), 3);
+		assert_eq!(links.len(), 4);
 		assert!(links.contains(&"../core-architecture/credit-suite.md".to_string()));
 		assert!(links.contains(&"../core-architecture/pool.md".to_string()));
 		assert!(links.contains(&"./adapters.md".to_string()));
+		assert!(links.contains(&"./manual.markdown".to_string()));
 		assert!(!links.iter().any(|l| l.contains("https://")));
 		assert!(!links.iter().any(|l| l.contains(".png")));
 	}

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -45,6 +45,7 @@ use crate::config::Config;
 use crate::mcp::logging::{log_file_processing_error, log_indexing_progress};
 use crate::state;
 use crate::state::SharedState;
+use crate::store::CodeBlock;
 #[cfg(test)]
 use crate::store::DocumentBlock;
 use crate::store::Store;
@@ -1453,6 +1454,24 @@ pub async fn index_files_with_quiet(
 								state.clone(),
 							)
 							.await?;
+
+							// Also create a synthetic CodeBlock so GraphBuilder includes
+							// this file in the knowledge graph. The builder reads the file
+							// from disk and calls Markdown::extract_imports_exports for
+							// actual link extraction.
+							if config.graphrag.enabled {
+								all_code_blocks.push(CodeBlock {
+									path: file_path.to_string(),
+									language: "markdown".to_string(),
+									content: String::new(),
+									symbols: vec![],
+									start_line: 0,
+									end_line: contents.lines().count(),
+									hash: crate::embedding::calculate_content_hash(&contents),
+									distance: None,
+								});
+							}
+
 							file_processed = true;
 						} else {
 							// Handle code files - index as semantic code blocks only
@@ -1690,6 +1709,21 @@ pub async fn index_files_with_quiet(
 								state.clone(),
 							)
 							.await?;
+
+							// Also create a synthetic CodeBlock for GraphRAG
+							if config.graphrag.enabled {
+								all_code_blocks.push(CodeBlock {
+									path: file_path.to_string(),
+									language: "markdown".to_string(),
+									content: String::new(),
+									symbols: vec![],
+									start_line: 0,
+									end_line: contents.lines().count(),
+									hash: crate::embedding::calculate_content_hash(&contents),
+									distance: None,
+								});
+							}
+
 							file_processed = true;
 						} else {
 							// Handle code files - index as semantic code blocks only
@@ -2101,6 +2135,26 @@ pub async fn handle_file_change(store: &Store, file_path: &str, config: &Config)
 							&document_file_metadata,
 						)
 						.await?;
+					}
+
+					// Update GraphRAG for this markdown file
+					if config.graphrag.enabled {
+						let md_blocks = vec![CodeBlock {
+							path: relative_file_path.to_string(),
+							language: "markdown".to_string(),
+							content: String::new(),
+							symbols: vec![],
+							start_line: 0,
+							end_line: contents.lines().count(),
+							hash: crate::embedding::calculate_content_hash(&contents),
+							distance: None,
+						}];
+						let graph_builder =
+							graphrag::GraphBuilder::new_with_quiet(config.clone(), true)
+								.await?;
+						graph_builder
+							.process_code_blocks(&md_blocks, Some(state.clone()))
+							.await?;
 					}
 				} else {
 					// Handle code files

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -81,6 +81,19 @@ pub struct NoindexWalker;
 static NOINDEX_CACHE: OnceLock<parking_lot::RwLock<HashMap<std::path::PathBuf, bool>>> =
 	OnceLock::new();
 
+fn markdown_graphrag_block(file_path: &str, contents: &str) -> CodeBlock {
+	CodeBlock {
+		path: file_path.to_string(),
+		language: "markdown".to_string(),
+		content: contents.to_string(),
+		symbols: Vec::new(),
+		start_line: 0,
+		end_line: contents.lines().count(),
+		hash: crate::embedding::calculate_content_hash(contents),
+		distance: None,
+	}
+}
+
 impl NoindexWalker {
 	/// Creates a WalkBuilder that respects .gitignore and .noindex files
 	/// PERFORMANCE: Uses caching to avoid repeated .noindex detection
@@ -820,6 +833,10 @@ pub async fn index_branch_delta(
 								state.clone(),
 							)
 							.await?;
+
+							if config.graphrag.enabled {
+								all_code_blocks.push(markdown_graphrag_block(file_path, &contents));
+							}
 						} else {
 							process_file_differential(
 								&ctx,
@@ -1460,16 +1477,7 @@ pub async fn index_files_with_quiet(
 							// from disk and calls Markdown::extract_imports_exports for
 							// actual link extraction.
 							if config.graphrag.enabled {
-								all_code_blocks.push(CodeBlock {
-									path: file_path.to_string(),
-									language: "markdown".to_string(),
-									content: String::new(),
-									symbols: vec![],
-									start_line: 0,
-									end_line: contents.lines().count(),
-									hash: crate::embedding::calculate_content_hash(&contents),
-									distance: None,
-								});
+								all_code_blocks.push(markdown_graphrag_block(file_path, &contents));
 							}
 
 							file_processed = true;
@@ -1712,16 +1720,8 @@ pub async fn index_files_with_quiet(
 
 							// Also create a synthetic CodeBlock for GraphRAG
 							if config.graphrag.enabled {
-								all_code_blocks.push(CodeBlock {
-									path: file_path.to_string(),
-									language: "markdown".to_string(),
-									content: String::new(),
-									symbols: vec![],
-									start_line: 0,
-									end_line: contents.lines().count(),
-									hash: crate::embedding::calculate_content_hash(&contents),
-									distance: None,
-								});
+								all_code_blocks
+									.push(markdown_graphrag_block(&file_path, &contents));
 							}
 
 							file_processed = true;
@@ -2139,19 +2139,14 @@ pub async fn handle_file_change(store: &Store, file_path: &str, config: &Config)
 
 					// Update GraphRAG for this markdown file
 					if config.graphrag.enabled {
-						let md_blocks = vec![CodeBlock {
-							path: relative_file_path.to_string(),
-							language: "markdown".to_string(),
-							content: String::new(),
-							symbols: vec![],
-							start_line: 0,
-							end_line: contents.lines().count(),
-							hash: crate::embedding::calculate_content_hash(&contents),
-							distance: None,
-						}];
-						let graph_builder =
-							graphrag::GraphBuilder::new_with_quiet(config.clone(), true)
-								.await?;
+						let md_blocks =
+							vec![markdown_graphrag_block(&relative_file_path, &contents)];
+						let graph_builder = graphrag::GraphBuilder::new_with_quiet(
+							config.clone(),
+							&current_dir,
+							true,
+						)
+						.await?;
 						graph_builder
 							.process_code_blocks(&md_blocks, Some(state.clone()))
 							.await?;
@@ -2274,6 +2269,16 @@ pub async fn handle_file_change(store: &Store, file_path: &str, config: &Config)
 #[cfg(test)]
 mod context_optimization_tests {
 	use super::*;
+
+	#[test]
+	fn markdown_graphrag_blocks_preserve_content_for_change_detection() {
+		let original = markdown_graphrag_block("docs/guide.md", "# Guide\nOriginal");
+		let updated = markdown_graphrag_block("docs/guide.md", "# Guide\nUpdated");
+
+		assert_eq!(original.content, "# Guide\nOriginal");
+		assert_eq!(original.language, "markdown");
+		assert_ne!(original.hash, updated.hash);
+	}
 
 	#[test]
 	fn test_context_optimization() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -173,7 +173,9 @@ pub struct StructuralSearchParams {
 	pub references: Option<String>,
 	/// Language to search (required: rust, javascript, typescript, python, go, java, cpp, php, ruby, swift, lua, bash, css, json)
 	pub language: String,
-	/// File paths or glob patterns to search (default: current directory)
+	/// Narrow the search to matching files. Each entry is either a path
+	/// substring (`src/mcp`, `server.rs`) or a glob (`src/**/*.rs`), relative
+	/// to the repo root. Default: all files of the language.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub paths: Option<Vec<String>>,
 	/// Only keep matches INSIDE a node matching this kind name or pattern
@@ -602,6 +604,23 @@ impl McpServer {
 			&prefilter_tokens,
 		);
 
+		// Zero candidate files means the language/paths combination selected
+		// nothing — tell the LLM exactly which knob to turn instead of letting
+		// the strategy chain produce a generic "no matches" diagnostic.
+		if files.is_empty() {
+			let paths_desc = params
+				.paths
+				.as_ref()
+				.map(|p| format!(" matching paths {:?}", p))
+				.unwrap_or_default();
+			return Ok(format!(
+				"No {} files found{}. Check that `language` matches the file extensions \
+				 (e.g. .ts → typescript, .tsx → typescript) and that `paths` entries are \
+				 substrings or globs relative to the repo root (e.g. `src/mcp` or `src/**/*.rs`).",
+				language, paths_desc
+			));
+		}
+
 		// Rewrite mode: separate path, no caching.
 		if let Some(ref rewrite_template) = params.rewrite {
 			return self.structural_rewrite(
@@ -714,6 +733,11 @@ fn format_structural_response(
 			offset, total
 		);
 	}
+	let file_count = {
+		let files_hit: std::collections::HashSet<&str> =
+			matches.iter().map(|m| m.file.as_str()).collect();
+		files_hit.len()
+	};
 	let end = (offset + max_results).min(total);
 	let page = &matches[offset..end];
 
@@ -746,11 +770,12 @@ fn format_structural_response(
 			""
 		};
 		out.push_str(&format!(
-			"\n\nShowing {}–{} of {}{} matches.",
+			"\n\nShowing {}–{} of {}{} matches across {} files.",
 			offset + 1,
 			end,
 			total,
-			capped
+			capped,
+			file_count
 		));
 		if end < total {
 			out.push_str(&format!(
@@ -759,7 +784,7 @@ fn format_structural_response(
 			));
 		}
 	} else {
-		out.push_str(&format!("\n\n{} matches found.", total));
+		out.push_str(&format!("\n\n{} matches in {} files.", total, file_count));
 	}
 	if let Some(d) = diagnostic {
 		out.push_str("\n\n");

--- a/src/mcp/structural.rs
+++ b/src/mcp/structural.rs
@@ -93,6 +93,37 @@ pub fn fingerprint_request(parts: &[&str]) -> u64 {
 	h.finish()
 }
 
+/// One compiled `paths` filter entry: glob when the spec contains glob
+/// metacharacters, plain substring otherwise. Substring keeps the forgiving
+/// "src/mcp" style working; glob honors the documented `src/**/*.rs` style,
+/// which a substring check would silently reject (zero files, zero matches).
+enum PathSpec {
+	Substring(String),
+	Glob(globset::GlobMatcher),
+}
+
+impl PathSpec {
+	fn compile(spec: &str) -> Self {
+		if spec.contains(['*', '?', '[']) {
+			match globset::Glob::new(spec) {
+				Ok(g) => PathSpec::Glob(g.compile_matcher()),
+				// Invalid glob — fall back to substring so a stray `[` never
+				// silently empties the candidate set.
+				Err(_) => PathSpec::Substring(spec.to_string()),
+			}
+		} else {
+			PathSpec::Substring(spec.to_string())
+		}
+	}
+
+	fn matches(&self, display: &str) -> bool {
+		match self {
+			PathSpec::Substring(s) => display.contains(s.as_str()),
+			PathSpec::Glob(g) => g.is_match(display),
+		}
+	}
+}
+
 /// Collect candidate files via a parallel gitignore-aware walk. Reads file
 /// contents (needed by every later stage) and evaluates the literal-token
 /// prefilter inline. Returns files sorted by display path plus the repo stamp.
@@ -102,6 +133,10 @@ pub fn collect_file_data(
 	paths_filter: Option<&[String]>,
 	prefilter_tokens: &[String],
 ) -> (Vec<FileData>, RepoStamp) {
+	let compiled_filter: Option<Vec<PathSpec>> =
+		paths_filter.map(|ps| ps.iter().map(|p| PathSpec::compile(p)).collect());
+	// `Option<&[PathSpec]>` is Copy — safe to move into each per-thread closure.
+	let filter_ref = compiled_filter.as_deref();
 	let acc: parking_lot::Mutex<(Vec<FileData>, RepoStamp)> =
 		parking_lot::Mutex::new((Vec::new(), RepoStamp::default()));
 
@@ -131,8 +166,8 @@ pub fn collect_file_data(
 				.unwrap_or(path)
 				.to_string_lossy()
 				.to_string();
-			if let Some(filter) = paths_filter {
-				if !filter.iter().any(|p| display.contains(p)) {
+			if let Some(filter) = filter_ref {
+				if !filter.iter().any(|p| p.matches(&display)) {
 					return ignore::WalkState::Continue;
 				}
 			}

--- a/src/store/graphrag.rs
+++ b/src/store/graphrag.rs
@@ -479,30 +479,31 @@ impl<'a> GraphRagOperations<'a> {
 		if self.table_ops.table_exists(tables::DOCUMENT_BLOCKS).await? {
 			let doc_table = self.get_table(tables::DOCUMENT_BLOCKS).await?;
 			let mut doc_results = doc_table.query().execute().await?;
-
-			let mut seen_md_paths = std::collections::HashSet::new();
-			// Collect paths already covered by code blocks
-			for block in &all_blocks {
-				seen_md_paths.insert(block.path.clone());
-			}
+			let code_block_paths: std::collections::HashSet<String> =
+				all_blocks.iter().map(|block| block.path.clone()).collect();
+			let mut markdown_paths = std::collections::HashSet::new();
 
 			while let Some(batch) = doc_results.try_next().await? {
 				if batch.num_rows() > 0 {
 					let converter =
 						crate::store::batch_converter::BatchConverter::new(self.code_vector_dim);
 					let doc_blocks = converter.batch_to_document_blocks(&batch, None)?;
-					for doc in &doc_blocks {
-						if doc.path.ends_with(".md") && seen_md_paths.insert(doc.path.clone()) {
-							// Create a synthetic CodeBlock so GraphBuilder processes
-							// this markdown file for nodes and cross-references
+					for doc in doc_blocks {
+						let is_markdown =
+							doc.path.ends_with(".md") || doc.path.ends_with(".markdown");
+						if is_markdown && !code_block_paths.contains(&doc.path) {
+							markdown_paths.insert(doc.path.clone());
+							// Preserve every document chunk. GraphBuilder groups them by
+							// path and hashes their combined content, so markdown edits are
+							// visible to incremental GraphRAG processing.
 							all_blocks.push(crate::store::CodeBlock {
-								path: doc.path.clone(),
+								path: doc.path,
 								language: "markdown".to_string(),
-								content: String::new(),
-								symbols: vec![],
-								start_line: 0,
+								content: doc.content,
+								symbols: Vec::new(),
+								start_line: doc.start_line,
 								end_line: doc.end_line,
-								hash: doc.hash.clone(),
+								hash: doc.hash,
 								distance: None,
 							});
 						}
@@ -512,7 +513,7 @@ impl<'a> GraphRagOperations<'a> {
 
 			tracing::debug!(
 				"Added {} markdown files from document_blocks for GraphRAG",
-				seen_md_paths.len().saturating_sub(all_blocks.len())
+				markdown_paths.len()
 			);
 		}
 

--- a/src/store/graphrag.rs
+++ b/src/store/graphrag.rs
@@ -904,9 +904,9 @@ impl<'a> GraphRagOperations<'a> {
 		} else if all_batches.len() == 1 {
 			Ok(all_batches.into_iter().next().unwrap())
 		} else {
-			// For simplicity, return the first batch
-			// In a production system, you might want to concatenate all batches
-			Ok(all_batches.into_iter().next().unwrap())
+			// Concatenate all batches into one
+			let schema = all_batches[0].schema();
+			Ok(arrow::compute::concat_batches(&schema, &all_batches)?)
 		}
 	}
 

--- a/src/store/graphrag.rs
+++ b/src/store/graphrag.rs
@@ -446,32 +446,74 @@ impl<'a> GraphRagOperations<'a> {
 	pub async fn get_all_code_blocks_for_graphrag(&self) -> Result<Vec<CodeBlock>> {
 		let mut all_blocks = Vec::new();
 
-		if !self.table_ops.table_exists(tables::CODE_BLOCKS).await? {
-			return Ok(all_blocks);
-		}
+		if self.table_ops.table_exists(tables::CODE_BLOCKS).await? {
+			let table = self.get_table(tables::CODE_BLOCKS).await?;
 
-		let table = self.get_table(tables::CODE_BLOCKS).await?;
+			// Get all code blocks in batches to avoid memory issues
+			let mut results = table.query().execute().await?;
 
-		// Get all code blocks in batches to avoid memory issues
-		let mut results = table.query().execute().await?;
+			// Process all result batches
+			while let Some(batch) = results.try_next().await? {
+				if batch.num_rows() > 0 {
+					// Convert batch to CodeBlocks
+					let converter =
+						crate::store::batch_converter::BatchConverter::new(self.code_vector_dim);
+					let mut code_blocks = converter.batch_to_code_blocks(&batch, None)?;
+					all_blocks.append(&mut code_blocks);
 
-		// Process all result batches
-		while let Some(batch) = results.try_next().await? {
-			if batch.num_rows() > 0 {
-				// Convert batch to CodeBlocks
-				let converter =
-					crate::store::batch_converter::BatchConverter::new(self.code_vector_dim);
-				let mut code_blocks = converter.batch_to_code_blocks(&batch, None)?;
-				all_blocks.append(&mut code_blocks);
-
-				// Log progress for large datasets
-				if cfg!(debug_assertions) && all_blocks.len() % 1000 == 0 {
-					tracing::debug!(
-						"Loaded {} code blocks for GraphRAG processing...",
-						all_blocks.len()
-					);
+					// Log progress for large datasets
+					if cfg!(debug_assertions) && all_blocks.len() % 1000 == 0 {
+						tracing::debug!(
+							"Loaded {} code blocks for GraphRAG processing...",
+							all_blocks.len()
+						);
+					}
 				}
 			}
+		}
+
+		// Also include markdown files from document_blocks so they get GraphRAG
+		// nodes and cross-reference relationships. Document blocks are stored
+		// separately from code blocks, so without this, markdown files would be
+		// invisible to GraphRAG when rebuilding from existing database.
+		if self.table_ops.table_exists(tables::DOCUMENT_BLOCKS).await? {
+			let doc_table = self.get_table(tables::DOCUMENT_BLOCKS).await?;
+			let mut doc_results = doc_table.query().execute().await?;
+
+			let mut seen_md_paths = std::collections::HashSet::new();
+			// Collect paths already covered by code blocks
+			for block in &all_blocks {
+				seen_md_paths.insert(block.path.clone());
+			}
+
+			while let Some(batch) = doc_results.try_next().await? {
+				if batch.num_rows() > 0 {
+					let converter =
+						crate::store::batch_converter::BatchConverter::new(self.code_vector_dim);
+					let doc_blocks = converter.batch_to_document_blocks(&batch, None)?;
+					for doc in &doc_blocks {
+						if doc.path.ends_with(".md") && seen_md_paths.insert(doc.path.clone()) {
+							// Create a synthetic CodeBlock so GraphBuilder processes
+							// this markdown file for nodes and cross-references
+							all_blocks.push(crate::store::CodeBlock {
+								path: doc.path.clone(),
+								language: "markdown".to_string(),
+								content: String::new(),
+								symbols: vec![],
+								start_line: 0,
+								end_line: doc.end_line,
+								hash: doc.hash.clone(),
+								distance: None,
+							});
+						}
+					}
+				}
+			}
+
+			tracing::debug!(
+				"Added {} markdown files from document_blocks for GraphRAG",
+				seen_md_paths.len().saturating_sub(all_blocks.len())
+			);
 		}
 
 		Ok(all_blocks)


### PR DESCRIPTION
## Summary

Supersedes #39 so the maintainers can finalize and merge the work from a Muvon-owned branch.

Original implementation and all nine original commits are preserved with authorship by @de-snake. Thank you for the document GraphRAG work.

This adds markdown document nodes and directional `References` relationships for local `.md` links, including rebuilds from existing `document_blocks`.

## Finalization against current master

- Merged the latest `master` while preserving its indexed relationship-discovery optimizations.
- Fixed cross-platform markdown path resolution, including the previous Windows failure mode.
- Added markdown nodes to the newer branch-delta indexing path.
- Preserved markdown content in synthetic GraphRAG blocks so document edits change the node hash and trigger reprocessing.
- Kept markdown links as directional `References` edges rather than leaking code `Imports` edges.
- Updated the watcher path for the current `GraphBuilder::new_with_quiet` API.
- Preserved all document chunks during GraphRAG rebuilds and retained support for `.markdown` documents.

## Validation

- `cargo test --no-default-features --all-targets` — 335 passed
- `cargo clippy --no-default-features --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- Focused markdown and GraphRAG regression suite after the final master merge — 18 passed

GitHub CI is the final authority for the all-features and platform matrix.