### PR TITLE
feat(indexer): implement branch-aware indexing

### DIFF
--- a/src/indexer/branch.rs
+++ b/src/indexer/branch.rs
@@ -172,9 +172,10 @@ pub struct MasterState {
 	/// against the local ref because pulling is a workspace action that
 	/// belongs to the user.
 	pub local_behind_remote: bool,
-	/// `Some(n)` if the main DB was re-indexed by reconcile because the DB
-	/// commit didn't match the local ref. `None` when no master reindex was
-	/// triggered (DB already current, or no main DB exists yet).
+	/// `Some(commit)` if reconcile baselined an empty main DB (the commit it
+	/// was stamped with — HEAD of the working tree at index time). `None`
+	/// when the main DB already existed; a stale main DB is never re-indexed
+	/// from a branch checkout.
 	pub db_resynced_to: Option<String>,
 }
 
@@ -184,14 +185,14 @@ pub struct MasterState {
 /// 1. Read the default branch name, local ref, and (best-effort) remote ref.
 /// 2. Compute the fork-point between local default branch and `HEAD`.
 /// 3. Read the main DB's last indexed commit.
-/// 4. If DB commit != local ref commit: re-index the main store so the branch
-///    DB lays on top of a coherent main snapshot. This is the "always index up
-///    to master before branching" guarantee — silent skip is what got the
-///    `conversation_compression/` files lost in the first place.
+/// 4. If the main DB is empty: run a full index as a baseline (stamped with
+///    HEAD — the branch working tree is all we can see from here). If it is
+///    non-empty but stale vs the local ref: warn only; re-indexing from a
+///    branch checkout cannot produce a default-branch snapshot.
 /// 5. Surface (don't auto-fix) `local < remote` divergence. Pulling is a
 ///    user workspace action; we won't run it implicitly.
 ///
-/// Pass `main_store` so we can resynchronize when needed.
+/// Pass `main_store` so we can baseline an empty main DB when needed.
 pub async fn reconcile_master_state(
 	main_store: &crate::store::Store,
 	state: crate::state::SharedState,
@@ -251,23 +252,36 @@ pub async fn reconcile_master_state(
 	// recorded yet", which would silently trigger a full reindex/resync.
 	let db_commit = main_store.get_last_commit_hash().await?;
 
+	// Baseline an EMPTY main DB only. When the main DB exists but sits at a
+	// different commit than the default-branch ref, we must NOT re-index it
+	// from here: the working tree is the feature branch, so a "resync" would
+	// write branch content into the main DB stamped with the branch commit —
+	// the mismatch would then be detected again on every run, forcing a full
+	// branch-delta rebuild each time. The overlay instead anchors to whatever
+	// commit the main DB actually holds (via `base_db_commit`), and we warn
+	// when that snapshot is neither the default-branch ref nor current HEAD.
 	let db_resynced_to = match &db_commit {
-		Some(db) if db == &local_ref_commit => None,
-		_ => {
+		Some(db) => {
+			let head_commit = GitUtils::get_current_commit_hash(git_repo_root).ok();
+			if db != &local_ref_commit && head_commit.as_ref() != Some(db) && !quiet {
+				eprintln!(
+					"⚠️  Main index is at {} but local '{}' is at {} — the branch \
+					 overlay stays anchored to the indexed snapshot. Checkout '{}' \
+					 and re-index to refresh the main index.",
+					&db[..db.len().min(8)],
+					branch_name,
+					&local_ref_commit[..local_ref_commit.len().min(8)],
+					branch_name,
+				);
+			}
+			None
+		}
+		None => {
 			if !quiet {
-				match &db_commit {
-					Some(prev) => println!(
-						"🔄 Main index at {} but local '{}' is at {} — resyncing main \
-						 index before computing branch delta.",
-						&prev[..prev.len().min(8)],
-						branch_name,
-						&local_ref_commit[..local_ref_commit.len().min(8)],
-					),
-					None => println!(
-						"🔄 Main index empty — running a full main index before computing \
-						 branch delta."
-					),
-				}
+				println!(
+					"🔄 Main index empty — running a full main index before computing \
+					 branch delta."
+				);
 			}
 			super::index_files_with_quiet(
 				main_store,
@@ -279,14 +293,17 @@ pub async fn reconcile_master_state(
 			.await
 			.map_err(|e| {
 				anyhow::anyhow!(
-					"Main index resync failed while preparing branch delta for '{}': {}. \
+					"Main index baseline failed while preparing branch delta for '{}': {}. \
 						 Branch indexing aborted — main DB is left in its previous state.",
 					branch_name,
 					e
 				)
 			})?;
 			main_store.flush().await?;
-			Some(local_ref_commit.clone())
+			// The baseline indexed the current working tree and was stamped
+			// with HEAD (the branch commit), not the default-branch ref —
+			// re-read what was actually stored so the manifest stays coherent.
+			main_store.get_last_commit_hash().await?
 		}
 	};
 

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -599,19 +599,28 @@ pub async fn index_branch_delta(
 	let current_dir = state.read().current_directory.clone();
 
 	// Reconcile master state BEFORE computing branch delta. This guarantees:
-	//   - The main index matches the local default-branch ref (resyncs if not),
-	//     so the branch DB lays on top of a coherent main snapshot.
+	//   - An empty main DB gets a baseline index so the overlay has something
+	//     to sit on; a non-empty main DB is left untouched (re-indexing it from
+	//     a branch checkout can't produce a default-branch snapshot) and the
+	//     overlay anchors to the commit it actually holds.
 	//   - A loud warning surfaces if `origin/<default>` is ahead of local — we
 	//     don't auto-pull (workspace action), we just refuse to be silent.
-	// If the resync itself fails, the error propagates and the branch index is
-	// not written, so we never end up with a branch DB anchored to a missing
+	// If the baseline itself fails, the error propagates and the branch index
+	// is not written, so we never end up with a branch DB anchored to a missing
 	// main snapshot.
 	let master_state =
 		branch::reconcile_master_state(main_store, state.clone(), config, git_repo_root, quiet)
 			.await?;
 
 	let default_branch = master_state.branch_name.clone();
-	let base_db_commit = master_state.local_ref_commit.clone();
+	// Anchor to the commit the main DB actually holds — that's what the
+	// search-time coherence check compares against. On a feature branch it
+	// legitimately differs from the default-branch ref.
+	let base_db_commit = master_state
+		.db_resynced_to
+		.clone()
+		.or_else(|| master_state.db_commit.clone())
+		.unwrap_or_default();
 	let remote_base_observed = master_state.remote_ref_commit.clone().unwrap_or_default();
 
 	// Reset state counters that may have been advanced by a master resync
@@ -638,8 +647,8 @@ pub async fn index_branch_delta(
 	// every one of them invalidates the assumptions the branch DB was built on:
 	//   - default branch renamed (override mapping is keyed off it)
 	//   - main DB moved to a different commit (overlay would be incoherent)
-	//   - we just resynced main (any prior branch DB was built against the
-	//     stale main snapshot; throw it away rather than serve mixed content)
+	//   - main DB was just baselined from empty (any prior branch DB was
+	//     built against a snapshot that no longer exists)
 	let force_rebuild = existing_manifest.as_ref().is_some_and(|m| {
 		m.base_branch != default_branch
 			|| (!m.base_db_commit.is_empty() && m.base_db_commit != base_db_commit)
@@ -683,7 +692,8 @@ pub async fn index_branch_delta(
 	}
 
 	let branch_commit = branch::get_branch_commit(git_repo_root, "HEAD")?;
-	let base_commit = base_db_commit.clone();
+	// Manifest's legacy field: default-branch tip at index time (informational).
+	let base_commit = master_state.local_ref_commit.clone();
 
 	// Check if we can skip (same branch commit, no working changes)
 	if !force_rebuild {
@@ -707,44 +717,47 @@ pub async fn index_branch_delta(
 	// Determine which files to actually re-process
 	let files_to_process: std::collections::HashSet<String> = if !force_rebuild {
 		if let Some(ref manifest) = existing_manifest {
-			// Incremental: find what changed since last branch index
 			let old_changed: std::collections::HashSet<&str> =
 				manifest.changed_paths.iter().map(|s| s.as_str()).collect();
 			let new_changed: std::collections::HashSet<&str> =
 				changed_files.iter().map(|s| s.as_str()).collect();
 
 			// Files no longer in delta (reverted to match main) — remove from branch DB
+			let mut removed_any = false;
 			for path in old_changed.difference(&new_changed) {
-				if let Err(e) = branch_store.remove_blocks_by_path(path).await {
-					tracing::warn!(path = %path, error = %e, "Failed to remove reverted file from branch DB");
-				}
-			}
-
-			// Files to process: new in delta OR changed since last branch index
-			if manifest.branch_commit != branch_commit {
-				// Commits changed — find files modified since last indexed branch commit
-				match git::get_changed_files_since_commit(git_repo_root, &manifest.branch_commit) {
-					Ok(since_last) => {
-						let since_set: std::collections::HashSet<String> =
-							since_last.into_iter().collect();
-						// Only re-process files that are in the delta AND changed since last index
-						changed_files
-							.into_iter()
-							.filter(|f| {
-								since_set.contains(f.as_str()) || !old_changed.contains(f.as_str())
-							})
-							.collect()
+				match branch_store.remove_blocks_by_path(path).await {
+					Ok(()) => removed_any = true,
+					Err(e) => {
+						tracing::warn!(path = %path, error = %e, "Failed to remove reverted file from branch DB")
 					}
-					Err(_) => changed_files.into_iter().collect(),
 				}
-			} else {
-				// Same commit but working tree changes — process all changed files
-				changed_files.into_iter().collect()
 			}
-		} else {
-			// No existing manifest — process everything
-			changed_files.into_iter().collect()
+			// Persist removals even when nothing else needs re-processing —
+			// the batch flush below only runs when files get processed.
+			if removed_any {
+				branch_store.flush().await?;
+			}
 		}
+
+		// Re-process only delta files whose mtime moved past what the branch DB
+		// already indexed — same skip rule as the main index path (deleting a
+		// file's blocks also deletes its metadata row, so a scrubbed file is
+		// never wrongly skipped). Without this, every trigger re-embeds the
+		// ENTIRE delta: one saved file would reprocess all N changed files, and
+		// a commit would re-embed files already indexed at save time.
+		let branch_meta = branch_store.get_all_file_metadata().await?;
+		changed_files
+			.into_iter()
+			.filter(|f| {
+				match (
+					get_file_mtime(&current_dir.join(f)),
+					branch_meta.get(f.as_str()),
+				) {
+					(Ok(actual), Some(stored)) => actual > *stored,
+					_ => true,
+				}
+			})
+			.collect()
 	} else {
 		// Force rebuild — process everything
 		changed_files.into_iter().collect()
@@ -1953,11 +1966,10 @@ pub async fn index_files_with_quiet(
 		// Check if we have new blocks from this indexing run OR if GraphRAG needs building from existing database
 		let needs_graphrag_from_existing = if all_code_blocks.is_empty() {
 			// No new blocks from this run - check if we have existing blocks in database to build from
-			// This handles the case where GraphRAG is enabled after database is already indexed
-			let existing_blocks = store
-				.get_all_code_blocks_for_graphrag()
-				.await
-				.unwrap_or_default();
+			// This handles the case where GraphRAG is enabled after database is already indexed.
+			// Check the cheap row-count flag FIRST: `get_all_code_blocks_for_graphrag`
+			// loads the entire code_blocks table into memory, which on steady-state
+			// runs (all files skipped) is a large allocation for a boolean.
 			let needs_indexing = match store.graphrag_needs_indexing().await {
 				Ok(v) => v,
 				Err(e) => {
@@ -1968,7 +1980,15 @@ pub async fn index_files_with_quiet(
 					false
 				}
 			};
-			!existing_blocks.is_empty() && needs_indexing
+			if needs_indexing {
+				let existing_blocks = store
+					.get_all_code_blocks_for_graphrag()
+					.await
+					.unwrap_or_default();
+				!existing_blocks.is_empty()
+			} else {
+				false
+			}
 		} else {
 			false // We have new blocks, process them normally
 		};

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1406,7 +1406,7 @@ pub(crate) async fn perform_indexing(
 	// forcing full rebuilds on every subsequent branch index.
 	let branch_context = git_repo_root
 		.as_deref()
-		.and_then(|r| indexer::branch::detect_branch_context(r));
+		.and_then(indexer::branch::detect_branch_context);
 
 	let indexing_result = match branch_context {
 		Some(branch_name) => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1399,14 +1399,46 @@ pub(crate) async fn perform_indexing(
 		None
 	};
 
-	let indexing_result = indexer::index_files_with_quiet(
-		store,
-		state.clone(),
-		config,
-		git_repo_root.as_deref(),
-		true,
-	)
-	.await;
+	// Mirror the CLI index/watch flow: on a non-default branch, index the
+	// delta into the branch store. Writing the main store from a branch
+	// checkout would replace default-branch content with branch content and
+	// stamp the main DB with the branch commit — corrupting the overlay and
+	// forcing full rebuilds on every subsequent branch index.
+	let branch_context = git_repo_root
+		.as_deref()
+		.and_then(|r| indexer::branch::detect_branch_context(r));
+
+	let indexing_result = match branch_context {
+		Some(branch_name) => {
+			async {
+				let branch_store =
+					Store::new_for_branch_at(working_directory, &branch_name).await?;
+				branch_store.initialize_collections().await?;
+				indexer::index_branch_delta(
+					store,
+					&branch_store,
+					state.clone(),
+					config,
+					git_repo_root.as_deref().unwrap(),
+					&branch_name,
+					true,
+				)
+				.await?;
+				branch_store.flush().await
+			}
+			.await
+		}
+		None => {
+			indexer::index_files_with_quiet(
+				store,
+				state.clone(),
+				config,
+				git_repo_root.as_deref(),
+				true,
+			)
+			.await
+		}
+	};
 
 	lock.release()?;
 	debug!("MCP server: released indexing lock");

--- a/src/watcher_config.rs
+++ b/src/watcher_config.rs
@@ -102,6 +102,16 @@ impl IgnorePatterns {
 
 	/// Check if a path should be ignored during file watching
 	pub fn should_ignore_path(&self, path: &Path) -> bool {
+		// Never react to .git internals: git touches its metadata constantly
+		// (`git status` refreshes the index, fetch writes FETCH_HEAD, lock
+		// files come and go) and none of it changes indexable content —
+		// without this every git invocation triggers a debounced reindex.
+		// Working-tree files still change on checkout/merge, so those events
+		// arrive from the files themselves.
+		if path.components().any(|c| c.as_os_str() == ".git") {
+			return true;
+		}
+
 		let path_str = path.to_string_lossy();
 
 		// Get relative path from working directory


### PR DESCRIPTION
- Index deltas into branch stores for non-default branches
- Prevent incorrect main DB re-indexing during branch reconciliation
- Perform full index baseline only when the main DB is empty
- Anchor branch DB to actual main store commit hashes
- Use mtime checks for delta files to avoid redundant reprocessing
- Ensure branch store flushes when removing reverted files
- Optimize GraphRAG block loading efficiency
- Improve manifest coherence using HEAD hash for storage consistency
- Ignore .git internal directory in file watcher to reduce noise
- Add warnings for main index commit mismatches with local references