### PR TITLE
feat(graphrag): implement symbol-tier extraction and provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ AI: *uses LSP find-references* "process_payment() is called from 4 places:
 octocode search "authentication middleware"
 → src/middleware/auth.rs | Similarity 0.923
 
-# GraphRAG reveals the full dependency chain
-octocode graphrag get-relationships --node_id src/middleware/auth.rs
+# The GraphRAG CLI queries the optional persisted graph
+octocode config --graphrag-enabled true
+octocode index
+octocode graphrag get-relationships --node-id src/middleware/auth.rs
 Outgoing:
   imports → jwt (src/auth/jwt.rs): token validation logic
   calls   → user_store (src/db/user_store.rs): user lookup by token
@@ -78,20 +80,21 @@ Incoming:
   imports ← router (src/router.rs): wires auth into the request pipeline
 ```
 
-Octocode uses **tree-sitter AST parsing** to extract real symbols (functions, imports, dependencies), builds a **GraphRAG knowledge graph** of relationships between files, and exposes everything via **MCP** — so AI tools can *navigate* your project architecture, not just search it.
+Octocode uses **tree-sitter AST parsing** to build a live graph of files, symbols, imports, calls, inheritance, and implementations. The MCP `graphrag` tool builds this graph lazily from the current source tree, without an index, embeddings, or an LLM. Optional indexed GraphRAG adds semantic file discovery, descriptions, and broader architectural relationships.
 
 ## 🔬 How It Works
 
 ```
-Source Code → Tree-sitter AST → Symbols & Relationships → Knowledge Graph
-                                        ↓
-                    Embeddings + Hybrid Search + Reranking → MCP Server
+Current Source → Tree-sitter AST → Live Symbol Graph ──────────────→ MCP `graphrag`
+                                           ↑                              ↑
+Indexed Code → Embeddings + Optional LLM → Persisted File Enrichment ─────┘
 ```
 
-1. **AST Parsing** — tree-sitter extracts real code symbols (functions, classes, imports), not arbitrary text chunks
-2. **Knowledge Graph** — GraphRAG maps relationships between files: `imports`, `calls`, `implements`, `extends`, `configures`, and 9 more types — each with importance weighting
-3. **Hybrid Search** — semantic similarity + BM25 full-text search + reranking — not just vector embeddings
-4. **MCP Server** — exposes `semantic_search`, `view_signatures`, and `graphrag` tools to any MCP-compatible client
+1. **Live AST Graph** — tree-sitter extracts file and symbol nodes plus deterministic `contains`, `imports`, `calls`, `extends`, and `implements` relationships directly from current source
+2. **Always-on Graph Navigation** — MCP graph lookup, relationship traversal, path finding, and overview work with `[graphrag].enabled = false`
+3. **Optional Enrichment** — enabling indexed GraphRAG overlays semantic file matches, LLM descriptions, and broader file-level architectural relationships; symbols are never embedded or LLM-generated
+4. **Hybrid Search** — semantic similarity + BM25 full-text search + reranking handles meaning-based code retrieval separately
+5. **MCP Server** — exposes `semantic_search`, `view_signatures`, `graphrag`, and `structural_search` to any MCP-compatible client
 
 ## ✨ What Makes It Different
 
@@ -239,7 +242,7 @@ Octocode includes a **built-in MCP server** that exposes your codebase as tools 
 |------|--------------|
 | `semantic_search` | Find code by meaning — "authentication flow", "error handling", "database queries" |
 | `view_signatures` | View file structure — function signatures, class definitions, imports |
-| `graphrag` | Query relationships — "what calls this function?", "what does this module import?" |
+| `graphrag` | Always-on file/symbol graph — search nodes, inspect relationships, and find paths without indexing |
 | `structural_search` | AST pattern matching — find `.unwrap()` calls, `new` instantiations, specific patterns |
 | `lsp_goto_definition` | Jump to a symbol's definition (requires `--with-lsp`) |
 | `lsp_find_references` | Find all usages of a symbol across the workspace (requires `--with-lsp`) |

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -107,8 +107,8 @@ text_model = "fastembed:nomic-ai/nomic-embed-text-v1.5"
 # JINA_API_KEY, VOYAGE_API_KEY, GOOGLE_API_KEY
 
 [graphrag]
-# The lightweight Tree-sitter symbol graph is always available through MCP.
-# This flag enables the persisted GraphRAG layer used for indexed enrichment.
+# The lightweight Tree-sitter file/symbol graph is always available through MCP.
+# This flag enables the persisted GraphRAG layer used for indexed enrichment and CLI graph commands.
 enabled = false
 # Optional LLM enrichment for the persisted graph; ignored when enabled = false.
 use_llm = false

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -110,6 +110,16 @@ text_model = "fastembed:nomic-ai/nomic-embed-text-v1.5"
 enabled = false
 use_llm = false
 
+[graphrag.symbols]
+# Symbol-tier GraphRAG: one graph node per declared symbol (function, class,
+# struct, trait, ...) extracted via tree-sitter — no LLM required.
+# Symbol nodes get "{file_path}::{symbol_name}" ids, link to their file via
+# "contains" edges, and calls/extends/implements between symbols become edges.
+enabled = true
+# Generate vector embeddings for symbol nodes (one embedding call per symbol).
+# When false, symbol nodes are stored with zero vectors and match by name/kind only.
+embed = false
+
 [graphrag.llm]
 # Models for GraphRAG AI enhancements in provider:model format
 description_model = "openrouter:openai/gpt-4o-mini"

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -107,18 +107,11 @@ text_model = "fastembed:nomic-ai/nomic-embed-text-v1.5"
 # JINA_API_KEY, VOYAGE_API_KEY, GOOGLE_API_KEY
 
 [graphrag]
+# The lightweight Tree-sitter symbol graph is always available through MCP.
+# This flag enables the persisted GraphRAG layer used for indexed enrichment.
 enabled = false
+# Optional LLM enrichment for the persisted graph; ignored when enabled = false.
 use_llm = false
-
-[graphrag.symbols]
-# Symbol-tier GraphRAG: one graph node per declared symbol (function, class,
-# struct, trait, ...) extracted via tree-sitter — no LLM required.
-# Symbol nodes get "{file_path}::{symbol_name}" ids, link to their file via
-# "contains" edges, and calls/extends/implements between symbols become edges.
-enabled = true
-# Generate vector embeddings for symbol nodes (one embedding call per symbol).
-# When false, symbol nodes are stored with zero vectors and match by name/kind only.
-embed = false
 
 [graphrag.llm]
 # Models for GraphRAG AI enhancements in provider:model format

--- a/doc/ADVANCED_USAGE.md
+++ b/doc/ADVANCED_USAGE.md
@@ -293,7 +293,7 @@ octocode mcp --path /path/to/your/project --with-lsp "typescript-language-server
 |------|-------------|------------|
 | **semantic_search** | Semantic code search across the codebase (supports multi-query) | `query` (string or array), `mode` (string: all/code/docs/text/commits), `detail_level` (string), `max_results` (integer) |
 | **view_signatures** | View file signatures and code structure | `files` (array of file paths or glob patterns) |
-| **graphrag** | Advanced GraphRAG operations: search, get-node, get-relationships, find-path, overview | `operation` (string), `query` (string), `node_id` (string), `source_id` (string), `target_id` (string), `max_depth` (integer), `format` (string) |
+| **graphrag** | Always-on live file/symbol graph: search, get-node, get-relationships, find-path, overview | `operation` (string), `query` (string), `node_id` (string), `source_id` (string), `target_id` (string), `max_depth` (integer), `format` (string) |
 | **structural_search** | AST-based structural code search using ast-grep patterns | `pattern` (string), `language` (string), `paths` (array), `context` (integer), `max_results` (integer) |
 
 #### semantic_search Tool Details
@@ -508,6 +508,15 @@ octocode view "src/**/*.rs" --md
 ```
 
 ## Knowledge Graph Operations
+
+The MCP `graphrag` tool always builds a lightweight Tree-sitter graph from current source. It requires no index, embeddings, or LLM and supports file IDs plus symbol IDs such as `src/auth/service.rs::AuthService::authenticate`. Its baseline edges are `contains`, `imports`, `calls`, `extends`, and `implements`.
+
+The commands below use the persisted GraphRAG database instead. Enable and build it first:
+
+```bash
+octocode config --graphrag-enabled true
+octocode index
+```
 
 ### Basic GraphRAG Commands
 

--- a/doc/API_KEYS.md
+++ b/doc/API_KEYS.md
@@ -111,7 +111,7 @@ octocode config \
 
 ## Optional: LLM Provider
 
-For AI-powered features like commit messages, code review, and GraphRAG descriptions.
+For AI-powered features like commit messages, code review, and optional persisted GraphRAG descriptions. The live MCP symbol graph does not use an LLM.
 
 Octocode supports multiple LLM providers through a unified interface. Configure using `provider:model` format.
 
@@ -248,7 +248,7 @@ description_model = "local:<model-id>"
 relationship_model = "local:<model-id>"
 ```
 
-Contextual indexing and GraphRAG require structured-output support, so an
+Contextual indexing and optional LLM GraphRAG enrichment require structured-output support, so an
 otherwise compatible endpoint can still be rejected when the selected model's
 capabilities are not recognized.
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -51,14 +51,15 @@ The codebase is organized into the following core modules:
 - **Metadata indexing** for filtering
 - **Batch operations** for optimal performance
 
-### 4. GraphRAG Builder (`src/indexer/graphrag/`)
-- **AI-powered relationship extraction** between files
-- **Multi-language import resolver** - Maps import statements to actual file paths
-- **Import/export dependency tracking** with intelligent path resolution
-- **Module hierarchy analysis** with cross-language support
-- **Intelligent file descriptions** using LLMs
-- **Cached import resolution** for optimized repeated lookups
-- **Language-specific import handling** (Rust, JavaScript/TypeScript, Python, Go, PHP, C/C++, Ruby, Bash)
+### 4. Structural Graph and GraphRAG (`src/indexer/graphrag/`)
+
+- **Always-on MCP graph** built lazily from current source with Tree-sitter
+- **File and symbol nodes** with owner-aware method identities
+- **Deterministic relationships** for containment, imports, calls, inheritance, and implementations
+- **Conservative resolution** that prefers scoped/imported targets and drops ambiguous call targets
+- **In-memory caching** guarded by a repository metadata stamp; MCP watcher events also invalidate the cache when in-process indexing is enabled
+- **Optional persisted enrichment** for semantic file lookup, AI descriptions, and broader file-level architectural relationships
+- **No symbol embeddings or symbol LLM processing**; live AST symbols remain authoritative
 
 ### 5. Search Engine
 - **Semantic similarity search** using vector embeddings
@@ -102,40 +103,52 @@ The codebase is organized into the following core modules:
 ## Knowledge Graph Structure
 
 ### Nodes
-Each file/module in the codebase becomes a node with:
-- **File path and metadata** (size, modification time, etc.)
-- **AI-generated descriptions** explaining the file's purpose
-- **Extracted symbols** (functions, classes, variables, etc.)
-- **Import/export lists** for dependency tracking
-- **Vector embeddings** for semantic search
+
+The live graph contains:
+
+- **File nodes**, identified by their repository-relative path
+- **Symbol nodes**, normally identified as `path/to/file::symbol` or `path/to/file::Owner::method`
+- **Line-qualified IDs** only when true overloads would otherwise collide
+
+Symbols and owners come directly from the current Tree-sitter AST. They are not persisted or embedded. When indexed GraphRAG is enabled, persisted file descriptions and file-level nodes may be overlaid only when their source files still exist.
 
 ### Relationships
-Connections between nodes represent different types of relationships:
-- **`imports`**: Direct import dependencies between files
-- **`calls`**: Function/method call relationships between files
-- **`sibling_module`**: Files in the same directory
-- **`parent_module`** / **`child_module`**: Hierarchical relationships
+
+The deterministic live graph emits:
+
+- **`contains`**: File to declared symbol
+- **`imports`**: File to resolved imported file
+- **`calls`**: Calling symbol to conservatively resolved callable symbol
+- **`extends`**: Declared type to its resolved parent type
+- **`implements`**: Declared type to its resolved interface or trait
+
+Optional persisted enrichment can add broader file-level relationship types such as `uses`, `configures`, and architectural or design-pattern relationships.
 
 ### Graph Operations
-- **Search**: Find nodes by semantic query
-- **Get Node**: Retrieve detailed information about a specific file
+
+- **Search**: Lexically seed current file/symbol nodes; add semantic file seeds when persisted GraphRAG is available
+- **Get Node**: Retrieve a file or symbol node
 - **Get Relationships**: Find all connections for a node
 - **Find Path**: Discover connection paths between two nodes
 - **Overview**: Get high-level graph statistics
 
 ## Data Flow
 
-1. **Indexing Phase**:
+1. **Always-on MCP graph**:
    ```
-   Source Files → Tree-sitter Parser → Symbol Extraction → Embedding Generation → Vector Storage
-                                                        ↓
-   GraphRAG Analysis ← AI Description Generation ← Chunk Processing
+   Current Source → Repository Stamp → Tree-sitter Parse → File/Symbol Graph → MCP Operations
+                            │                                      ↑
+                            └── unchanged → reuse in-memory cache ─┘
    ```
 
-2. **Search Phase**:
+2. **Optional indexed enrichment**:
    ```
-   Query → Embedding Generation → Vector Similarity Search → Result Ranking → Response
+   Indexed Files → File Embeddings → Optional LLM Analysis → Persisted File Graph
+                                                              ↓
+   MCP Request → Live Graph + Current Persisted File Overlay → Response
    ```
+
+The live graph detects repository metadata changes on the next graph request. When `index.mcp_index = true`, watcher events invalidate it immediately as part of the normal debounce pipeline.
 
 ## Supported Languages
 
@@ -146,6 +159,7 @@ Connections between nodes represent different types of relationships:
 | **JavaScript** | `.js`, `.jsx` | ES6 imports/exports, function declarations |
 | **TypeScript** | `.ts`, `.tsx` | Type definitions, interface extraction, modules |
 | **Go** | `.go` | Package/import analysis, function extraction |
+| **Java** | `.java` | Class, interface, method, inheritance, and implementation extraction |
 | **PHP** | `.php` | Class/function extraction, namespace support |
 | **C++** | `.cpp`, `.hpp`, `.h`, `.cc`, `.cxx`, `.c++`, `.hxx`, `.cppm`, `.ixx`, `.mxx`, `.ccm`, `.cxxm` | Include analysis, class/function extraction |
 | **Ruby** | `.rb` | Class/module extraction, method definitions |
@@ -153,6 +167,7 @@ Connections between nodes represent different types of relationships:
 | **Bash** | `.sh`, `.bash` | Function and variable extraction |
 | **CSS** | `.css`, `.scss`, `.sass` | Selector and rule extraction |
 | **Lua** | `.lua` | Function and module extraction |
+| **Swift** | `.swift` | Type, protocol, function, and method extraction |
 | **Svelte** | `.svelte` | Component structure, script/style extraction |
 | **Markdown** | `.md` | Document section indexing, header extraction |
 

--- a/doc/COMMANDS.md
+++ b/doc/COMMANDS.md
@@ -26,7 +26,7 @@ octocode index /path/to/project
 - Scans all supported files in your project
 - Extracts code symbols and structure using Tree-sitter
 - Generates embeddings for semantic search
-- Builds knowledge graph relationships (if enabled)
+- Builds persisted knowledge-graph relationships (if GraphRAG is enabled)
 - Stores everything in local LanceDB database
 - **Safe file discovery** - Prevents infinite recursion from symlinks
 - **Respects ignore patterns** - Honors .gitignore and .noindex files
@@ -402,7 +402,7 @@ octocode mcp --path /path/to/project --debug
 **Available MCP tools:**
 - `semantic_search` - Semantic code search (supports multi-query, all modes including commits)
 - `view_signatures` - View file signatures and code structure by glob patterns
-- `graphrag` - Advanced GraphRAG operations (search, get-node, get-relationships, find-path, overview)
+- `graphrag` - Always-on live file/symbol graph operations (search, get-node, get-relationships, find-path, overview); no index or LLM required
 - `structural_search` - AST-based structural code search using ast-grep patterns
 - `lsp_*` - LSP integration tools (when --with-lsp is used)
 
@@ -433,9 +433,13 @@ octocode mcp --multi --bind "127.0.0.1:8080" --path /workspace --debug
 
 ### `octocode graphrag`
 
-Knowledge graph operations using GraphRAG.
+Commands for the persisted GraphRAG database. Unlike the MCP `graphrag` tool's always-on live structural graph, this CLI requires `[graphrag].enabled = true` and a completed `octocode index` run.
 
 ```bash
+# Enable and build the optional persisted graph first
+octocode config --graphrag-enabled true
+octocode index
+
 # Search the relationship graph
 octocode graphrag search --query "authentication modules"
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -217,11 +217,13 @@ Core embedding configuration.
 ### [graphrag]
 
 Persisted knowledge-graph enrichment settings. The MCP `graphrag` tool and its
-lightweight Tree-sitter symbol graph are always available without indexing,
+lightweight Tree-sitter file/symbol graph are always available without indexing,
 embeddings, or an LLM.
 
-- `enabled`: Persist and overlay indexed file-level GraphRAG enrichment
-- `use_llm`: Add AI-discovered relationships and file descriptions to that persisted layer
+- `enabled`: Persist and overlay indexed file-level GraphRAG enrichment; also enables the `octocode graphrag` CLI, which reads that persisted graph
+- `use_llm`: Add AI-discovered relationships and file descriptions to that persisted layer; ignored when `enabled = false`
+
+The live MCP graph creates file and symbol nodes directly from current source and emits deterministic `contains`, `imports`, `calls`, `extends`, and `implements` relationships. It is cached in memory and rebuilt after repository metadata changes. Symbol nodes are never embedded, persisted, or sent to an LLM.
 
 ### [graphrag.llm]
 
@@ -274,7 +276,7 @@ octocode config --text-embedding-model "fastembed:multilingual-e5-small"
 # Set LLM model (provider:model format)
 octocode config --model "anthropic:claude-3-5-sonnet-20241022"
 
-# Enable/disable GraphRAG
+# Enable/disable optional persisted GraphRAG enrichment
 octocode config --graphrag-enabled true
 octocode config --graphrag-enabled false
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -70,6 +70,10 @@ text_model = "voyage:voyage-3.5-lite"
 enabled = false
 use_llm = false
 
+[graphrag.symbols]
+enabled = true
+embed = false
+
 [graphrag.llm]
 description_model = "openrouter:openai/gpt-4o-mini"
 relationship_model = "openrouter:openai/gpt-4o-mini"
@@ -221,6 +225,13 @@ Knowledge graph generation settings.
 - `enabled`: Enable/disable GraphRAG features
 - `use_llm`: Enable AI-powered relationship discovery and file descriptions
 
+### [graphrag.symbols]
+
+Symbol-tier graph nodes: one node per declared symbol (function, class, struct, trait, ...) extracted via tree-sitter — no LLM required. Symbol nodes use `{file_path}::{symbol_name}` ids, link to their file via `contains` edges, and calls / extends / implements between symbols become graph edges.
+
+- `enabled`: Extract per-symbol nodes and symbol→symbol edges during GraphRAG builds (default: true)
+- `embed`: Generate vector embeddings for symbol nodes; when false, symbol nodes are stored with zero vectors and match by name/kind only (default: false)
+
 ### [graphrag.llm]
 
 LLM-specific configuration for GraphRAG AI features.
@@ -344,6 +355,10 @@ text_model = "voyage:voyage-3.5-lite"
 [graphrag]
 enabled = false
 use_llm = false
+
+[graphrag.symbols]
+enabled = true
+embed = false
 ```
 
 **Note**: MCP server settings like port, debug mode, and LSP integration are controlled via command-line flags, not configuration file options.

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -53,7 +53,7 @@ octocode config \
 ## Configuration File Structure
 
 ```toml
-version = 1
+version = 2
 
 [llm]
 model = "openrouter:openai/gpt-4o-mini"
@@ -69,10 +69,6 @@ text_model = "voyage:voyage-3.5-lite"
 [graphrag]
 enabled = false
 use_llm = false
-
-[graphrag.symbols]
-enabled = true
-embed = false
 
 [graphrag.llm]
 description_model = "openrouter:openai/gpt-4o-mini"
@@ -220,17 +216,12 @@ Core embedding configuration.
 
 ### [graphrag]
 
-Knowledge graph generation settings.
+Persisted knowledge-graph enrichment settings. The MCP `graphrag` tool and its
+lightweight Tree-sitter symbol graph are always available without indexing,
+embeddings, or an LLM.
 
-- `enabled`: Enable/disable GraphRAG features
-- `use_llm`: Enable AI-powered relationship discovery and file descriptions
-
-### [graphrag.symbols]
-
-Symbol-tier graph nodes: one node per declared symbol (function, class, struct, trait, ...) extracted via tree-sitter — no LLM required. Symbol nodes use `{file_path}::{symbol_name}` ids, link to their file via `contains` edges, and calls / extends / implements between symbols become graph edges.
-
-- `enabled`: Extract per-symbol nodes and symbol→symbol edges during GraphRAG builds (default: true)
-- `embed`: Generate vector embeddings for symbol nodes; when false, symbol nodes are stored with zero vectors and match by name/kind only (default: false)
+- `enabled`: Persist and overlay indexed file-level GraphRAG enrichment
+- `use_llm`: Add AI-discovered relationships and file descriptions to that persisted layer
 
 ### [graphrag.llm]
 
@@ -355,10 +346,6 @@ text_model = "voyage:voyage-3.5-lite"
 [graphrag]
 enabled = false
 use_llm = false
-
-[graphrag.symbols]
-enabled = true
-embed = false
 ```
 
 **Note**: MCP server settings like port, debug mode, and LSP integration are controlled via command-line flags, not configuration file options.

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -32,7 +32,7 @@ octocode index --verbose
 - Scans all supported files in your project
 - Extracts code symbols and structure
 - Generates embeddings for semantic search
-- Builds knowledge graph relationships
+- Builds persisted knowledge-graph enrichment when GraphRAG is enabled
 - Stores everything in local database
 
 ### 3. Try Your First Search
@@ -97,9 +97,9 @@ octocode config \
 octocode config \
   --code-embedding-model "voyage:voyage-code-3" \
   --text-embedding-model "voyage:voyage-3.5-lite"
-```
 
-# Enable GraphRAG for relationship analysis
+# Enable optional persisted GraphRAG enrichment and CLI graph commands
+# (the MCP graphrag tool's live structural graph works without this)
 octocode config --graphrag-enabled true
 
 # Set search preferences
@@ -194,7 +194,8 @@ octocode graphrag overview --md > STRUCTURE.md
 # Use faster embedding models
 octocode config --code-embedding-model "fastembed:all-MiniLM-L6-v2"
 
-# Disable GraphRAG temporarily
+# Disable optional persisted GraphRAG enrichment
+# (the live MCP structural graph remains available)
 octocode config --graphrag-enabled false
 ```
 

--- a/doc/MCP_CLIENTS.md
+++ b/doc/MCP_CLIENTS.md
@@ -16,7 +16,7 @@ When connected, your AI assistant can:
 |------|-------------|
 | `semantic_search` | Search codebase by meaning — finds code by what it does, not exact symbol names |
 | `view_signatures` | Extract function signatures, class definitions, and declarations from files |
-| `graphrag` | Query code relationships, dependencies, and architecture |
+| `graphrag` | Query the always-on live file/symbol graph; no index, embeddings, or LLM required |
 | `structural_search` | Search or rewrite code by AST structure using ast-grep pattern syntax |
 
 ---

--- a/doc/MCP_INTEGRATION.md
+++ b/doc/MCP_INTEGRATION.md
@@ -164,12 +164,16 @@ Extract and view function signatures, class definitions, and other meaningful co
 
 ### graphrag
 
-Advanced relationship-aware GraphRAG operations for code analysis. Supports multiple operations for exploring the knowledge graph.
+Relationship-aware graph operations over current source. The base graph is built lazily with Tree-sitter and works when `[graphrag].enabled = false`; it needs no code index, embeddings, or LLM. Unchanged repositories reuse an in-memory graph, while repository metadata changes are detected on the next request. With in-process MCP indexing enabled, watcher events also invalidate the graph cache.
+
+The live graph contains file and symbol nodes connected by deterministic `contains`, `imports`, `calls`, `extends`, and `implements` edges. Enabling persisted GraphRAG overlays semantic file matches, descriptions, and additional file-level relationships. It does not embed or LLM-enrich symbol nodes.
+
+For agent use, `search` selects likely file or symbol nodes; it does not automatically traverse their edges. Follow it with `get-relationships`, then use `get-node` or `find-path` when deeper navigation is needed. Use `structural_search` separately for AST-pattern matching and `semantic_search` for meaning-based code retrieval.
 
 **Parameters:**
 - `operation` (string, required) - Operation to perform: "search", "get-node", "get-relationships", "find-path", "overview"
-- `query` (string, optional) - Search query for 'search' operation
-- `node_id` (string, optional) - Node identifier for 'get-node' and 'get-relationships' operations
+- `query` (string, optional) - Search query for 'search'; deterministic name/path lookup is always available, with semantic file lookup added when persisted GraphRAG is enabled
+- `node_id` (string, optional) - Node identifier for 'get-node' and 'get-relationships': `path/to/file`, `path/to/file::symbol`, or `path/to/file::Owner::method`
 - `source_id` (string, optional) - Source node identifier for 'find-path' operation
 - `target_id` (string, optional) - Target node identifier for 'find-path' operation
 - `max_depth` (integer, optional) - Maximum path depth for 'find-path' operation (default: 3)
@@ -177,11 +181,11 @@ Advanced relationship-aware GraphRAG operations for code analysis. Supports mult
 
 **Operation Examples:**
 
-**Search for nodes by semantic query:**
+**Search for file or symbol nodes:**
 ```json
 {
   "operation": "search",
-  "query": "How does user authentication flow through the system?"
+  "query": "AuthService authenticate"
 }
 ```
 
@@ -198,7 +202,7 @@ Advanced relationship-aware GraphRAG operations for code analysis. Supports mult
 ```json
 {
   "operation": "get-relationships",
-  "node_id": "src/auth/mod.rs",
+  "node_id": "src/auth/service.rs::AuthService::authenticate",
   "format": "text"
 }
 ```

--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -203,7 +203,7 @@ octocode clear && octocode index  # Index all at once vs incremental
 embeddings_batch_size = 16       # Smaller batches for cloud APIs
 
 [graphrag.llm]
-# Optimize AI call costs and rate limits
+# Optimize optional persisted GraphRAG enrichment costs and rate limits
 ai_batch_size = 8               # Process multiple files per AI call
 max_batch_tokens = 16384        # Stay within model context limits
 fallback_to_individual = true   # Reliability if batch processing fails

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,38 +91,11 @@ Focus on:
 
 Avoid listing specific functions/classes. Instead, describe the file's architectural significance and how it fits into the larger system design.";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GraphRAGSymbolsConfig {
-	/// Extract one graph node per declared symbol (function, class, struct,
-	/// trait, ...) via tree-sitter — no LLM required.
-	#[serde(default = "default_graphrag_symbols_enabled")]
-	pub enabled: bool,
-	/// Generate vector embeddings for symbol nodes. When false, symbol nodes
-	/// are stored with zero vectors and match by name/kind only.
-	#[serde(default)]
-	pub embed: bool,
-}
-
-impl Default for GraphRAGSymbolsConfig {
-	fn default() -> Self {
-		Self {
-			enabled: true,
-			embed: false,
-		}
-	}
-}
-
-fn default_graphrag_symbols_enabled() -> bool {
-	true
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GraphRAGConfig {
 	pub enabled: bool,
 	pub use_llm: bool,
 	pub llm: LLMConfig,
-	#[serde(default)]
-	pub symbols: GraphRAGSymbolsConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,11 +91,38 @@ Focus on:
 
 Avoid listing specific functions/classes. Instead, describe the file's architectural significance and how it fits into the larger system design.";
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphRAGSymbolsConfig {
+	/// Extract one graph node per declared symbol (function, class, struct,
+	/// trait, ...) via tree-sitter — no LLM required.
+	#[serde(default = "default_graphrag_symbols_enabled")]
+	pub enabled: bool,
+	/// Generate vector embeddings for symbol nodes. When false, symbol nodes
+	/// are stored with zero vectors and match by name/kind only.
+	#[serde(default)]
+	pub embed: bool,
+}
+
+impl Default for GraphRAGSymbolsConfig {
+	fn default() -> Self {
+		Self {
+			enabled: true,
+			embed: false,
+		}
+	}
+}
+
+fn default_graphrag_symbols_enabled() -> bool {
+	true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GraphRAGConfig {
 	pub enabled: bool,
 	pub use_llm: bool,
 	pub llm: LLMConfig,
+	#[serde(default)]
+	pub symbols: GraphRAGSymbolsConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -690,7 +717,8 @@ mod tests {
 		assert_eq!(config.search.hybrid.default_vector_weight, 0.73);
 		assert_eq!(config.search.hybrid.rrf_k, 60.0);
 		assert!(!config.search.reasoning.enabled);
-		let [backup] = siblings(&config_path, "bak").as_slice() else {
+		let backups = siblings(&config_path, "bak");
+		let [backup] = backups.as_slice() else {
 			panic!("migration should leave exactly one backup");
 		};
 		assert_eq!(fs::read_to_string(backup).unwrap(), original);

--- a/src/indexer/graphrag/ai.rs
+++ b/src/indexer/graphrag/ai.rs
@@ -307,6 +307,7 @@ impl AIEnhancements {
 					description: ai_rel.description,
 					confidence: ai_rel.confidence,
 					weight: 0.9, // High weight for AI-discovered architectural patterns
+					provenance: crate::indexer::graphrag::types::Provenance::Inferred,
 				})
 				.collect();
 			return Ok(relationships);

--- a/src/indexer/graphrag/builder.rs
+++ b/src/indexer/graphrag/builder.rs
@@ -22,7 +22,10 @@ use crate::embedding::{
 use crate::indexer::graphrag::ai::AIEnhancements;
 use crate::indexer::graphrag::database::DatabaseOperations;
 use crate::indexer::graphrag::relationships::RelationshipDiscovery;
-use crate::indexer::graphrag::types::{CodeGraph, CodeNode, CodeRelationship};
+use crate::indexer::graphrag::symbols::{discover_symbol_relationships, extract_symbols_from_file};
+use crate::indexer::graphrag::types::{
+	CodeGraph, CodeNode, CodeRelationship, Provenance, RelationType,
+};
 use crate::indexer::graphrag::utils::{
 	cosine_similarity, detect_project_root, detect_project_root_from, to_relative_path,
 };
@@ -137,6 +140,12 @@ impl GraphBuilder {
 		// for the whole graph on every incremental run.
 		let mut processed_node_ids: HashSet<String> = HashSet::new();
 
+		// Symbol-tier accumulators (graphrag.symbols): one node per declared
+		// symbol, plus file→symbol "contains" edges.
+		let mut symbol_nodes: Vec<CodeNode> = Vec::new();
+		let mut symbol_embed_texts: Vec<String> = Vec::new();
+		let mut symbol_contains_edges: Vec<CodeRelationship> = Vec::new();
+
 		// Group code blocks by file for efficient processing
 		let mut files_to_blocks: HashMap<String, Vec<&CodeBlock>> = HashMap::new();
 		for block in code_blocks {
@@ -196,16 +205,30 @@ impl GraphBuilder {
 					}
 				}
 
-				// CRITICAL FIX: Also remove from in-memory graph to prevent duplicates
+				// CRITICAL FIX: Also remove from in-memory graph to prevent duplicates.
+				// Path-based: covers the file node AND its symbol-tier nodes
+				// ("{path}::{symbol}") plus every edge touching them.
 				{
 					let mut graph = self.graph.write().await;
-					if graph.nodes.remove(&relative_path).is_some() && !self.quiet {
-						eprintln!("🗑️  Removed stale in-memory node: {}", relative_path);
+					let stale_ids: HashSet<String> = graph
+						.nodes
+						.iter()
+						.filter(|(_, n)| n.path == relative_path)
+						.map(|(id, _)| id.clone())
+						.collect();
+					if !stale_ids.is_empty() {
+						if !self.quiet {
+							eprintln!(
+								"🗑️  Removed {} stale in-memory node(s) for: {}",
+								stale_ids.len(),
+								relative_path
+							);
+						}
+						graph.nodes.retain(|id, _| !stale_ids.contains(id));
+						graph.relationships.retain(|rel| {
+							!stale_ids.contains(&rel.source) && !stale_ids.contains(&rel.target)
+						});
 					}
-					// Remove stale relationships referencing this node
-					graph
-						.relationships
-						.retain(|rel| rel.source != relative_path && rel.target != relative_path);
 				}
 
 				// Extract file information efficiently
@@ -243,24 +266,32 @@ impl GraphBuilder {
 
 				let symbols: Vec<String> = all_symbols.into_iter().collect();
 
-				// Extract imports and exports using language-specific AST parsing
-				let (imports, exports) = self
-					.extract_imports_exports_from_file(&file_path, &language)
-					.await
-					.unwrap_or_else(|e| {
-						if !self.quiet {
-							eprintln!(
-								"⚠️  Import/export extraction failed for {}: {}",
-								relative_path, e
-							);
+				// Unified single-pass AST extraction: imports, exports, call
+				// sites, type relations, and symbol declarations from ONE
+				// tree-sitter parse (replaces three per-file parses).
+				let (imports, exports, file_calls, file_type_rels, symbol_decls) =
+					match extract_symbols_from_file(&file_path, &language) {
+						Ok(data) => (
+							data.imports,
+							data.exports,
+							data.calls,
+							data.type_relations,
+							data.symbols,
+						),
+						Err(e) => {
+							if !self.quiet {
+								eprintln!("⚠️  AST extraction failed for {}: {}", relative_path, e);
+							}
+							// Fallback to the old heuristic if AST parsing fails
+							let (imports, exports) =
+								RelationshipDiscovery::extract_imports_exports_efficient(
+									&symbols,
+									&language,
+									&relative_path,
+								);
+							(imports, exports, Vec::new(), Vec::new(), Vec::new())
 						}
-						// Fallback to old method if AST parsing fails
-						RelationshipDiscovery::extract_imports_exports_efficient(
-							&symbols,
-							&language,
-							&relative_path,
-						)
-					});
+					};
 
 				if !self.quiet && (!imports.is_empty() || !exports.is_empty()) {
 					eprintln!(
@@ -277,20 +308,12 @@ impl GraphBuilder {
 					}
 				}
 
-				// Extract callees + type relations (extends/implements).
+				// Attribute callees + type relations (extends/implements).
 				// When per-function FunctionInfo entries are available, attribute
 				// callees by line range. When they are not — currently always, see
 				// extract_functions_from_block — synthesize a single file-scope
 				// FunctionInfo so the edges still reach relationships.rs, which
 				// emits at (source_file.id → target_file.id) granularity.
-				let file_calls = self
-					.extract_function_calls_from_file(&file_path, &language)
-					.await
-					.unwrap_or_default();
-				let file_type_rels = self
-					.extract_type_relations_from_file(&file_path, &language)
-					.await
-					.unwrap_or_default();
 
 				if !all_functions.is_empty() {
 					for func in &mut all_functions {
@@ -515,11 +538,50 @@ impl GraphBuilder {
 					hash: content_hash,
 					embedding: Vec::new(), // Will be filled after batch embedding
 					size_lines: total_lines as u32,
-					language,
+					language: language.clone(),
 				};
 
 				new_nodes.push(node);
 				processed_count += 1;
+
+				// Symbol-tier nodes: one per declared symbol (graphrag.symbols).
+				if self.config.graphrag.symbols.enabled {
+					for decl in &symbol_decls {
+						let symbol_id = format!("{}::{}", relative_path, decl.name);
+						let description =
+							format!("{} {} in {}", decl.kind, decl.name, relative_path);
+						symbol_embed_texts
+							.push(format!("{}\n{}", description, decl.source_snippet));
+						symbol_nodes.push(CodeNode {
+							id: symbol_id.clone(),
+							name: decl.name.clone(),
+							kind: decl.kind.clone(),
+							path: relative_path.clone(),
+							description,
+							symbols: vec![decl.name.clone()],
+							hash: calculate_unique_content_hash(&decl.source_snippet, &symbol_id),
+							embedding: Vec::new(),
+							imports: Vec::new(),
+							exports: Vec::new(),
+							functions: Vec::new(),
+							size_lines: decl.end_line.saturating_sub(decl.start_line) + 1,
+							language: language.clone(),
+						});
+						processed_node_ids.insert(symbol_id.clone());
+						symbol_contains_edges.push(CodeRelationship {
+							source: relative_path.clone(),
+							target: symbol_id,
+							relation_type: RelationType::Contains,
+							description: format!(
+								"{} contains {} {}",
+								relative_path, decl.kind, decl.name
+							),
+							confidence: 1.0,
+							weight: RelationType::Contains.importance_weight(),
+							provenance: Provenance::Extracted,
+						});
+					}
+				}
 
 				// Update state if provided
 				if let Some(ref state) = state {
@@ -676,6 +738,46 @@ impl GraphBuilder {
 			.await?;
 		}
 
+		// Persist symbol-tier nodes before relationship discovery so symbol
+		// edges can resolve against them.
+		if !symbol_nodes.is_empty() {
+			if self.config.graphrag.symbols.embed {
+				let embeddings = crate::embedding::generate_embeddings_batch(
+					&symbol_embed_texts,
+					false, // Text embeddings for GraphRAG symbol descriptions
+					&self.config,
+					crate::embedding::types::InputType::Document,
+				)
+				.await?;
+				for (node, embedding) in symbol_nodes.iter_mut().zip(embeddings.iter()) {
+					node.embedding = embedding.clone();
+				}
+			} else {
+				// Zero vectors satisfy the storage dimension check; cosine
+				// similarity with a zero vector is 0.0, so search matches
+				// these nodes by name/kind only.
+				let dim = self.store.get_code_vector_dim();
+				for node in &mut symbol_nodes {
+					node.embedding = vec![0.0; dim];
+				}
+			}
+
+			{
+				let mut graph = self.graph.write().await;
+				for node in &symbol_nodes {
+					graph.nodes.insert(node.id.clone(), node.clone());
+				}
+				graph
+					.relationships
+					.extend(symbol_contains_edges.iter().cloned());
+			}
+
+			let db_ops = DatabaseOperations::new(&self.store);
+			db_ops
+				.save_graph_incremental(&symbol_nodes, &symbol_contains_edges)
+				.await?;
+		}
+
 		// Discover relationships incrementally for processed nodes
 		// This ensures relationships are stored during processing, not just at the end
 		if processed_count > 0 {
@@ -754,7 +856,7 @@ impl GraphBuilder {
 				// Process relationships in batches to avoid storing everything at the end
 				let relationship_batch_size = self.config.index.embeddings_batch_size * 4; // Larger batches for relationships
 
-				let all_relationships = if self.llm_enabled() {
+				let mut all_relationships = if self.llm_enabled() {
 					// Enhanced relationship discovery with optional AI for complex cases
 					self.discover_relationships_with_ai_enhancement(&all_processed_nodes)
 						.await?
@@ -763,6 +865,23 @@ impl GraphBuilder {
 					self.discover_relationships_efficiently(&all_processed_nodes)
 						.await?
 				};
+
+				// Symbol→symbol edges (calls / extends / implements) resolved to
+				// symbol-tier nodes — pure tree-sitter + name resolution, no LLM.
+				if self.config.graphrag.symbols.enabled {
+					let all_nodes = {
+						let graph = self.graph.read().await;
+						graph
+							.nodes
+							.values()
+							.map(|n| n.without_embedding())
+							.collect::<Vec<CodeNode>>()
+					};
+					all_relationships.extend(discover_symbol_relationships(
+						&all_processed_nodes,
+						&all_nodes,
+					));
+				}
 
 				// Storage is append-only: keep only edges that touch a node from
 				// this run, or the importer sources added above would re-append
@@ -1317,176 +1436,5 @@ impl GraphBuilder {
 			*batches_processed = 0;
 		}
 		Ok(())
-	}
-
-	// Extract imports/exports using language-specific AST parsing
-	pub async fn extract_imports_exports_from_file(
-		&self,
-		file_path: &str,
-		language: &str,
-	) -> Result<(Vec<String>, Vec<String>)> {
-		use crate::indexer::languages;
-		use std::fs;
-		use tree_sitter::Parser;
-
-		// Get language implementation
-		let lang_impl = languages::get_language(language).ok_or_else(|| {
-			anyhow::anyhow!("Failed to get language implementation for: {}", language)
-		})?;
-
-		// Read file content
-		let contents = fs::read_to_string(file_path)?;
-
-		// Parse with tree-sitter
-		let mut parser = Parser::new();
-		parser.set_language(&lang_impl.get_ts_language())?;
-		let tree = parser
-			.parse(&contents, None)
-			.ok_or_else(|| anyhow::anyhow!("Failed to parse file"))?;
-
-		let mut all_imports = Vec::new();
-		let mut all_exports = Vec::new();
-
-		// Walk through all nodes and extract imports/exports
-		let cursor = tree.walk();
-		extract_imports_exports_recursive(
-			cursor.node(),
-			&contents,
-			lang_impl.as_ref(),
-			&mut all_imports,
-			&mut all_exports,
-		);
-
-		Ok((all_imports, all_exports))
-	}
-
-	/// Extract function calls from a file using language-specific AST parsing.
-	/// Returns (line_number, callee_name) pairs.
-	pub async fn extract_function_calls_from_file(
-		&self,
-		file_path: &str,
-		language: &str,
-	) -> Result<Vec<(u32, String)>> {
-		use crate::indexer::languages;
-		use std::fs;
-		use tree_sitter::Parser;
-
-		let lang_impl = languages::get_language(language).ok_or_else(|| {
-			anyhow::anyhow!("Failed to get language implementation for: {}", language)
-		})?;
-
-		let contents = fs::read_to_string(file_path)?;
-
-		let mut parser = Parser::new();
-		parser.set_language(&lang_impl.get_ts_language())?;
-		let tree = parser
-			.parse(&contents, None)
-			.ok_or_else(|| anyhow::anyhow!("Failed to parse file"))?;
-
-		let mut calls = Vec::new();
-		extract_function_calls_recursive(
-			tree.walk().node(),
-			&contents,
-			lang_impl.as_ref(),
-			&mut calls,
-		);
-
-		Ok(calls)
-	}
-
-	/// Extract type-level relationships (Extends / Implements) from a file using
-	/// language-specific AST parsing. Returns (line, kind, target_name) tuples.
-	pub async fn extract_type_relations_from_file(
-		&self,
-		file_path: &str,
-		language: &str,
-	) -> Result<Vec<(u32, TypeRelationKind, String)>> {
-		use crate::indexer::languages;
-		use std::fs;
-		use tree_sitter::Parser;
-
-		let lang_impl = languages::get_language(language).ok_or_else(|| {
-			anyhow::anyhow!("Failed to get language implementation for: {}", language)
-		})?;
-
-		let contents = fs::read_to_string(file_path)?;
-
-		let mut parser = Parser::new();
-		parser.set_language(&lang_impl.get_ts_language())?;
-		let tree = parser
-			.parse(&contents, None)
-			.ok_or_else(|| anyhow::anyhow!("Failed to parse file"))?;
-
-		let mut rels = Vec::new();
-		extract_type_relations_recursive(
-			tree.walk().node(),
-			&contents,
-			lang_impl.as_ref(),
-			&mut rels,
-		);
-
-		Ok(rels)
-	}
-}
-
-// Recursively extract function calls from AST nodes
-fn extract_function_calls_recursive(
-	node: tree_sitter::Node,
-	contents: &str,
-	lang_impl: &dyn crate::indexer::languages::Language,
-	calls: &mut Vec<(u32, String)>,
-) {
-	let callees = lang_impl.extract_function_calls(node, contents);
-	if !callees.is_empty() {
-		let line = node.start_position().row as u32; // 0-based to match FunctionInfo
-		for callee in callees {
-			calls.push((line, callee));
-		}
-	}
-
-	let mut cursor = node.walk();
-	for child in node.children(&mut cursor) {
-		extract_function_calls_recursive(child, contents, lang_impl, calls);
-	}
-}
-
-// Recursively extract type-level relationships (Extends / Implements) from AST nodes.
-fn extract_type_relations_recursive(
-	node: tree_sitter::Node,
-	contents: &str,
-	lang_impl: &dyn crate::indexer::languages::Language,
-	rels: &mut Vec<(u32, TypeRelationKind, String)>,
-) {
-	let pairs = lang_impl.extract_type_relations(node, contents);
-	if !pairs.is_empty() {
-		let line = node.start_position().row as u32;
-		for (kind, target) in pairs {
-			rels.push((line, kind, target));
-		}
-	}
-
-	let mut cursor = node.walk();
-	for child in node.children(&mut cursor) {
-		extract_type_relations_recursive(child, contents, lang_impl, rels);
-	}
-}
-
-// Recursively extract imports/exports from AST nodes
-fn extract_imports_exports_recursive(
-	node: tree_sitter::Node,
-	contents: &str,
-	lang_impl: &dyn crate::indexer::languages::Language,
-	all_imports: &mut Vec<String>,
-	all_exports: &mut Vec<String>,
-) {
-	// Extract imports/exports from current node
-	let (imports, exports) = lang_impl.extract_imports_exports(node, contents);
-	all_imports.extend(imports);
-	all_exports.extend(exports);
-
-	// Recursively process children
-	let mut cursor = node.walk();
-	for child in node.children(&mut cursor) {
-		extract_imports_exports_recursive(child, contents, lang_impl, all_imports, all_exports);
 	}
 }

--- a/src/indexer/graphrag/builder.rs
+++ b/src/indexer/graphrag/builder.rs
@@ -22,10 +22,8 @@ use crate::embedding::{
 use crate::indexer::graphrag::ai::AIEnhancements;
 use crate::indexer::graphrag::database::DatabaseOperations;
 use crate::indexer::graphrag::relationships::RelationshipDiscovery;
-use crate::indexer::graphrag::symbols::{discover_symbol_relationships, extract_symbols_from_file};
-use crate::indexer::graphrag::types::{
-	CodeGraph, CodeNode, CodeRelationship, Provenance, RelationType,
-};
+use crate::indexer::graphrag::symbols::{extract_symbols_from_file, FileAstData};
+use crate::indexer::graphrag::types::{CodeGraph, CodeNode, CodeRelationship};
 use crate::indexer::graphrag::utils::{
 	cosine_similarity, detect_project_root, detect_project_root_from, to_relative_path,
 };
@@ -140,12 +138,6 @@ impl GraphBuilder {
 		// for the whole graph on every incremental run.
 		let mut processed_node_ids: HashSet<String> = HashSet::new();
 
-		// Symbol-tier accumulators (graphrag.symbols): one node per declared
-		// symbol, plus file→symbol "contains" edges.
-		let mut symbol_nodes: Vec<CodeNode> = Vec::new();
-		let mut symbol_embed_texts: Vec<String> = Vec::new();
-		let mut symbol_contains_edges: Vec<CodeRelationship> = Vec::new();
-
 		// Group code blocks by file for efficient processing
 		let mut files_to_blocks: HashMap<String, Vec<&CodeBlock>> = HashMap::new();
 		for block in code_blocks {
@@ -206,7 +198,7 @@ impl GraphBuilder {
 				}
 
 				// CRITICAL FIX: Also remove from in-memory graph to prevent duplicates.
-				// Path-based: covers the file node AND its symbol-tier nodes
+				// Path-based: covers the file node and cleans legacy persisted symbol rows.
 				// ("{path}::{symbol}") plus every edge touching them.
 				{
 					let mut graph = self.graph.write().await;
@@ -269,29 +261,30 @@ impl GraphBuilder {
 				// Unified single-pass AST extraction: imports, exports, call
 				// sites, type relations, and symbol declarations from ONE
 				// tree-sitter parse (replaces three per-file parses).
-				let (imports, exports, file_calls, file_type_rels, symbol_decls) =
-					match extract_symbols_from_file(&file_path, &language) {
-						Ok(data) => (
-							data.imports,
-							data.exports,
-							data.calls,
-							data.type_relations,
-							data.symbols,
-						),
-						Err(e) => {
-							if !self.quiet {
-								eprintln!("⚠️  AST extraction failed for {}: {}", relative_path, e);
-							}
-							// Fallback to the old heuristic if AST parsing fails
-							let (imports, exports) =
-								RelationshipDiscovery::extract_imports_exports_efficient(
-									&symbols,
-									&language,
-									&relative_path,
-								);
-							(imports, exports, Vec::new(), Vec::new(), Vec::new())
+				let ast_data = match extract_symbols_from_file(&file_path, &language) {
+					Ok(data) => data,
+					Err(e) => {
+						if !self.quiet {
+							eprintln!("⚠️  AST extraction failed for {}: {}", relative_path, e);
 						}
-					};
+						// Fallback to the old heuristic if AST parsing fails
+						let (imports, exports) =
+							RelationshipDiscovery::extract_imports_exports_efficient(
+								&symbols,
+								&language,
+								&relative_path,
+							);
+						FileAstData {
+							imports,
+							exports,
+							..FileAstData::default()
+						}
+					}
+				};
+				let imports = ast_data.imports.clone();
+				let exports = ast_data.exports.clone();
+				let file_calls = ast_data.calls.clone();
+				let file_type_rels = ast_data.type_relations.clone();
 
 				if !self.quiet && (!imports.is_empty() || !exports.is_empty()) {
 					eprintln!(
@@ -328,20 +321,22 @@ impl GraphBuilder {
 						let in_range = |line: u32| line >= func.start_line && line <= func.end_line;
 						func.extends = file_type_rels
 							.iter()
-							.filter(|(line, k, _)| {
-								*k == TypeRelationKind::Extends && in_range(*line)
+							.filter(|relation| {
+								relation.kind == TypeRelationKind::Extends
+									&& in_range(relation.line)
 							})
-							.map(|(_, _, name)| name.clone())
+							.map(|relation| relation.target_name.clone())
 							.collect();
 						func.extends.sort();
 						func.extends.dedup();
 
 						func.implements = file_type_rels
 							.iter()
-							.filter(|(line, k, _)| {
-								*k == TypeRelationKind::Implements && in_range(*line)
+							.filter(|relation| {
+								relation.kind == TypeRelationKind::Implements
+									&& in_range(relation.line)
 							})
-							.map(|(_, _, name)| name.clone())
+							.map(|relation| relation.target_name.clone())
 							.collect();
 						func.implements.sort();
 						func.implements.dedup();
@@ -353,16 +348,16 @@ impl GraphBuilder {
 
 					let mut extends: Vec<String> = file_type_rels
 						.iter()
-						.filter(|(_, k, _)| *k == TypeRelationKind::Extends)
-						.map(|(_, _, name)| name.clone())
+						.filter(|relation| relation.kind == TypeRelationKind::Extends)
+						.map(|relation| relation.target_name.clone())
 						.collect();
 					extends.sort();
 					extends.dedup();
 
 					let mut implements: Vec<String> = file_type_rels
 						.into_iter()
-						.filter(|(_, k, _)| *k == TypeRelationKind::Implements)
-						.map(|(_, _, name)| name)
+						.filter(|relation| relation.kind == TypeRelationKind::Implements)
+						.map(|relation| relation.target_name)
 						.collect();
 					implements.sort();
 					implements.dedup();
@@ -544,45 +539,6 @@ impl GraphBuilder {
 				new_nodes.push(node);
 				processed_count += 1;
 
-				// Symbol-tier nodes: one per declared symbol (graphrag.symbols).
-				if self.config.graphrag.symbols.enabled {
-					for decl in &symbol_decls {
-						let symbol_id = format!("{}::{}", relative_path, decl.name);
-						let description =
-							format!("{} {} in {}", decl.kind, decl.name, relative_path);
-						symbol_embed_texts
-							.push(format!("{}\n{}", description, decl.source_snippet));
-						symbol_nodes.push(CodeNode {
-							id: symbol_id.clone(),
-							name: decl.name.clone(),
-							kind: decl.kind.clone(),
-							path: relative_path.clone(),
-							description,
-							symbols: vec![decl.name.clone()],
-							hash: calculate_unique_content_hash(&decl.source_snippet, &symbol_id),
-							embedding: Vec::new(),
-							imports: Vec::new(),
-							exports: Vec::new(),
-							functions: Vec::new(),
-							size_lines: decl.end_line.saturating_sub(decl.start_line) + 1,
-							language: language.clone(),
-						});
-						processed_node_ids.insert(symbol_id.clone());
-						symbol_contains_edges.push(CodeRelationship {
-							source: relative_path.clone(),
-							target: symbol_id,
-							relation_type: RelationType::Contains,
-							description: format!(
-								"{} contains {} {}",
-								relative_path, decl.kind, decl.name
-							),
-							confidence: 1.0,
-							weight: RelationType::Contains.importance_weight(),
-							provenance: Provenance::Extracted,
-						});
-					}
-				}
-
 				// Update state if provided
 				if let Some(ref state) = state {
 					let mut state_guard = state.write();
@@ -738,46 +694,6 @@ impl GraphBuilder {
 			.await?;
 		}
 
-		// Persist symbol-tier nodes before relationship discovery so symbol
-		// edges can resolve against them.
-		if !symbol_nodes.is_empty() {
-			if self.config.graphrag.symbols.embed {
-				let embeddings = crate::embedding::generate_embeddings_batch(
-					&symbol_embed_texts,
-					false, // Text embeddings for GraphRAG symbol descriptions
-					&self.config,
-					crate::embedding::types::InputType::Document,
-				)
-				.await?;
-				for (node, embedding) in symbol_nodes.iter_mut().zip(embeddings.iter()) {
-					node.embedding = embedding.clone();
-				}
-			} else {
-				// Zero vectors satisfy the storage dimension check; cosine
-				// similarity with a zero vector is 0.0, so search matches
-				// these nodes by name/kind only.
-				let dim = self.store.get_code_vector_dim();
-				for node in &mut symbol_nodes {
-					node.embedding = vec![0.0; dim];
-				}
-			}
-
-			{
-				let mut graph = self.graph.write().await;
-				for node in &symbol_nodes {
-					graph.nodes.insert(node.id.clone(), node.clone());
-				}
-				graph
-					.relationships
-					.extend(symbol_contains_edges.iter().cloned());
-			}
-
-			let db_ops = DatabaseOperations::new(&self.store);
-			db_ops
-				.save_graph_incremental(&symbol_nodes, &symbol_contains_edges)
-				.await?;
-		}
-
 		// Discover relationships incrementally for processed nodes
 		// This ensures relationships are stored during processing, not just at the end
 		if processed_count > 0 {
@@ -817,6 +733,7 @@ impl GraphBuilder {
 				let mut selected = graph
 					.nodes
 					.values()
+					.filter(|node| !node.is_symbol_node())
 					.filter(|node| processed_node_ids.contains(&node.id))
 					.map(|node| node.without_embedding())
 					.collect::<Vec<CodeNode>>();
@@ -844,6 +761,7 @@ impl GraphBuilder {
 				let importers: Vec<CodeNode> = graph
 					.nodes
 					.values()
+					.filter(|node| !node.is_symbol_node())
 					.filter(|node| !processed_node_ids.contains(&node.id))
 					.filter(|node| node.imports.iter().any(|i| imports_new(i)))
 					.map(|node| node.without_embedding())
@@ -865,23 +783,6 @@ impl GraphBuilder {
 					self.discover_relationships_efficiently(&all_processed_nodes)
 						.await?
 				};
-
-				// Symbol→symbol edges (calls / extends / implements) resolved to
-				// symbol-tier nodes — pure tree-sitter + name resolution, no LLM.
-				if self.config.graphrag.symbols.enabled {
-					let all_nodes = {
-						let graph = self.graph.read().await;
-						graph
-							.nodes
-							.values()
-							.map(|n| n.without_embedding())
-							.collect::<Vec<CodeNode>>()
-					};
-					all_relationships.extend(discover_symbol_relationships(
-						&all_processed_nodes,
-						&all_nodes,
-					));
-				}
 
 				// Storage is append-only: keep only edges that touch a node from
 				// this run, or the importer sources added above would re-append
@@ -972,6 +873,7 @@ impl GraphBuilder {
 				graph
 					.nodes
 					.values()
+					.filter(|node| !node.is_symbol_node())
 					.map(|n| n.without_embedding())
 					.collect::<Vec<CodeNode>>()
 			};
@@ -995,6 +897,7 @@ impl GraphBuilder {
 			graph
 				.nodes
 				.values()
+				.filter(|node| !node.is_symbol_node())
 				.map(|n| n.without_embedding())
 				.collect::<Vec<CodeNode>>()
 		};

--- a/src/indexer/graphrag/builder.rs
+++ b/src/indexer/graphrag/builder.rs
@@ -283,7 +283,23 @@ impl GraphBuilder {
 				};
 				let imports = ast_data.imports.clone();
 				let exports = ast_data.exports.clone();
-				let file_calls = ast_data.calls.clone();
+				let file_calls: Vec<(u32, String)> = ast_data
+					.calls
+					.iter()
+					.map(|(line, call)| {
+						let name = if call.qualifier.is_none() {
+							ast_data
+								.import_bindings
+								.iter()
+								.find(|binding| binding.local_name == call.name)
+								.and_then(|binding| binding.imported_name.clone())
+								.unwrap_or_else(|| call.name.clone())
+						} else {
+							call.name.clone()
+						};
+						(*line, name)
+					})
+					.collect();
 				let file_type_rels = ast_data.type_relations.clone();
 
 				if !self.quiet && (!imports.is_empty() || !exports.is_empty()) {
@@ -342,7 +358,8 @@ impl GraphBuilder {
 						func.implements.dedup();
 					}
 				} else if !file_calls.is_empty() || !file_type_rels.is_empty() {
-					let mut callees: Vec<String> = file_calls.into_iter().map(|(_, c)| c).collect();
+					let mut callees: Vec<String> =
+						file_calls.into_iter().map(|(_, callee)| callee).collect();
 					callees.sort();
 					callees.dedup();
 
@@ -774,7 +791,7 @@ impl GraphBuilder {
 				// Process relationships in batches to avoid storing everything at the end
 				let relationship_batch_size = self.config.index.embeddings_batch_size * 4; // Larger batches for relationships
 
-				let mut all_relationships = if self.llm_enabled() {
+				let all_relationships = if self.llm_enabled() {
 					// Enhanced relationship discovery with optional AI for complex cases
 					self.discover_relationships_with_ai_enhancement(&all_processed_nodes)
 						.await?

--- a/src/indexer/graphrag/database.rs
+++ b/src/indexer/graphrag/database.rs
@@ -14,7 +14,7 @@
 
 // GraphRAG database operations
 
-use crate::indexer::graphrag::types::{CodeGraph, CodeNode, CodeRelationship};
+use crate::indexer::graphrag::types::{CodeGraph, CodeNode, CodeRelationship, Provenance};
 use crate::indexer::graphrag::utils::cosine_similarity;
 use crate::store::Store;
 use anyhow::{Context, Result};
@@ -225,6 +225,8 @@ impl<'a> DatabaseOperations<'a> {
 			let type_array = extract_string_column(&rel_batch, "relation_type")?;
 			let desc_array = extract_string_column(&rel_batch, "description")?;
 			let conf_array = extract_f32_column(&rel_batch, "confidence")?;
+			// Absent in tables written before the provenance column existed.
+			let provenance_array = try_string_column(&rel_batch, "provenance");
 
 			// Deduplicate relationships by (source, target, type) triple —
 			// batch writes can produce duplicates across incremental flushes
@@ -248,6 +250,8 @@ impl<'a> DatabaseOperations<'a> {
 					description: desc_array.value(i).to_string(),
 					confidence: conf_array.value(i),
 					weight: 1.0,
+					provenance: provenance_array
+						.map_or(Provenance::default(), |arr| Provenance::parse_or_default(arr.value(i))),
 				};
 				graph.relationships.push(relationship);
 			}
@@ -595,6 +599,8 @@ impl<'a> DatabaseOperations<'a> {
 			Field::new("description", DataType::Utf8, false),
 			Field::new("confidence", DataType::Float32, false),
 			Field::new("weight", DataType::Float32, false),
+			// Nullable so appending to pre-provenance tables auto-evolves the schema.
+			Field::new("provenance", DataType::Utf8, true),
 		]));
 
 		// Generate unique IDs
@@ -614,6 +620,10 @@ impl<'a> DatabaseOperations<'a> {
 			.collect();
 		let confidences: Vec<f32> = relationships.iter().map(|r| r.confidence).collect();
 		let weights: Vec<f32> = relationships.iter().map(|r| r.weight).collect();
+		let provenances: Vec<&str> = relationships
+			.iter()
+			.map(|r| r.provenance.as_str())
+			.collect();
 
 		// Create record batch
 		let batch = arrow::record_batch::RecordBatch::try_new(
@@ -626,6 +636,7 @@ impl<'a> DatabaseOperations<'a> {
 				Arc::new(arrow::array::StringArray::from(descriptions)),
 				Arc::new(arrow::array::Float32Array::from(confidences)),
 				Arc::new(arrow::array::Float32Array::from(weights)),
+				Arc::new(arrow::array::StringArray::from(provenances)),
 			],
 		)?;
 

--- a/src/indexer/graphrag/database.rs
+++ b/src/indexer/graphrag/database.rs
@@ -600,7 +600,7 @@ impl<'a> DatabaseOperations<'a> {
 			Field::new("description", DataType::Utf8, false),
 			Field::new("confidence", DataType::Float32, false),
 			Field::new("weight", DataType::Float32, false),
-			// Nullable so appending to pre-provenance tables auto-evolves the schema.
+			// Nullable so pre-provenance rows can be upgraded with null values.
 			Field::new("provenance", DataType::Utf8, true),
 		]));
 

--- a/src/indexer/graphrag/database.rs
+++ b/src/indexer/graphrag/database.rs
@@ -250,8 +250,9 @@ impl<'a> DatabaseOperations<'a> {
 					description: desc_array.value(i).to_string(),
 					confidence: conf_array.value(i),
 					weight: 1.0,
-					provenance: provenance_array
-						.map_or(Provenance::default(), |arr| Provenance::parse_or_default(arr.value(i))),
+					provenance: provenance_array.map_or(Provenance::default(), |arr| {
+						Provenance::parse_or_default(arr.value(i))
+					}),
 				};
 				graph.relationships.push(relationship);
 			}

--- a/src/indexer/graphrag/mod.rs
+++ b/src/indexer/graphrag/mod.rs
@@ -18,6 +18,7 @@ pub mod ai;
 pub mod builder;
 pub mod database;
 pub mod relationships;
+pub mod symbols;
 pub mod types;
 pub mod utils;
 

--- a/src/indexer/graphrag/mod.rs
+++ b/src/indexer/graphrag/mod.rs
@@ -18,6 +18,7 @@ pub mod ai;
 pub mod builder;
 pub mod database;
 pub mod relationships;
+pub mod runtime;
 pub mod symbols;
 pub mod types;
 pub mod utils;

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -61,6 +61,19 @@ impl RelationshipDiscovery {
 		let all_files: Vec<String> = all_nodes.iter().map(|node| node.path.clone()).collect();
 
 		for source_file in new_files {
+			let imported_node_ids: std::collections::HashSet<&str> =
+				crate::indexer::languages::get_language(&source_file.language)
+					.map(|language| {
+						source_file
+							.imports
+							.iter()
+							.filter_map(|import| {
+								language.resolve_import(import, &source_file.path, &all_files)
+							})
+							.filter_map(|path| file_map.get(&path).map(|node| node.id.as_str()))
+							.collect()
+					})
+					.unwrap_or_default();
 			// 1. Import/Export relationships via pre-built index (O(1) per import)
 			// Markdown imports are paths, not symbols. They are resolved below by
 			// `resolve_import_relationships` and emitted only as References edges.
@@ -123,7 +136,12 @@ impl RelationshipDiscovery {
 			for function in &source_file.functions {
 				for callee in &function.calls {
 					if let Some(target_ids) = symbol_index.get(callee.as_str()) {
-						for &target_id in target_ids {
+						let target_ids = Self::select_scoped_targets(
+							target_ids,
+							&imported_node_ids,
+							source_file.id.as_str(),
+						);
+						for target_id in target_ids {
 							if target_id != source_file.id {
 								relationships.push(CodeRelationship {
 									source: source_file.id.clone(),
@@ -145,7 +163,11 @@ impl RelationshipDiscovery {
 				//    `trait A: B`, `class C(D)`).
 				for extended in &function.extends {
 					if let Some(target_ids) = symbol_index.get(extended.as_str()) {
-						for &target_id in target_ids {
+						for target_id in Self::select_scoped_targets(
+							target_ids,
+							&imported_node_ids,
+							source_file.id.as_str(),
+						) {
 							if target_id != source_file.id {
 								relationships.push(CodeRelationship {
 									source: source_file.id.clone(),
@@ -167,7 +189,11 @@ impl RelationshipDiscovery {
 				//    (e.g. `class Foo implements Bar`, `impl Trait for Type`).
 				for implemented in &function.implements {
 					if let Some(target_ids) = symbol_index.get(implemented.as_str()) {
-						for &target_id in target_ids {
+						for target_id in Self::select_scoped_targets(
+							target_ids,
+							&imported_node_ids,
+							source_file.id.as_str(),
+						) {
 							if target_id != source_file.id {
 								relationships.push(CodeRelationship {
 									source: source_file.id.clone(),
@@ -200,6 +226,42 @@ impl RelationshipDiscovery {
 		});
 
 		Ok(relationships)
+	}
+
+	/// Prefer a single imported declaration, then a single global declaration.
+	/// Ambiguous file-level matches are dropped rather than fanning one call out
+	/// to every file that happens to export a ubiquitous name such as `run`.
+	fn select_scoped_targets<'a>(
+		target_ids: &[&'a str],
+		imported_node_ids: &std::collections::HashSet<&str>,
+		source_id: &str,
+	) -> Vec<&'a str> {
+		let mut imported: Vec<_> = target_ids
+			.iter()
+			.copied()
+			.filter(|target| *target != source_id && imported_node_ids.contains(*target))
+			.collect();
+		imported.sort_unstable();
+		imported.dedup();
+		if imported.len() == 1 {
+			return imported;
+		}
+		if imported.len() > 1 {
+			return Vec::new();
+		}
+
+		let mut global: Vec<_> = target_ids
+			.iter()
+			.copied()
+			.filter(|target| *target != source_id)
+			.collect();
+		global.sort_unstable();
+		global.dedup();
+		if global.len() == 1 {
+			global
+		} else {
+			Vec::new()
+		}
 	}
 
 	/// Resolve import string against the pre-built symbol index.
@@ -674,5 +736,32 @@ impl RelationshipDiscovery {
 		} else {
 			format!("{} {} file ({} lines)", file_name, language, lines)
 		}
+	}
+}
+
+#[cfg(test)]
+mod scoped_target_tests {
+	use super::RelationshipDiscovery;
+	use std::collections::HashSet;
+
+	#[test]
+	fn imported_target_wins_over_unrelated_global_match() {
+		let targets = ["src/a.rs", "src/b.rs"];
+		let imported = HashSet::from(["src/b.rs"]);
+		assert_eq!(
+			RelationshipDiscovery::select_scoped_targets(&targets, &imported, "src/main.rs"),
+			vec!["src/b.rs"]
+		);
+	}
+
+	#[test]
+	fn ambiguous_targets_are_not_fanned_out() {
+		let targets = ["src/a.rs", "src/b.rs"];
+		assert!(RelationshipDiscovery::select_scoped_targets(
+			&targets,
+			&HashSet::new(),
+			"src/main.rs"
+		)
+		.is_empty());
 	}
 }

--- a/src/indexer/graphrag/relationships.rs
+++ b/src/indexer/graphrag/relationships.rs
@@ -78,6 +78,7 @@ impl RelationshipDiscovery {
 								description: format!("Imports {} from {}", import, target_id),
 								confidence: 0.9,
 								weight: 1.0,
+								provenance: crate::indexer::graphrag::types::Provenance::Inferred,
 							});
 						}
 					}
@@ -104,6 +105,7 @@ impl RelationshipDiscovery {
 						description: "Hierarchical module relationship".to_string(),
 						confidence: 0.8,
 						weight: 0.7,
+						provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 					});
 				}
 			}
@@ -131,6 +133,8 @@ impl RelationshipDiscovery {
 									description: format!("{} calls {}", function.name, callee),
 									confidence: 0.85,
 									weight: 0.8,
+									provenance:
+										crate::indexer::graphrag::types::Provenance::Inferred,
 								});
 							}
 						}
@@ -151,6 +155,8 @@ impl RelationshipDiscovery {
 									description: format!("{} extends {}", function.name, extended),
 									confidence: 0.9,
 									weight: 1.0,
+									provenance:
+										crate::indexer::graphrag::types::Provenance::Inferred,
 								});
 							}
 						}
@@ -174,6 +180,8 @@ impl RelationshipDiscovery {
 									),
 									confidence: 0.9,
 									weight: 1.0,
+									provenance:
+										crate::indexer::graphrag::types::Provenance::Inferred,
 								});
 							}
 						}
@@ -327,6 +335,7 @@ impl RelationshipDiscovery {
 							),
 							confidence: 0.95,
 							weight: 1.0,
+							provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 						});
 
 						// Code exports may imply a reverse edge. Markdown headings are
@@ -345,6 +354,8 @@ impl RelationshipDiscovery {
 										),
 										confidence: 0.9,
 										weight: 0.8,
+										provenance:
+											crate::indexer::graphrag::types::Provenance::Inferred,
 									});
 								}
 							}
@@ -379,6 +390,7 @@ impl RelationshipDiscovery {
 					description: "Rust module declaration".to_string(),
 					confidence: 0.8,
 					weight: 0.8,
+					provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 				});
 			}
 
@@ -396,6 +408,7 @@ impl RelationshipDiscovery {
 						description: "Rust crate root relationship".to_string(),
 						confidence: 0.7,
 						weight: 0.6,
+						provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 					});
 				}
 			}
@@ -429,6 +442,7 @@ impl RelationshipDiscovery {
 						description: "JavaScript index module relationship".to_string(),
 						confidence: 0.7,
 						weight: 0.6,
+						provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 					});
 				}
 			}
@@ -460,6 +474,7 @@ impl RelationshipDiscovery {
 						description: "Python package initialization".to_string(),
 						confidence: 0.8,
 						weight: 0.7,
+						provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 					});
 				}
 			}
@@ -488,6 +503,7 @@ impl RelationshipDiscovery {
 					description: format!("Go package relationship: {}", source_package),
 					confidence: 0.8,
 					weight: 0.7,
+					provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 				});
 			}
 		}
@@ -516,6 +532,7 @@ impl RelationshipDiscovery {
 					description: format!("PHP namespace relationship: {}", source_namespace),
 					confidence: 0.8,
 					weight: 0.7,
+					provenance: crate::indexer::graphrag::types::Provenance::Extracted,
 				});
 			}
 		}

--- a/src/indexer/graphrag/runtime.rs
+++ b/src/indexer/graphrag/runtime.rs
@@ -427,6 +427,10 @@ pub fn find_paths(
 	use std::collections::{HashMap, VecDeque};
 
 	const MAX_PATHS: usize = 20;
+	// Total-work bound: the path cap alone only triggers on reaching the
+	// target, so an unreachable target on a dense symbol graph would still
+	// enumerate every simple path up to max_depth.
+	const MAX_EXPANSIONS: usize = 100_000;
 	let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
 	for relationship in &graph.relationships {
 		adjacency
@@ -441,7 +445,12 @@ pub fn find_paths(
 
 	let mut queue = VecDeque::from([vec![source_id.to_string()]]);
 	let mut paths = Vec::new();
+	let mut expansions = 0usize;
 	while let Some(path) = queue.pop_front() {
+		expansions += 1;
+		if expansions > MAX_EXPANSIONS {
+			break;
+		}
 		let current = path.last().map(String::as_str).unwrap_or_default();
 		if current == target_id {
 			paths.push(path);

--- a/src/indexer/graphrag/runtime.rs
+++ b/src/indexer/graphrag/runtime.rs
@@ -1,0 +1,584 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Always-on, zero-LLM structural graph. It is built lazily from the existing
+//! tree-sitter language adapters, cached in memory, and invalidated by the MCP
+//! watcher or a repository stamp. Optional persisted GraphRAG data only enriches
+//! this live base graph.
+
+use super::symbols::{
+	discover_symbol_relationships, extract_symbols_from_file, symbol_node_ids, SymbolFileData,
+};
+use super::types::{CodeGraph, CodeNode, CodeRelationship, Provenance, RelationType};
+use crate::indexer::{languages, NoindexWalker};
+use anyhow::{Context, Result};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::UNIX_EPOCH;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepositoryStamp {
+	fingerprint: u64,
+}
+
+#[derive(Debug, Clone)]
+struct SourceFile {
+	absolute_path: PathBuf,
+	relative_path: String,
+	language: String,
+}
+
+struct CachedGraph {
+	stamp: RepositoryStamp,
+	graph: Arc<CodeGraph>,
+}
+
+/// Cloneable cache handle shared by the graph provider and file watcher.
+#[derive(Clone, Default)]
+pub struct RuntimeGraphCache {
+	value: Arc<parking_lot::RwLock<Option<CachedGraph>>>,
+	build_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl RuntimeGraphCache {
+	/// Drop the cached graph immediately. The next graph operation rebuilds it
+	/// from current source, so file-watcher hot reload never serves stale edges.
+	pub fn invalidate(&self) {
+		*self.value.write() = None;
+	}
+
+	pub async fn graph(&self, root: &Path) -> Result<Arc<CodeGraph>> {
+		let scan_root = root.to_path_buf();
+		let (files, stamp) = tokio::task::spawn_blocking(move || scan_sources(&scan_root))
+			.await
+			.context("Structural graph source scan task failed")?;
+
+		if let Some(graph) = self.cached(&stamp) {
+			return Ok(graph);
+		}
+
+		// Serialize cold/stale rebuilds. Concurrent MCP requests reuse the graph
+		// produced by the first request instead of parsing the repository twice.
+		let _build_guard = self.build_lock.lock().await;
+		if let Some(graph) = self.cached(&stamp) {
+			return Ok(graph);
+		}
+
+		let graph = tokio::task::spawn_blocking(move || build_graph(files))
+			.await
+			.context("Structural graph build task failed")?;
+		let graph = Arc::new(graph);
+		*self.value.write() = Some(CachedGraph {
+			stamp,
+			graph: Arc::clone(&graph),
+		});
+		Ok(graph)
+	}
+
+	fn cached(&self, stamp: &RepositoryStamp) -> Option<Arc<CodeGraph>> {
+		self.value
+			.read()
+			.as_ref()
+			.filter(|cached| cached.stamp == *stamp)
+			.map(|cached| Arc::clone(&cached.graph))
+	}
+}
+
+fn scan_sources(root: &Path) -> (Vec<SourceFile>, RepositoryStamp) {
+	let mut files = Vec::new();
+	let mut stamp_items = Vec::new();
+
+	for result in NoindexWalker::create_walker(root).build() {
+		let entry = match result {
+			Ok(entry) => entry,
+			Err(_) => continue,
+		};
+		if !entry.file_type().is_some_and(|kind| kind.is_file()) {
+			continue;
+		}
+		let path = entry.path();
+		let Some(language) = crate::grep::language_from_extension(path) else {
+			continue;
+		};
+		if languages::get_language(language).is_none() {
+			continue;
+		}
+
+		let metadata = match entry.metadata() {
+			Ok(metadata) => metadata,
+			Err(_) => continue,
+		};
+		// Match structural_search's generated/bundle safety limit.
+		if metadata.len() > 5_000_000 {
+			continue;
+		}
+		let relative_path = path
+			.strip_prefix(root)
+			.unwrap_or(path)
+			.to_string_lossy()
+			.to_string();
+		let modified_nanos = metadata
+			.modified()
+			.ok()
+			.and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+			.map(|duration| duration.as_nanos())
+			.unwrap_or_default();
+		stamp_items.push((relative_path.clone(), metadata.len(), modified_nanos));
+
+		files.push(SourceFile {
+			absolute_path: path.to_path_buf(),
+			relative_path,
+			language: language.to_string(),
+		});
+	}
+
+	files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+	stamp_items.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+	let mut hasher = DefaultHasher::new();
+	stamp_items.hash(&mut hasher);
+	let stamp = RepositoryStamp {
+		fingerprint: hasher.finish(),
+	};
+	(files, stamp)
+}
+
+fn build_graph(files: Vec<SourceFile>) -> CodeGraph {
+	let cursor = AtomicUsize::new(0);
+	let parsed = parking_lot::Mutex::new(Vec::new());
+	let workers = std::thread::available_parallelism()
+		.map(|count| count.get())
+		.unwrap_or(4)
+		.min(16)
+		.min(files.len().max(1));
+
+	std::thread::scope(|scope| {
+		for _ in 0..workers {
+			scope.spawn(|| {
+				let mut local = Vec::new();
+				loop {
+					let index = cursor.fetch_add(1, Ordering::Relaxed);
+					let Some(file) = files.get(index) else {
+						break;
+					};
+					let path = file.absolute_path.to_string_lossy();
+					if let Ok(ast) = extract_symbols_from_file(&path, &file.language) {
+						local.push((file.clone(), ast));
+					}
+				}
+				parsed.lock().extend(local);
+			});
+		}
+	});
+
+	let mut parsed = parsed.into_inner();
+	parsed.sort_by(|a, b| a.0.relative_path.cmp(&b.0.relative_path));
+	let mut graph = CodeGraph::default();
+	let mut symbol_files = Vec::with_capacity(parsed.len());
+
+	for (file, ast) in &parsed {
+		let file_name = Path::new(&file.relative_path)
+			.file_name()
+			.and_then(|name| name.to_str())
+			.unwrap_or(&file.relative_path)
+			.to_string();
+		let size_lines = ast
+			.symbols
+			.iter()
+			.map(|symbol| symbol.end_line + 1)
+			.max()
+			.unwrap_or(0);
+		let file_node = CodeNode {
+			id: file.relative_path.clone(),
+			name: file_name,
+			kind: "source_file".to_string(),
+			path: file.relative_path.clone(),
+			description: String::new(),
+			symbols: ast
+				.symbols
+				.iter()
+				.map(|symbol| symbol.name.clone())
+				.collect(),
+			hash: String::new(),
+			embedding: Vec::new(),
+			imports: ast.imports.clone(),
+			exports: ast.exports.clone(),
+			functions: Vec::new(),
+			size_lines,
+			language: file.language.clone(),
+		};
+		graph.nodes.insert(file_node.id.clone(), file_node);
+
+		let symbol_ids = symbol_node_ids(&file.relative_path, &ast.symbols);
+		for (symbol, symbol_id) in ast.symbols.iter().zip(symbol_ids) {
+			graph.nodes.insert(
+				symbol_id.clone(),
+				CodeNode {
+					id: symbol_id.clone(),
+					name: symbol.name.clone(),
+					kind: symbol.kind.clone(),
+					path: file.relative_path.clone(),
+					description: format!(
+						"{} {} in {}:{}",
+						symbol.kind,
+						symbol.name,
+						file.relative_path,
+						symbol.start_line + 1
+					),
+					symbols: vec![symbol.name.clone()],
+					hash: String::new(),
+					embedding: Vec::new(),
+					imports: Vec::new(),
+					exports: Vec::new(),
+					functions: Vec::new(),
+					size_lines: symbol.end_line.saturating_sub(symbol.start_line) + 1,
+					language: file.language.clone(),
+				},
+			);
+			graph.relationships.push(CodeRelationship {
+				source: file.relative_path.clone(),
+				target: symbol_id,
+				relation_type: RelationType::Contains,
+				description: format!("{} contains {}", file.relative_path, symbol.name),
+				confidence: 1.0,
+				weight: RelationType::Contains.importance_weight(),
+				provenance: Provenance::Extracted,
+			});
+		}
+
+		symbol_files.push(SymbolFileData::from_ast(
+			file.relative_path.clone(),
+			file.language.clone(),
+			ast,
+		));
+	}
+
+	let all_paths: Vec<String> = parsed
+		.iter()
+		.map(|(file, _)| file.relative_path.clone())
+		.collect();
+	for file in &symbol_files {
+		let Some(language) = languages::get_language(&file.language) else {
+			continue;
+		};
+		for import in &file.imports {
+			if let Some(target) = language.resolve_import(import, &file.path, &all_paths) {
+				graph.relationships.push(CodeRelationship {
+					source: file.path.clone(),
+					target,
+					relation_type: RelationType::Imports,
+					description: format!("{} imports {}", file.path, import),
+					confidence: 1.0,
+					weight: RelationType::Imports.importance_weight(),
+					provenance: Provenance::Extracted,
+				});
+			}
+		}
+	}
+
+	let all_nodes: Vec<CodeNode> = graph.nodes.values().cloned().collect();
+	graph
+		.relationships
+		.extend(discover_symbol_relationships(&symbol_files, &all_nodes));
+	graph.relationships.sort_unstable_by(|a, b| {
+		(&a.source, &a.target, &a.relation_type).cmp(&(&b.source, &b.target, &b.relation_type))
+	});
+	graph.relationships.dedup_by(|a, b| {
+		a.source == b.source && a.target == b.target && a.relation_type == b.relation_type
+	});
+	graph
+}
+
+/// Overlay the optional persisted file graph onto the live structural graph.
+/// Runtime symbols remain authoritative and stale persisted symbol rows are
+/// ignored; enrichment contributes file descriptions and additional file-level
+/// relationships only while their endpoints still exist in current source.
+pub fn merge_enrichment(base: &CodeGraph, enriched: CodeGraph, root: &Path) -> CodeGraph {
+	let mut graph = base.clone();
+	for (id, node) in enriched.nodes {
+		if node.is_symbol_node() {
+			continue;
+		}
+		if let Some(current) = graph.nodes.get_mut(&id) {
+			if !node.description.is_empty() {
+				current.description = node.description;
+			}
+		} else if root.join(&node.path).is_file() {
+			graph.nodes.insert(id, node);
+		}
+	}
+
+	for relationship in enriched.relationships {
+		if relationship.source.contains("::") || relationship.target.contains("::") {
+			continue;
+		}
+		if graph.nodes.contains_key(&relationship.source)
+			&& graph.nodes.contains_key(&relationship.target)
+		{
+			graph.relationships.push(relationship);
+		}
+	}
+	graph.relationships.sort_unstable_by(|a, b| {
+		(&a.source, &a.target, &a.relation_type).cmp(&(&b.source, &b.target, &b.relation_type))
+	});
+	graph.relationships.dedup_by(|a, b| {
+		a.source == b.source && a.target == b.target && a.relation_type == b.relation_type
+	});
+	graph
+}
+
+/// Deterministic lexical seed lookup for the runtime graph. Relationship words
+/// are ignored so `what calls parse_config` seeds `parse_config`, not noise.
+pub fn search_nodes(graph: &CodeGraph, query: &str, limit: usize) -> Vec<CodeNode> {
+	const STOPWORDS: &[&str] = &[
+		"a", "an", "and", "are", "by", "calls", "does", "for", "from", "how", "in", "is", "of",
+		"or", "the", "to", "uses", "what", "where", "who",
+	];
+	let terms: Vec<String> = query
+		.split(|character: char| !character.is_alphanumeric() && character != '_')
+		.map(str::to_lowercase)
+		.filter(|term| !term.is_empty() && !STOPWORDS.contains(&term.as_str()))
+		.collect();
+	if terms.is_empty() {
+		return Vec::new();
+	}
+
+	let mut scored = Vec::new();
+	for node in graph.nodes.values() {
+		let name = node.name.to_lowercase();
+		let id = node.id.to_lowercase();
+		let path = node.path.to_lowercase();
+		let mut score = 0u32;
+		for term in &terms {
+			if name == *term {
+				score += 100;
+			} else if name.starts_with(term) {
+				score += 40;
+			} else if name.contains(term) {
+				score += 20;
+			} else if id.contains(term) || path.contains(term) {
+				score += 5;
+			}
+		}
+		if score > 0 {
+			scored.push((score, node));
+		}
+	}
+
+	scored.sort_unstable_by(|(score_a, node_a), (score_b, node_b)| {
+		score_b
+			.cmp(score_a)
+			.then_with(|| node_a.id.len().cmp(&node_b.id.len()))
+			.then_with(|| node_a.id.cmp(&node_b.id))
+	});
+	scored
+		.into_iter()
+		.take(limit)
+		.map(|(_, node)| node.clone())
+		.collect()
+}
+
+/// Bounded directed path search shared by runtime graph operations. A hard
+/// result cap prevents highly connected symbol graphs from enumerating an
+/// unbounded number of simple paths.
+pub fn find_paths(
+	graph: &CodeGraph,
+	source_id: &str,
+	target_id: &str,
+	max_depth: usize,
+) -> Vec<Vec<String>> {
+	use std::collections::{HashMap, VecDeque};
+
+	const MAX_PATHS: usize = 20;
+	let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
+	for relationship in &graph.relationships {
+		adjacency
+			.entry(relationship.source.as_str())
+			.or_default()
+			.push(relationship.target.as_str());
+	}
+	for targets in adjacency.values_mut() {
+		targets.sort_unstable();
+		targets.dedup();
+	}
+
+	let mut queue = VecDeque::from([vec![source_id.to_string()]]);
+	let mut paths = Vec::new();
+	while let Some(path) = queue.pop_front() {
+		let current = path.last().map(String::as_str).unwrap_or_default();
+		if current == target_id {
+			paths.push(path);
+			if paths.len() >= MAX_PATHS {
+				break;
+			}
+			continue;
+		}
+		if path.len().saturating_sub(1) >= max_depth {
+			continue;
+		}
+		for neighbor in adjacency.get(current).into_iter().flatten() {
+			if path.iter().any(|node| node.as_str() == *neighbor) {
+				continue;
+			}
+			let mut next = path.clone();
+			next.push((*neighbor).to_string());
+			queue.push_back(next);
+		}
+	}
+	paths
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn graph_node(id: &str, name: &str, kind: &str, path: &str) -> CodeNode {
+		CodeNode {
+			id: id.to_string(),
+			name: name.to_string(),
+			kind: kind.to_string(),
+			path: path.to_string(),
+			description: String::new(),
+			symbols: Vec::new(),
+			hash: String::new(),
+			embedding: Vec::new(),
+			imports: Vec::new(),
+			exports: Vec::new(),
+			functions: Vec::new(),
+			size_lines: 0,
+			language: "rust".to_string(),
+		}
+	}
+
+	#[test]
+	fn lexical_search_prefers_exact_symbol_over_path_match() {
+		let mut graph = CodeGraph::default();
+		for (id, name) in [
+			("src/parse_config.rs", "parse_config.rs"),
+			("src/config.rs::parse_config", "parse_config"),
+		] {
+			graph.nodes.insert(
+				id.to_string(),
+				graph_node(id, name, "function", "src/config.rs"),
+			);
+		}
+
+		let results = search_nodes(&graph, "what calls parse_config", 5);
+		assert_eq!(results[0].id, "src/config.rs::parse_config");
+	}
+
+	#[test]
+	fn path_search_is_bounded_and_avoids_cycles() {
+		let mut graph = CodeGraph::default();
+		for (source, target) in [("a", "b"), ("b", "a"), ("b", "c")] {
+			graph.relationships.push(CodeRelationship {
+				source: source.to_string(),
+				target: target.to_string(),
+				relation_type: RelationType::Calls,
+				description: String::new(),
+				confidence: 1.0,
+				weight: 1.0,
+				provenance: Provenance::Extracted,
+			});
+		}
+
+		assert!(find_paths(&graph, "a", "c", 1).is_empty());
+		assert_eq!(find_paths(&graph, "a", "c", 2), vec![vec!["a", "b", "c"]]);
+	}
+
+	#[test]
+	fn persisted_enrichment_adds_file_edges_but_not_stale_symbols() {
+		let mut base = CodeGraph::default();
+		for id in ["src/a.rs", "src/b.rs"] {
+			base.nodes
+				.insert(id.to_string(), graph_node(id, id, "source_file", id));
+		}
+		base.nodes.insert(
+			"src/a.rs::run".to_string(),
+			graph_node("src/a.rs::run", "run", "function", "src/a.rs"),
+		);
+
+		let mut enriched = CodeGraph::default();
+		let mut file = graph_node("src/a.rs", "a.rs", "source_file", "src/a.rs");
+		file.description = "Enriched file description".to_string();
+		enriched.nodes.insert(file.id.clone(), file);
+		enriched.nodes.insert(
+			"src/a.rs::old".to_string(),
+			graph_node("src/a.rs::old", "old", "function", "src/a.rs"),
+		);
+		for (source, target, relation_type) in [
+			(
+				"src/a.rs",
+				"src/b.rs",
+				RelationType::ArchitecturalDependency,
+			),
+			("src/a.rs::old", "src/a.rs::run", RelationType::Calls),
+		] {
+			enriched.relationships.push(CodeRelationship {
+				source: source.to_string(),
+				target: target.to_string(),
+				relation_type,
+				description: String::new(),
+				confidence: 1.0,
+				weight: 1.0,
+				provenance: Provenance::Inferred,
+			});
+		}
+
+		let graph = merge_enrichment(&base, enriched, Path::new("."));
+		assert_eq!(
+			graph.nodes["src/a.rs"].description,
+			"Enriched file description"
+		);
+		assert!(!graph.nodes.contains_key("src/a.rs::old"));
+		assert!(graph.relationships.iter().any(|relationship| {
+			relationship.relation_type == RelationType::ArchitecturalDependency
+		}));
+		assert!(!graph
+			.relationships
+			.iter()
+			.any(|relationship| relationship.source == "src/a.rs::old"));
+	}
+
+	#[test]
+	fn builds_symbol_call_graph_directly_from_source() {
+		let root = std::env::temp_dir().join(format!(
+			"octocode-runtime-graph-{}-{}",
+			std::process::id(),
+			std::time::SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.expect("system clock should be after Unix epoch")
+				.as_nanos()
+		));
+		std::fs::create_dir_all(&root).expect("temporary source directory should be created");
+		std::fs::write(
+			root.join("lib.rs"),
+			"fn helper() {}\nfn run() { helper(); }\n",
+		)
+		.expect("temporary Rust source should be written");
+
+		let (files, _) = scan_sources(&root);
+		let graph = build_graph(files);
+		std::fs::remove_dir_all(&root).expect("temporary source directory should be removed");
+
+		assert!(graph.nodes.contains_key("lib.rs::helper"));
+		assert!(graph.nodes.contains_key("lib.rs::run"));
+		assert!(graph.relationships.iter().any(|relationship| {
+			relationship.source == "lib.rs::run"
+				&& relationship.target == "lib.rs::helper"
+				&& relationship.relation_type == RelationType::Calls
+		}));
+	}
+}

--- a/src/indexer/graphrag/runtime.rs
+++ b/src/indexer/graphrag/runtime.rs
@@ -110,12 +110,9 @@ fn scan_sources(root: &Path) -> (Vec<SourceFile>, RepositoryStamp) {
 			continue;
 		}
 		let path = entry.path();
-		let Some(language) = crate::grep::language_from_extension(path) else {
+		let Some(language) = supported_source_language(path) else {
 			continue;
 		};
-		if languages::get_language(language).is_none() {
-			continue;
-		}
 
 		let metadata = match entry.metadata() {
 			Ok(metadata) => metadata,
@@ -153,6 +150,13 @@ fn scan_sources(root: &Path) -> (Vec<SourceFile>, RepositoryStamp) {
 		fingerprint: hasher.finish(),
 	};
 	(files, stamp)
+}
+
+fn supported_source_language(path: &Path) -> Option<&'static str> {
+	let language = crate::indexer::detect_language(path)?;
+	languages::get_language(language)
+		.is_some()
+		.then_some(language)
 }
 
 fn build_graph(files: Vec<SourceFile>) -> CodeGraph {
@@ -230,14 +234,27 @@ fn build_graph(files: Vec<SourceFile>) -> CodeGraph {
 					name: symbol.name.clone(),
 					kind: symbol.kind.clone(),
 					path: file.relative_path.clone(),
-					description: format!(
-						"{} {} in {}:{}",
-						symbol.kind,
-						symbol.name,
-						file.relative_path,
-						symbol.start_line + 1
-					),
-					symbols: vec![symbol.name.clone()],
+					description: if let Some(owner) = &symbol.owner {
+						format!(
+							"{} {}::{} in {}:{}",
+							symbol.kind,
+							owner,
+							symbol.name,
+							file.relative_path,
+							symbol.start_line + 1
+						)
+					} else {
+						format!(
+							"{} {} in {}:{}",
+							symbol.kind,
+							symbol.name,
+							file.relative_path,
+							symbol.start_line + 1
+						)
+					},
+					symbols: std::iter::once(symbol.name.clone())
+						.chain(symbol.owner.clone())
+						.collect(),
 					hash: String::new(),
 					embedding: Vec::new(),
 					imports: Vec::new(),
@@ -288,10 +305,9 @@ fn build_graph(files: Vec<SourceFile>) -> CodeGraph {
 		}
 	}
 
-	let all_nodes: Vec<CodeNode> = graph.nodes.values().cloned().collect();
 	graph
 		.relationships
-		.extend(discover_symbol_relationships(&symbol_files, &all_nodes));
+		.extend(discover_symbol_relationships(&symbol_files));
 	graph.relationships.sort_unstable_by(|a, b| {
 		(&a.source, &a.target, &a.relation_type).cmp(&(&b.source, &b.target, &b.relation_type))
 	});
@@ -360,6 +376,11 @@ pub fn search_nodes(graph: &CodeGraph, query: &str, limit: usize) -> Vec<CodeNod
 		let name = node.name.to_lowercase();
 		let id = node.id.to_lowercase();
 		let path = node.path.to_lowercase();
+		let aliases: Vec<String> = node
+			.symbols
+			.iter()
+			.map(|symbol| symbol.to_lowercase())
+			.collect();
 		let mut score = 0u32;
 		for term in &terms {
 			if name == *term {
@@ -368,6 +389,10 @@ pub fn search_nodes(graph: &CodeGraph, query: &str, limit: usize) -> Vec<CodeNod
 				score += 40;
 			} else if name.contains(term) {
 				score += 20;
+			} else if aliases.iter().any(|alias| alias == term) {
+				score += 30;
+			} else if aliases.iter().any(|alias| alias.contains(term)) {
+				score += 10;
 			} else if id.contains(term) || path.contains(term) {
 				score += 5;
 			}
@@ -444,6 +469,18 @@ pub fn find_paths(
 mod tests {
 	use super::*;
 
+	#[test]
+	fn runtime_source_detection_covers_embedded_and_document_languages() {
+		assert_eq!(
+			supported_source_language(Path::new("src/App.svelte")),
+			Some("svelte")
+		);
+		assert_eq!(
+			supported_source_language(Path::new("docs/design.md")),
+			Some("markdown")
+		);
+	}
+
 	fn graph_node(id: &str, name: &str, kind: &str, path: &str) -> CodeNode {
 		CodeNode {
 			id: id.to_string(),
@@ -477,6 +514,22 @@ mod tests {
 
 		let results = search_nodes(&graph, "what calls parse_config", 5);
 		assert_eq!(results[0].id, "src/config.rs::parse_config");
+	}
+
+	#[test]
+	fn lexical_search_uses_symbol_owner_to_disambiguate_methods() {
+		let mut graph = CodeGraph::default();
+		for (id, owner) in [
+			("src/service.rs::Service::run", "Service"),
+			("src/worker.rs::Worker::run", "Worker"),
+		] {
+			let mut node = graph_node(id, "run", "function", id.split("::").next().unwrap());
+			node.symbols = vec!["run".to_string(), owner.to_string()];
+			graph.nodes.insert(id.to_string(), node);
+		}
+
+		let results = search_nodes(&graph, "Service run", 5);
+		assert_eq!(results[0].id, "src/service.rs::Service::run");
 	}
 
 	#[test]

--- a/src/indexer/graphrag/symbols.rs
+++ b/src/indexer/graphrag/symbols.rs
@@ -136,7 +136,8 @@ pub fn symbol_kind_from_node_kind(kind: &str) -> &'static str {
 		|| kind.contains("method")
 		|| kind.contains("procedure")
 		|| kind.contains("constructor")
-		|| kind.contains("init")
+		// starts_with, not contains: "definition" contains "init".
+		|| kind.starts_with("init")
 	{
 		"function"
 	} else if kind.contains("interface") {

--- a/src/indexer/graphrag/symbols.rs
+++ b/src/indexer/graphrag/symbols.rs
@@ -105,14 +105,14 @@ pub fn extract_symbols_from_file(file_path: &str, language: &str) -> Result<File
 		.parse(&contents, None)
 		.ok_or_else(|| anyhow::anyhow!("Failed to parse file: {}", file_path))?;
 
-	let meaningful_kinds = lang_impl.get_meaningful_kinds();
+	let symbol_kinds = lang_impl.get_symbol_kinds();
 	let mut data = FileAstData::default();
 	let mut seen_names = HashSet::new();
 	walk_ast(
 		tree.root_node(),
 		&contents,
 		lang_impl.as_ref(),
-		&meaningful_kinds,
+		&symbol_kinds,
 		&mut seen_names,
 		&mut data,
 	);
@@ -126,7 +126,7 @@ fn walk_ast(
 	node: tree_sitter::Node,
 	contents: &str,
 	lang_impl: &dyn Language,
-	meaningful_kinds: &[&str],
+	symbol_kinds: &[&str],
 	seen_names: &mut HashSet<String>,
 	data: &mut FileAstData,
 ) {
@@ -142,7 +142,7 @@ fn walk_ast(
 		data.type_relations.push((line, kind, target));
 	}
 
-	if meaningful_kinds.contains(&node.kind()) {
+	if symbol_kinds.contains(&node.kind()) {
 		if let Some(name) = lang_impl.extract_declaration_name(node, contents) {
 			let name = name.trim().to_string();
 			// First declaration of a name wins: duplicate names in one file
@@ -173,7 +173,7 @@ fn walk_ast(
 			child,
 			contents,
 			lang_impl,
-			meaningful_kinds,
+			symbol_kinds,
 			seen_names,
 			data,
 		);

--- a/src/indexer/graphrag/symbols.rs
+++ b/src/indexer/graphrag/symbols.rs
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Symbol-tier GraphRAG: one graph node per declared symbol (function, class,
-// struct, trait, ...), derived purely from tree-sitter — zero LLM required.
+// Live structural graph extraction: one node per declared symbol (function,
+// class, struct, trait, ...), derived purely from tree-sitter with zero LLM.
 // Also hosts the unified single-pass AST extractor that replaced the three
 // separate per-file parses (imports/exports, call sites, type relations).
 
 use crate::indexer::graphrag::types::{CodeNode, CodeRelationship, Provenance, RelationType};
 use crate::indexer::languages::{self, Language, TypeRelationKind};
 use anyhow::{Context, Result};
-use std::collections::{HashMap, HashSet};
-
-/// Cap on the per-symbol source snippet kept for LLM description batches.
-const MAX_SYMBOL_SNIPPET_CHARS: usize = 500;
+use std::collections::HashMap;
 
 /// A declared symbol extracted from one tree-sitter node.
 #[derive(Debug, Clone)]
@@ -36,21 +33,73 @@ pub struct SymbolDecl {
 	pub start_line: u32,
 	/// 0-based end line of the declaration node.
 	pub end_line: u32,
-	/// Truncated source text of the declaration (for LLM description batches).
-	pub source_snippet: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeRelationDecl {
+	pub line: u32,
+	pub source_name: Option<String>,
+	pub kind: TypeRelationKind,
+	pub target_name: String,
 }
 
 /// Everything the graph builder needs from ONE tree-sitter parse of a file.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct FileAstData {
 	pub imports: Vec<String>,
 	pub exports: Vec<String>,
 	/// (0-based line, callee name) pairs.
 	pub calls: Vec<(u32, String)>,
-	/// (0-based line, kind, target name) tuples.
-	pub type_relations: Vec<(u32, TypeRelationKind, String)>,
+	pub type_relations: Vec<TypeRelationDecl>,
 	/// Declared symbols with line ranges, in source order.
 	pub symbols: Vec<SymbolDecl>,
+}
+
+/// AST-derived relationship input for one source file. Source ranges stay
+/// available until edge discovery so calls can be attributed to their owning
+/// declaration without LLM assistance or a second heuristic metadata format.
+#[derive(Debug, Clone)]
+pub struct SymbolFileData {
+	pub path: String,
+	pub language: String,
+	pub imports: Vec<String>,
+	pub calls: Vec<(u32, String)>,
+	pub type_relations: Vec<TypeRelationDecl>,
+	pub symbols: Vec<SymbolDecl>,
+}
+
+impl SymbolFileData {
+	pub fn from_ast(path: String, language: String, data: &FileAstData) -> Self {
+		Self {
+			path,
+			language,
+			imports: data.imports.clone(),
+			calls: data.calls.clone(),
+			type_relations: data.type_relations.clone(),
+			symbols: data.symbols.clone(),
+		}
+	}
+}
+
+/// Generate symbol ids for one file. The common case keeps the concise
+/// `{path}::{name}` form; only same-file name collisions receive a source-line
+/// suffix so methods with the same name never overwrite each other.
+pub fn symbol_node_ids(path: &str, symbols: &[SymbolDecl]) -> Vec<String> {
+	let mut counts: HashMap<&str, usize> = HashMap::new();
+	for symbol in symbols {
+		*counts.entry(symbol.name.as_str()).or_default() += 1;
+	}
+
+	symbols
+		.iter()
+		.map(|symbol| {
+			if counts.get(symbol.name.as_str()).copied().unwrap_or(0) > 1 {
+				format!("{}::{}@{}", path, symbol.name, symbol.start_line + 1)
+			} else {
+				format!("{}::{}", path, symbol.name)
+			}
+		})
+		.collect()
 }
 
 /// Map a tree-sitter node kind to a coarse symbol kind for the `kind` column.
@@ -107,13 +156,11 @@ pub fn extract_symbols_from_file(file_path: &str, language: &str) -> Result<File
 
 	let symbol_kinds = lang_impl.get_symbol_kinds();
 	let mut data = FileAstData::default();
-	let mut seen_names = HashSet::new();
 	walk_ast(
 		tree.root_node(),
 		&contents,
 		lang_impl.as_ref(),
 		&symbol_kinds,
-		&mut seen_names,
 		&mut data,
 	);
 	Ok(data)
@@ -127,7 +174,6 @@ fn walk_ast(
 	contents: &str,
 	lang_impl: &dyn Language,
 	symbol_kinds: &[&str],
-	seen_names: &mut HashSet<String>,
 	data: &mut FileAstData,
 ) {
 	let (imports, exports) = lang_impl.extract_imports_exports(node, contents);
@@ -138,30 +184,28 @@ fn walk_ast(
 	for callee in lang_impl.extract_function_calls(node, contents) {
 		data.calls.push((line, callee));
 	}
-	for (kind, target) in lang_impl.extract_type_relations(node, contents) {
-		data.type_relations.push((line, kind, target));
+	let type_relations = lang_impl.extract_type_relations(node, contents);
+	if !type_relations.is_empty() {
+		let source_name = lang_impl.extract_type_relation_source(node, contents);
+		for (kind, target_name) in type_relations {
+			data.type_relations.push(TypeRelationDecl {
+				line,
+				source_name: source_name.clone(),
+				kind,
+				target_name,
+			});
+		}
 	}
 
 	if symbol_kinds.contains(&node.kind()) {
 		if let Some(name) = lang_impl.extract_declaration_name(node, contents) {
 			let name = name.trim().to_string();
-			// First declaration of a name wins: duplicate names in one file
-			// (e.g. Rust methods on separate impl blocks) collapse into one
-			// stable symbol node id.
-			if !name.is_empty() && seen_names.insert(name.clone()) {
-				let text = node.utf8_text(contents.as_bytes()).unwrap_or_default();
-				let source_snippet = if text.len() > MAX_SYMBOL_SNIPPET_CHARS {
-					crate::utils::truncate_at_char_boundary(text, MAX_SYMBOL_SNIPPET_CHARS)
-						.to_string()
-				} else {
-					text.to_string()
-				};
+			if !name.is_empty() {
 				data.symbols.push(SymbolDecl {
 					kind: symbol_kind_from_node_kind(node.kind()).to_string(),
 					name,
 					start_line: node.start_position().row as u32,
 					end_line: node.end_position().row as u32,
-					source_snippet,
 				});
 			}
 		}
@@ -169,14 +213,7 @@ fn walk_ast(
 
 	let mut cursor = node.walk();
 	for child in node.children(&mut cursor) {
-		walk_ast(
-			child,
-			contents,
-			lang_impl,
-			symbol_kinds,
-			seen_names,
-			data,
-		);
+		walk_ast(child, contents, lang_impl, symbol_kinds, data);
 	}
 }
 
@@ -184,8 +221,8 @@ fn walk_ast(
 struct SymbolIndex<'a> {
 	/// Symbol name → symbol node ids declaring it (project-wide).
 	by_name: HashMap<&'a str, Vec<&'a str>>,
-	/// Owning file path → (symbol name → symbol node id).
-	by_file: HashMap<&'a str, HashMap<&'a str, &'a str>>,
+	/// Owning file path → (symbol name → symbol node ids).
+	by_file: HashMap<&'a str, HashMap<&'a str, Vec<&'a str>>>,
 }
 
 impl<'a> SymbolIndex<'a> {
@@ -207,7 +244,9 @@ impl<'a> SymbolIndex<'a> {
 				.by_file
 				.entry(node.path.as_str())
 				.or_default()
-				.insert(node.name.as_str(), node.id.as_str());
+				.entry(node.name.as_str())
+				.or_default()
+				.push(node.id.as_str());
 		}
 		index
 	}
@@ -217,33 +256,39 @@ impl<'a> SymbolIndex<'a> {
 	/// Returns (target id, provenance, confidence) triples.
 	fn resolve(
 		&self,
-		source_id: &str,
 		source_path: &str,
 		target_name: &str,
 		imported_files: &[String],
 		allow_ambiguous: bool,
 	) -> Vec<(&'a str, Provenance, f32)> {
 		// 1. Same file — direct AST fact.
-		if let Some(target) = self
+		if let Some(targets) = self
 			.by_file
 			.get(source_path)
 			.and_then(|m| m.get(target_name))
 		{
-			// Self-recursion produces no edge.
-			if *target != source_id {
-				return vec![(*target, Provenance::Extracted, 0.9)];
+			if targets.len() == 1 {
+				return vec![(targets[0], Provenance::Extracted, 0.9)];
+			}
+			if allow_ambiguous {
+				return targets
+					.iter()
+					.map(|id| (*id, Provenance::Ambiguous, 0.4))
+					.collect();
 			}
 			return Vec::new();
 		}
 
 		// 2. A file the source imports declares the target.
 		for imported in imported_files {
-			if let Some(target) = self
+			if let Some(targets) = self
 				.by_file
 				.get(imported.as_str())
 				.and_then(|m| m.get(target_name))
 			{
-				return vec![(*target, Provenance::Extracted, 0.85)];
+				if targets.len() == 1 {
+					return vec![(targets[0], Provenance::Extracted, 0.85)];
+				}
 			}
 		}
 
@@ -266,7 +311,7 @@ impl<'a> SymbolIndex<'a> {
 /// source files against the full graph. Pure tree-sitter + name resolution —
 /// no LLM. File-level edges are produced separately by `relationships.rs`.
 pub fn discover_symbol_relationships(
-	new_files: &[CodeNode],
+	new_files: &[SymbolFileData],
 	all_nodes: &[CodeNode],
 ) -> Vec<CodeRelationship> {
 	let index = SymbolIndex::build(all_nodes);
@@ -279,7 +324,7 @@ pub fn discover_symbol_relationships(
 	let mut relationships = Vec::new();
 
 	for source_file in new_files {
-		if source_file.language == "markdown" || source_file.is_symbol_node() {
+		if source_file.language == "markdown" {
 			continue;
 		}
 		let Some(lang_impl) = languages::get_language(&source_file.language) else {
@@ -293,66 +338,72 @@ pub fn discover_symbol_relationships(
 			.filter_map(|imp| lang_impl.resolve_import(imp, &source_file.path, &all_files))
 			.collect();
 
-		let Some(file_syms) = index.by_file.get(source_file.path.as_str()) else {
-			continue;
+		let symbol_ids = symbol_node_ids(&source_file.path, &source_file.symbols);
+		let owning_symbol = |line: u32, functions_only: bool| {
+			source_file
+				.symbols
+				.iter()
+				.enumerate()
+				.filter(|(_, symbol)| {
+					line >= symbol.start_line
+						&& line <= symbol.end_line
+						&& (!functions_only || symbol.kind == "function")
+				})
+				.min_by_key(|(_, symbol)| symbol.end_line.saturating_sub(symbol.start_line))
+				.map(|(index, symbol)| (symbol_ids[index].as_str(), symbol.name.as_str()))
 		};
 
-		for function in &source_file.functions {
-			// File-scope synthetic entries have no owning symbol node; the
-			// file-level graph already covers those references.
-			let Some(source_id) = file_syms.get(function.name.as_str()) else {
-				continue;
-			};
-
-			for callee in &function.calls {
+		for (line, callee) in &source_file.calls {
+			if let Some((source_id, source_name)) = owning_symbol(*line, true) {
 				for (target, provenance, confidence) in
-					index.resolve(source_id, &source_file.path, callee, &imported_files, false)
+					index.resolve(&source_file.path, callee, &imported_files, false)
 				{
 					relationships.push(CodeRelationship {
 						source: source_id.to_string(),
 						target: target.to_string(),
 						relation_type: RelationType::Calls,
-						description: format!("{} calls {}", function.name, callee),
+						description: format!("{} calls {}", source_name, callee),
 						confidence,
 						weight: 0.8,
 						provenance,
 					});
 				}
 			}
+		}
 
-			for extended in &function.extends {
+		for relation in &source_file.type_relations {
+			let owner = owning_symbol(relation.line, false).or_else(|| {
+				relation.source_name.as_deref().and_then(|name| {
+					source_file
+						.symbols
+						.iter()
+						.enumerate()
+						.filter(|(_, symbol)| symbol.name == name)
+						.min_by_key(|(_, symbol)| symbol.end_line.saturating_sub(symbol.start_line))
+						.map(|(index, symbol)| (symbol_ids[index].as_str(), symbol.name.as_str()))
+				})
+			});
+			if let Some((source_id, source_name)) = owner {
+				let relation_type = match relation.kind {
+					TypeRelationKind::Extends => RelationType::Extends,
+					TypeRelationKind::Implements => RelationType::Implements,
+				};
 				for (target, provenance, confidence) in index.resolve(
-					source_id,
 					&source_file.path,
-					extended,
+					&relation.target_name,
 					&imported_files,
 					true,
 				) {
 					relationships.push(CodeRelationship {
 						source: source_id.to_string(),
 						target: target.to_string(),
-						relation_type: RelationType::Extends,
-						description: format!("{} extends {}", function.name, extended),
-						confidence,
-						weight: 1.0,
-						provenance,
-					});
-				}
-			}
-
-			for implemented in &function.implements {
-				for (target, provenance, confidence) in index.resolve(
-					source_id,
-					&source_file.path,
-					implemented,
-					&imported_files,
-					true,
-				) {
-					relationships.push(CodeRelationship {
-						source: source_id.to_string(),
-						target: target.to_string(),
-						relation_type: RelationType::Implements,
-						description: format!("{} implements {}", function.name, implemented),
+						relation_type: relation_type.clone(),
+						description: format!(
+							"{} {} {}",
+							source_name,
+							relation_type.as_str(),
+							relation.target_name
+						),
 						confidence,
 						weight: 1.0,
 						provenance,
@@ -376,29 +427,16 @@ pub fn discover_symbol_relationships(
 mod tests {
 	use super::*;
 
-	fn function_info(
-		name: &str,
-		calls: &[&str],
-		extends: &[&str],
-	) -> crate::indexer::graphrag::types::FunctionInfo {
-		crate::indexer::graphrag::types::FunctionInfo {
+	fn declaration(name: &str, kind: &str, start_line: u32, end_line: u32) -> SymbolDecl {
+		SymbolDecl {
 			name: name.to_string(),
-			signature: String::new(),
-			start_line: 0,
-			end_line: u32::MAX,
-			calls: calls.iter().map(|s| s.to_string()).collect(),
-			called_by: Vec::new(),
-			parameters: Vec::new(),
-			return_type: None,
-			extends: extends.iter().map(|s| s.to_string()).collect(),
-			implements: Vec::new(),
+			kind: kind.to_string(),
+			start_line,
+			end_line,
 		}
 	}
 
-	fn file_node(
-		path: &str,
-		functions: Vec<crate::indexer::graphrag::types::FunctionInfo>,
-	) -> CodeNode {
+	fn file_node(path: &str) -> CodeNode {
 		CodeNode {
 			id: path.to_string(),
 			name: path.to_string(),
@@ -410,7 +448,7 @@ mod tests {
 			embedding: Vec::new(),
 			imports: Vec::new(),
 			exports: Vec::new(),
-			functions,
+			functions: Vec::new(),
 			size_lines: 0,
 			language: "rust".to_string(),
 		}
@@ -463,6 +501,10 @@ pub struct Config {
     pub name: String,
 }
 
+pub trait Named {}
+
+impl Named for Config {}
+
 impl Config {
     pub fn new() -> Self {
         Config { name: String::new() }
@@ -512,25 +554,58 @@ pub fn main_fn() {
 			"calls: {:?}",
 			data.calls
 		);
+
+		let implementation = data
+			.type_relations
+			.iter()
+			.find(|relation| relation.kind == TypeRelationKind::Implements)
+			.expect("Config implements Named relation");
+		assert_eq!(implementation.source_name.as_deref(), Some("Config"));
+		assert_eq!(implementation.target_name, "Named");
+	}
+
+	#[test]
+	fn duplicate_symbol_names_receive_distinct_stable_ids() {
+		let symbols = vec![
+			declaration("new", "function", 4, 8),
+			declaration("new", "function", 20, 24),
+			declaration("run", "function", 30, 35),
+		];
+		assert_eq!(
+			symbol_node_ids("src/lib.rs", &symbols),
+			vec!["src/lib.rs::new@5", "src/lib.rs::new@21", "src/lib.rs::run"]
+		);
 	}
 
 	#[test]
 	fn test_discover_symbol_relationships() {
 		// Files: a.rs (run calls helper + unique_fn + ambiguous `new`),
 		// b.rs and c.rs both declare `new` and `Base`.
-		let a = file_node(
-			"src/a.rs",
-			vec![function_info(
-				"run",
-				&["helper", "unique_fn", "new"],
-				&["Base"],
-			)],
-		);
-		let b = file_node("src/b.rs", Vec::new());
-		let c = file_node("src/c.rs", Vec::new());
+		let a = SymbolFileData {
+			path: "src/a.rs".to_string(),
+			language: "rust".to_string(),
+			imports: Vec::new(),
+			calls: ["helper", "unique_fn", "new"]
+				.into_iter()
+				.map(|callee| (5, callee.to_string()))
+				.collect(),
+			type_relations: vec![TypeRelationDecl {
+				line: 5,
+				source_name: Some("run".to_string()),
+				kind: TypeRelationKind::Extends,
+				target_name: "Base".to_string(),
+			}],
+			symbols: vec![
+				declaration("run", "function", 0, 10),
+				declaration("helper", "function", 20, 25),
+			],
+		};
+		let a_file = file_node("src/a.rs");
+		let b = file_node("src/b.rs");
+		let c = file_node("src/c.rs");
 
 		let all_nodes = vec![
-			a.clone(),
+			a_file,
 			b,
 			c,
 			symbol_node("src/a.rs", "run"),

--- a/src/indexer/graphrag/symbols.rs
+++ b/src/indexer/graphrag/symbols.rs
@@ -1,0 +1,575 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Symbol-tier GraphRAG: one graph node per declared symbol (function, class,
+// struct, trait, ...), derived purely from tree-sitter — zero LLM required.
+// Also hosts the unified single-pass AST extractor that replaced the three
+// separate per-file parses (imports/exports, call sites, type relations).
+
+use crate::indexer::graphrag::types::{CodeNode, CodeRelationship, Provenance, RelationType};
+use crate::indexer::languages::{self, Language, TypeRelationKind};
+use anyhow::{Context, Result};
+use std::collections::{HashMap, HashSet};
+
+/// Cap on the per-symbol source snippet kept for LLM description batches.
+const MAX_SYMBOL_SNIPPET_CHARS: usize = 500;
+
+/// A declared symbol extracted from one tree-sitter node.
+#[derive(Debug, Clone)]
+pub struct SymbolDecl {
+	pub name: String,
+	/// Coarse symbol kind: "function", "class", "struct", "trait", "interface",
+	/// "enum", "module", "macro", "const", "type", or "symbol".
+	pub kind: String,
+	/// 0-based start line of the declaration node.
+	pub start_line: u32,
+	/// 0-based end line of the declaration node.
+	pub end_line: u32,
+	/// Truncated source text of the declaration (for LLM description batches).
+	pub source_snippet: String,
+}
+
+/// Everything the graph builder needs from ONE tree-sitter parse of a file.
+#[derive(Debug, Default)]
+pub struct FileAstData {
+	pub imports: Vec<String>,
+	pub exports: Vec<String>,
+	/// (0-based line, callee name) pairs.
+	pub calls: Vec<(u32, String)>,
+	/// (0-based line, kind, target name) tuples.
+	pub type_relations: Vec<(u32, TypeRelationKind, String)>,
+	/// Declared symbols with line ranges, in source order.
+	pub symbols: Vec<SymbolDecl>,
+}
+
+/// Map a tree-sitter node kind to a coarse symbol kind for the `kind` column.
+pub fn symbol_kind_from_node_kind(kind: &str) -> &'static str {
+	if kind.contains("function")
+		|| kind.contains("method")
+		|| kind.contains("procedure")
+		|| kind.contains("constructor")
+	{
+		"function"
+	} else if kind.contains("interface") {
+		"interface"
+	} else if kind.contains("class") {
+		"class"
+	} else if kind.contains("struct") {
+		"struct"
+	} else if kind.contains("trait") {
+		"trait"
+	} else if kind.contains("enum") {
+		"enum"
+	} else if kind.contains("mod")
+		|| kind.contains("module")
+		|| kind.contains("namespace")
+		|| kind.contains("package")
+	{
+		"module"
+	} else if kind.contains("macro") {
+		"macro"
+	} else if kind.contains("const") || kind.contains("variable") {
+		"const"
+	} else if kind.contains("type") {
+		"type"
+	} else {
+		"symbol"
+	}
+}
+
+/// Unified single-pass AST extraction: imports, exports, call sites, type
+/// relations, and symbol declarations from ONE tree-sitter parse. Replaces
+/// the three separate parses (one per extractor) that ran per file.
+pub fn extract_symbols_from_file(file_path: &str, language: &str) -> Result<FileAstData> {
+	let lang_impl = languages::get_language(language).ok_or_else(|| {
+		anyhow::anyhow!("Failed to get language implementation for: {}", language)
+	})?;
+
+	let contents = std::fs::read_to_string(file_path)
+		.with_context(|| format!("Failed to read file for AST extraction: {}", file_path))?;
+
+	let mut parser = tree_sitter::Parser::new();
+	parser.set_language(&lang_impl.get_ts_language())?;
+	let tree = parser
+		.parse(&contents, None)
+		.ok_or_else(|| anyhow::anyhow!("Failed to parse file: {}", file_path))?;
+
+	let meaningful_kinds = lang_impl.get_meaningful_kinds();
+	let mut data = FileAstData::default();
+	let mut seen_names = HashSet::new();
+	walk_ast(
+		tree.root_node(),
+		&contents,
+		lang_impl.as_ref(),
+		&meaningful_kinds,
+		&mut seen_names,
+		&mut data,
+	);
+	Ok(data)
+}
+
+/// Single DFS over the AST collecting every extractor's output per node.
+/// Visits the same nodes in the same order as the three separate walks it
+/// replaced, so the aggregated per-category output is identical.
+fn walk_ast(
+	node: tree_sitter::Node,
+	contents: &str,
+	lang_impl: &dyn Language,
+	meaningful_kinds: &[&str],
+	seen_names: &mut HashSet<String>,
+	data: &mut FileAstData,
+) {
+	let (imports, exports) = lang_impl.extract_imports_exports(node, contents);
+	data.imports.extend(imports);
+	data.exports.extend(exports);
+
+	let line = node.start_position().row as u32; // 0-based, matches FunctionInfo
+	for callee in lang_impl.extract_function_calls(node, contents) {
+		data.calls.push((line, callee));
+	}
+	for (kind, target) in lang_impl.extract_type_relations(node, contents) {
+		data.type_relations.push((line, kind, target));
+	}
+
+	if meaningful_kinds.contains(&node.kind()) {
+		if let Some(name) = lang_impl.extract_declaration_name(node, contents) {
+			let name = name.trim().to_string();
+			// First declaration of a name wins: duplicate names in one file
+			// (e.g. Rust methods on separate impl blocks) collapse into one
+			// stable symbol node id.
+			if !name.is_empty() && seen_names.insert(name.clone()) {
+				let text = node.utf8_text(contents.as_bytes()).unwrap_or_default();
+				let source_snippet = if text.len() > MAX_SYMBOL_SNIPPET_CHARS {
+					crate::utils::truncate_at_char_boundary(text, MAX_SYMBOL_SNIPPET_CHARS)
+						.to_string()
+				} else {
+					text.to_string()
+				};
+				data.symbols.push(SymbolDecl {
+					kind: symbol_kind_from_node_kind(node.kind()).to_string(),
+					name,
+					start_line: node.start_position().row as u32,
+					end_line: node.end_position().row as u32,
+					source_snippet,
+				});
+			}
+		}
+	}
+
+	let mut cursor = node.walk();
+	for child in node.children(&mut cursor) {
+		walk_ast(
+			child,
+			contents,
+			lang_impl,
+			meaningful_kinds,
+			seen_names,
+			data,
+		);
+	}
+}
+
+/// Symbol lookup structures shared by symbol-edge discovery.
+struct SymbolIndex<'a> {
+	/// Symbol name → symbol node ids declaring it (project-wide).
+	by_name: HashMap<&'a str, Vec<&'a str>>,
+	/// Owning file path → (symbol name → symbol node id).
+	by_file: HashMap<&'a str, HashMap<&'a str, &'a str>>,
+}
+
+impl<'a> SymbolIndex<'a> {
+	fn build(all_nodes: &'a [CodeNode]) -> Self {
+		let mut index = SymbolIndex {
+			by_name: HashMap::new(),
+			by_file: HashMap::new(),
+		};
+		for node in all_nodes {
+			if !node.is_symbol_node() || node.language == "markdown" {
+				continue;
+			}
+			index
+				.by_name
+				.entry(node.name.as_str())
+				.or_default()
+				.push(node.id.as_str());
+			index
+				.by_file
+				.entry(node.path.as_str())
+				.or_default()
+				.insert(node.name.as_str(), node.id.as_str());
+		}
+		index
+	}
+
+	/// Resolve a referenced name to symbol node ids, scoped: same file first,
+	/// then files the source imports, then a unique global declaration.
+	/// Returns (target id, provenance, confidence) triples.
+	fn resolve(
+		&self,
+		source_id: &str,
+		source_path: &str,
+		target_name: &str,
+		imported_files: &[String],
+		allow_ambiguous: bool,
+	) -> Vec<(&'a str, Provenance, f32)> {
+		// 1. Same file — direct AST fact.
+		if let Some(target) = self
+			.by_file
+			.get(source_path)
+			.and_then(|m| m.get(target_name))
+		{
+			// Self-recursion produces no edge.
+			if *target != source_id {
+				return vec![(*target, Provenance::Extracted, 0.9)];
+			}
+			return Vec::new();
+		}
+
+		// 2. A file the source imports declares the target.
+		for imported in imported_files {
+			if let Some(target) = self
+				.by_file
+				.get(imported.as_str())
+				.and_then(|m| m.get(target_name))
+			{
+				return vec![(*target, Provenance::Extracted, 0.85)];
+			}
+		}
+
+		// 3. Unique global declaration.
+		match self.by_name.get(target_name) {
+			Some(ids) if ids.len() == 1 => vec![(ids[0], Provenance::Inferred, 0.6)],
+			// Multiple candidates: only type relations (extends/implements)
+			// record them — call sites hit ubiquitous method names (`new`,
+			// `get`) and would balloon the edge set with noise.
+			Some(ids) if allow_ambiguous => ids
+				.iter()
+				.map(|id| (**id, Provenance::Ambiguous, 0.4))
+				.collect(),
+			_ => Vec::new(),
+		}
+	}
+}
+
+/// Discover symbol→symbol edges (calls / extends / implements) for the given
+/// source files against the full graph. Pure tree-sitter + name resolution —
+/// no LLM. File-level edges are produced separately by `relationships.rs`.
+pub fn discover_symbol_relationships(
+	new_files: &[CodeNode],
+	all_nodes: &[CodeNode],
+) -> Vec<CodeRelationship> {
+	let index = SymbolIndex::build(all_nodes);
+	let all_files: Vec<String> = all_nodes
+		.iter()
+		.filter(|n| !n.is_symbol_node())
+		.map(|n| n.path.clone())
+		.collect();
+
+	let mut relationships = Vec::new();
+
+	for source_file in new_files {
+		if source_file.language == "markdown" || source_file.is_symbol_node() {
+			continue;
+		}
+		let Some(lang_impl) = languages::get_language(&source_file.language) else {
+			continue;
+		};
+
+		// Resolve each import to a concrete project file once per source file.
+		let imported_files: Vec<String> = source_file
+			.imports
+			.iter()
+			.filter_map(|imp| lang_impl.resolve_import(imp, &source_file.path, &all_files))
+			.collect();
+
+		let Some(file_syms) = index.by_file.get(source_file.path.as_str()) else {
+			continue;
+		};
+
+		for function in &source_file.functions {
+			// File-scope synthetic entries have no owning symbol node; the
+			// file-level graph already covers those references.
+			let Some(source_id) = file_syms.get(function.name.as_str()) else {
+				continue;
+			};
+
+			for callee in &function.calls {
+				for (target, provenance, confidence) in
+					index.resolve(source_id, &source_file.path, callee, &imported_files, false)
+				{
+					relationships.push(CodeRelationship {
+						source: source_id.to_string(),
+						target: target.to_string(),
+						relation_type: RelationType::Calls,
+						description: format!("{} calls {}", function.name, callee),
+						confidence,
+						weight: 0.8,
+						provenance,
+					});
+				}
+			}
+
+			for extended in &function.extends {
+				for (target, provenance, confidence) in index.resolve(
+					source_id,
+					&source_file.path,
+					extended,
+					&imported_files,
+					true,
+				) {
+					relationships.push(CodeRelationship {
+						source: source_id.to_string(),
+						target: target.to_string(),
+						relation_type: RelationType::Extends,
+						description: format!("{} extends {}", function.name, extended),
+						confidence,
+						weight: 1.0,
+						provenance,
+					});
+				}
+			}
+
+			for implemented in &function.implements {
+				for (target, provenance, confidence) in index.resolve(
+					source_id,
+					&source_file.path,
+					implemented,
+					&imported_files,
+					true,
+				) {
+					relationships.push(CodeRelationship {
+						source: source_id.to_string(),
+						target: target.to_string(),
+						relation_type: RelationType::Implements,
+						description: format!("{} implements {}", function.name, implemented),
+						confidence,
+						weight: 1.0,
+						provenance,
+					});
+				}
+			}
+		}
+	}
+
+	relationships.sort_unstable_by(|a, b| {
+		(&a.source, &a.target, &a.relation_type).cmp(&(&b.source, &b.target, &b.relation_type))
+	});
+	relationships.dedup_by(|a, b| {
+		a.source == b.source && a.target == b.target && a.relation_type == b.relation_type
+	});
+
+	relationships
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn function_info(
+		name: &str,
+		calls: &[&str],
+		extends: &[&str],
+	) -> crate::indexer::graphrag::types::FunctionInfo {
+		crate::indexer::graphrag::types::FunctionInfo {
+			name: name.to_string(),
+			signature: String::new(),
+			start_line: 0,
+			end_line: u32::MAX,
+			calls: calls.iter().map(|s| s.to_string()).collect(),
+			called_by: Vec::new(),
+			parameters: Vec::new(),
+			return_type: None,
+			extends: extends.iter().map(|s| s.to_string()).collect(),
+			implements: Vec::new(),
+		}
+	}
+
+	fn file_node(
+		path: &str,
+		functions: Vec<crate::indexer::graphrag::types::FunctionInfo>,
+	) -> CodeNode {
+		CodeNode {
+			id: path.to_string(),
+			name: path.to_string(),
+			kind: "source_file".to_string(),
+			path: path.to_string(),
+			description: String::new(),
+			symbols: Vec::new(),
+			hash: String::new(),
+			embedding: Vec::new(),
+			imports: Vec::new(),
+			exports: Vec::new(),
+			functions,
+			size_lines: 0,
+			language: "rust".to_string(),
+		}
+	}
+
+	fn symbol_node(path: &str, name: &str) -> CodeNode {
+		CodeNode {
+			id: format!("{}::{}", path, name),
+			name: name.to_string(),
+			kind: "function".to_string(),
+			path: path.to_string(),
+			description: String::new(),
+			symbols: Vec::new(),
+			hash: String::new(),
+			embedding: Vec::new(),
+			imports: Vec::new(),
+			exports: Vec::new(),
+			functions: Vec::new(),
+			size_lines: 0,
+			language: "rust".to_string(),
+		}
+	}
+
+	#[test]
+	fn test_symbol_kind_from_node_kind() {
+		assert_eq!(symbol_kind_from_node_kind("function_item"), "function");
+		assert_eq!(symbol_kind_from_node_kind("method_definition"), "function");
+		assert_eq!(symbol_kind_from_node_kind("class_declaration"), "class");
+		assert_eq!(symbol_kind_from_node_kind("struct_item"), "struct");
+		assert_eq!(symbol_kind_from_node_kind("trait_item"), "trait");
+		assert_eq!(
+			symbol_kind_from_node_kind("interface_declaration"),
+			"interface"
+		);
+		assert_eq!(symbol_kind_from_node_kind("enum_item"), "enum");
+		assert_eq!(symbol_kind_from_node_kind("mod_item"), "module");
+		assert_eq!(symbol_kind_from_node_kind("const_item"), "const");
+		assert_eq!(symbol_kind_from_node_kind("macro_definition"), "macro");
+		assert_eq!(symbol_kind_from_node_kind("type_item"), "type");
+		assert_eq!(symbol_kind_from_node_kind("whatever"), "symbol");
+	}
+
+	#[test]
+	fn test_extract_symbols_from_file_rust() {
+		let path =
+			std::env::temp_dir().join(format!("octocode_symbols_test_{}.rs", std::process::id()));
+		let code = r#"use std::collections::HashMap;
+
+pub struct Config {
+    pub name: String,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config { name: String::new() }
+    }
+}
+
+fn helper() -> u32 {
+    42
+}
+
+pub fn main_fn() {
+    let v = helper();
+    let m = HashMap::new();
+    println!("{}", v);
+}
+"#;
+		std::fs::write(&path, code).unwrap();
+
+		let data = extract_symbols_from_file(path.to_str().unwrap(), "rust").unwrap();
+		std::fs::remove_file(&path).unwrap();
+
+		// Imports extracted
+		assert!(
+			data.imports
+				.iter()
+				.any(|i| i == "std::collections::HashMap"),
+			"imports: {:?}",
+			data.imports
+		);
+
+		// Symbol declarations with kinds and ranges
+		let find = |name: &str| data.symbols.iter().find(|s| s.name == name);
+		let config = find("Config").expect("Config symbol");
+		assert_eq!(config.kind, "struct");
+		let new = find("new").expect("new symbol");
+		assert_eq!(new.kind, "function");
+		let helper = find("helper").expect("helper symbol");
+		assert_eq!(helper.kind, "function");
+		let main_fn = find("main_fn").expect("main_fn symbol");
+		assert_eq!(main_fn.kind, "function");
+		assert!(helper.start_line < main_fn.start_line);
+		assert!(main_fn.end_line >= main_fn.start_line);
+
+		// Call sites extracted with lines
+		assert!(
+			data.calls.iter().any(|(_, c)| c == "helper"),
+			"calls: {:?}",
+			data.calls
+		);
+	}
+
+	#[test]
+	fn test_discover_symbol_relationships() {
+		// Files: a.rs (run calls helper + unique_fn + ambiguous `new`),
+		// b.rs and c.rs both declare `new` and `Base`.
+		let a = file_node(
+			"src/a.rs",
+			vec![function_info(
+				"run",
+				&["helper", "unique_fn", "new"],
+				&["Base"],
+			)],
+		);
+		let b = file_node("src/b.rs", Vec::new());
+		let c = file_node("src/c.rs", Vec::new());
+
+		let all_nodes = vec![
+			a.clone(),
+			b,
+			c,
+			symbol_node("src/a.rs", "run"),
+			symbol_node("src/a.rs", "helper"),
+			symbol_node("src/b.rs", "unique_fn"),
+			symbol_node("src/b.rs", "new"),
+			symbol_node("src/c.rs", "new"),
+			symbol_node("src/b.rs", "Base"),
+			symbol_node("src/c.rs", "Base"),
+		];
+
+		let edges = discover_symbol_relationships(&[a], &all_nodes);
+
+		let find = |source: &str, target: &str, rel: RelationType| {
+			edges
+				.iter()
+				.find(|e| e.source == source && e.target == target && e.relation_type == rel)
+		};
+
+		// Same-file call → Extracted
+		let same_file = find("src/a.rs::run", "src/a.rs::helper", RelationType::Calls)
+			.expect("same-file call edge");
+		assert_eq!(same_file.provenance, Provenance::Extracted);
+
+		// Unique global call → Inferred
+		let global = find("src/a.rs::run", "src/b.rs::unique_fn", RelationType::Calls)
+			.expect("global-unique call edge");
+		assert_eq!(global.provenance, Provenance::Inferred);
+
+		// Ambiguous call (`new` in b.rs and c.rs) → no edge
+		assert!(find("src/a.rs::run", "src/b.rs::new", RelationType::Calls).is_none());
+		assert!(find("src/a.rs::run", "src/c.rs::new", RelationType::Calls).is_none());
+
+		// Ambiguous extends (`Base` in b.rs and c.rs) → Ambiguous edges to both
+		let amb_b = find("src/a.rs::run", "src/b.rs::Base", RelationType::Extends)
+			.expect("ambiguous extends edge to b");
+		assert_eq!(amb_b.provenance, Provenance::Ambiguous);
+		let amb_c = find("src/a.rs::run", "src/c.rs::Base", RelationType::Extends)
+			.expect("ambiguous extends edge to c");
+		assert_eq!(amb_c.provenance, Provenance::Ambiguous);
+	}
+}

--- a/src/indexer/graphrag/symbols.rs
+++ b/src/indexer/graphrag/symbols.rs
@@ -255,7 +255,7 @@ impl<'a> SymbolIndex<'a> {
 			// `get`) and would balloon the edge set with noise.
 			Some(ids) if allow_ambiguous => ids
 				.iter()
-				.map(|id| (**id, Provenance::Ambiguous, 0.4))
+				.map(|id| (&**id, Provenance::Ambiguous, 0.4))
 				.collect(),
 			_ => Vec::new(),
 		}

--- a/src/indexer/graphrag/symbols.rs
+++ b/src/indexer/graphrag/symbols.rs
@@ -17,8 +17,8 @@
 // Also hosts the unified single-pass AST extractor that replaced the three
 // separate per-file parses (imports/exports, call sites, type relations).
 
-use crate::indexer::graphrag::types::{CodeNode, CodeRelationship, Provenance, RelationType};
-use crate::indexer::languages::{self, Language, TypeRelationKind};
+use crate::indexer::graphrag::types::{CodeRelationship, Provenance, RelationType};
+use crate::indexer::languages::{self, CallTarget, Language, TypeRelationKind};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 
@@ -26,6 +26,8 @@ use std::collections::HashMap;
 #[derive(Debug, Clone)]
 pub struct SymbolDecl {
 	pub name: String,
+	/// Nearest syntactic type/module that owns this declaration.
+	pub owner: Option<String>,
 	/// Coarse symbol kind: "function", "class", "struct", "trait", "interface",
 	/// "enum", "module", "macro", "const", "type", or "symbol".
 	pub kind: String,
@@ -43,13 +45,24 @@ pub struct TypeRelationDecl {
 	pub target_name: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct ImportBinding {
+	/// Local identifier used at call sites.
+	pub local_name: String,
+	/// Original identifier in the imported file; None means a module namespace.
+	pub imported_name: Option<String>,
+	/// Import path consumed by the language's existing resolver.
+	pub import_path: String,
+}
+
 /// Everything the graph builder needs from ONE tree-sitter parse of a file.
 #[derive(Debug, Clone, Default)]
 pub struct FileAstData {
 	pub imports: Vec<String>,
+	pub import_bindings: Vec<ImportBinding>,
 	pub exports: Vec<String>,
-	/// (0-based line, callee name) pairs.
-	pub calls: Vec<(u32, String)>,
+	/// (0-based line, structured callee) pairs.
+	pub calls: Vec<(u32, CallTarget)>,
 	pub type_relations: Vec<TypeRelationDecl>,
 	/// Declared symbols with line ranges, in source order.
 	pub symbols: Vec<SymbolDecl>,
@@ -63,7 +76,8 @@ pub struct SymbolFileData {
 	pub path: String,
 	pub language: String,
 	pub imports: Vec<String>,
-	pub calls: Vec<(u32, String)>,
+	pub import_bindings: Vec<ImportBinding>,
+	pub calls: Vec<(u32, CallTarget)>,
 	pub type_relations: Vec<TypeRelationDecl>,
 	pub symbols: Vec<SymbolDecl>,
 }
@@ -74,6 +88,7 @@ impl SymbolFileData {
 			path,
 			language,
 			imports: data.imports.clone(),
+			import_bindings: data.import_bindings.clone(),
 			calls: data.calls.clone(),
 			type_relations: data.type_relations.clone(),
 			symbols: data.symbols.clone(),
@@ -81,22 +96,35 @@ impl SymbolFileData {
 	}
 }
 
-/// Generate symbol ids for one file. The common case keeps the concise
-/// `{path}::{name}` form; only same-file name collisions receive a source-line
-/// suffix so methods with the same name never overwrite each other.
+/// Generate stable, human-readable symbol ids for one file. Owned methods use
+/// `{path}::{owner}::{name}` so an LLM can distinguish `Service::run` from
+/// `Worker::run`; only true collisions (such as overloads on the same owner)
+/// receive a source-line suffix.
 pub fn symbol_node_ids(path: &str, symbols: &[SymbolDecl]) -> Vec<String> {
-	let mut counts: HashMap<&str, usize> = HashMap::new();
+	let mut counts: HashMap<(Option<&str>, &str), usize> = HashMap::new();
 	for symbol in symbols {
-		*counts.entry(symbol.name.as_str()).or_default() += 1;
+		*counts
+			.entry((symbol.owner.as_deref(), symbol.name.as_str()))
+			.or_default() += 1;
 	}
 
 	symbols
 		.iter()
 		.map(|symbol| {
-			if counts.get(symbol.name.as_str()).copied().unwrap_or(0) > 1 {
-				format!("{}::{}@{}", path, symbol.name, symbol.start_line + 1)
+			let base = if let Some(owner) = &symbol.owner {
+				format!("{}::{}::{}", path, owner, symbol.name)
 			} else {
 				format!("{}::{}", path, symbol.name)
+			};
+			if counts
+				.get(&(symbol.owner.as_deref(), symbol.name.as_str()))
+				.copied()
+				.unwrap_or(0)
+				> 1
+			{
+				format!("{}@{}", base, symbol.start_line + 1)
+			} else {
+				base
 			}
 		})
 		.collect()
@@ -108,6 +136,7 @@ pub fn symbol_kind_from_node_kind(kind: &str) -> &'static str {
 		|| kind.contains("method")
 		|| kind.contains("procedure")
 		|| kind.contains("constructor")
+		|| kind.contains("init")
 	{
 		"function"
 	} else if kind.contains("interface") {
@@ -156,13 +185,49 @@ pub fn extract_symbols_from_file(file_path: &str, language: &str) -> Result<File
 
 	let symbol_kinds = lang_impl.get_symbol_kinds();
 	let mut data = FileAstData::default();
+	let root = tree.root_node();
 	walk_ast(
-		tree.root_node(),
+		root,
 		&contents,
 		lang_impl.as_ref(),
 		&symbol_kinds,
 		&mut data,
 	);
+
+	for embedded in lang_impl.extract_embedded_sources(root, &contents) {
+		let Some(embedded_impl) = languages::get_language(embedded.language) else {
+			continue;
+		};
+		let mut embedded_parser = tree_sitter::Parser::new();
+		embedded_parser.set_language(&embedded_impl.get_ts_language())?;
+		let Some(embedded_tree) = embedded_parser.parse(&embedded.contents, None) else {
+			continue;
+		};
+		let mut embedded_data = FileAstData::default();
+		walk_ast(
+			embedded_tree.root_node(),
+			&embedded.contents,
+			embedded_impl.as_ref(),
+			&embedded_impl.get_symbol_kinds(),
+			&mut embedded_data,
+		);
+		for (line, _) in &mut embedded_data.calls {
+			*line += embedded.start_line;
+		}
+		for relation in &mut embedded_data.type_relations {
+			relation.line += embedded.start_line;
+		}
+		for symbol in &mut embedded_data.symbols {
+			symbol.start_line += embedded.start_line;
+			symbol.end_line += embedded.start_line;
+		}
+		data.imports.extend(embedded_data.imports);
+		data.import_bindings.extend(embedded_data.import_bindings);
+		data.exports.extend(embedded_data.exports);
+		data.calls.extend(embedded_data.calls);
+		data.type_relations.extend(embedded_data.type_relations);
+		data.symbols.extend(embedded_data.symbols);
+	}
 	Ok(data)
 }
 
@@ -177,6 +242,12 @@ fn walk_ast(
 	data: &mut FileAstData,
 ) {
 	let (imports, exports) = lang_impl.extract_imports_exports(node, contents);
+	data.import_bindings.extend(extract_import_bindings(
+		lang_impl.name(),
+		node,
+		contents,
+		&imports,
+	));
 	data.imports.extend(imports);
 	data.exports.extend(exports);
 
@@ -204,6 +275,7 @@ fn walk_ast(
 				data.symbols.push(SymbolDecl {
 					kind: symbol_kind_from_node_kind(node.kind()).to_string(),
 					name,
+					owner: lang_impl.extract_symbol_owner(node, contents),
 					start_line: node.start_position().row as u32,
 					end_line: node.end_position().row as u32,
 				});
@@ -217,36 +289,180 @@ fn walk_ast(
 	}
 }
 
-/// Symbol lookup structures shared by symbol-edge discovery.
-struct SymbolIndex<'a> {
-	/// Symbol name → symbol node ids declaring it (project-wide).
-	by_name: HashMap<&'a str, Vec<&'a str>>,
-	/// Owning file path → (symbol name → symbol node ids).
-	by_file: HashMap<&'a str, HashMap<&'a str, Vec<&'a str>>>,
+fn extract_import_bindings(
+	language: &str,
+	node: tree_sitter::Node,
+	contents: &str,
+	imports: &[String],
+) -> Vec<ImportBinding> {
+	if imports.is_empty() {
+		return Vec::new();
+	}
+	let Ok(text) = node.utf8_text(contents.as_bytes()) else {
+		return Vec::new();
+	};
+	let text = text.trim();
+	let mut bindings = Vec::new();
+
+	match language {
+		"python" if text.starts_with("import ") => {
+			for item in text.trim_start_matches("import ").split(',') {
+				let mut parts = item.trim().split_whitespace();
+				let Some(path) = parts.next() else { continue };
+				if parts.next() == Some("as") {
+					if let Some(alias) = parts.next() {
+						bindings.push(ImportBinding {
+							local_name: alias.to_string(),
+							imported_name: None,
+							import_path: path.to_string(),
+						});
+					}
+				}
+			}
+		}
+		"python" if text.starts_with("from ") => {
+			if let Some((module, names)) = text.trim_start_matches("from ").split_once(" import ") {
+				for item in names.trim_matches(['(', ')']).split(',') {
+					let mut parts = item.trim().split_whitespace();
+					let Some(imported) = parts.next() else {
+						continue;
+					};
+					let local = if parts.next() == Some("as") {
+						parts.next().unwrap_or(imported)
+					} else {
+						imported
+					};
+					bindings.push(ImportBinding {
+						local_name: local.to_string(),
+						imported_name: Some(imported.to_string()),
+						import_path: module.trim().to_string(),
+					});
+				}
+			}
+		}
+		"javascript" | "typescript" => {
+			let Some(path) = imports.first() else {
+				return bindings;
+			};
+			let clause = text
+				.trim_start_matches("import")
+				.split(" from ")
+				.next()
+				.unwrap_or_default()
+				.trim();
+			if let Some(alias) = clause.strip_prefix("* as ") {
+				bindings.push(ImportBinding {
+					local_name: alias.trim().to_string(),
+					imported_name: None,
+					import_path: path.clone(),
+				});
+			}
+			if let Some(start) = clause.find('{') {
+				if let Some(end) = clause.rfind('}') {
+					for item in clause[start + 1..end].split(',') {
+						let mut parts = item.trim().trim_start_matches("type ").split_whitespace();
+						let Some(imported) = parts.next() else {
+							continue;
+						};
+						let local = if parts.next() == Some("as") {
+							parts.next().unwrap_or(imported)
+						} else {
+							imported
+						};
+						bindings.push(ImportBinding {
+							local_name: local.to_string(),
+							imported_name: Some(imported.to_string()),
+							import_path: path.clone(),
+						});
+					}
+				}
+			}
+		}
+		"go" => {
+			for line in text.lines() {
+				let parts: Vec<_> = line
+					.trim()
+					.trim_start_matches("import")
+					.trim_matches(['(', ')'])
+					.split_whitespace()
+					.collect();
+				if parts.len() == 2 && !matches!(parts[0], "_" | ".") {
+					bindings.push(ImportBinding {
+						local_name: parts[0].to_string(),
+						imported_name: None,
+						import_path: parts[1].trim_matches('"').to_string(),
+					});
+				}
+			}
+		}
+		"rust" | "php" if text.contains(" as ") => {
+			let cleaned = text.trim_start_matches("use ").trim_end_matches(';').trim();
+			if let Some((path, alias)) = cleaned.rsplit_once(" as ") {
+				let imported = path
+					.rsplit([':', '\\'])
+					.find(|part| !part.is_empty())
+					.unwrap_or(path);
+				bindings.push(ImportBinding {
+					local_name: alias.trim().to_string(),
+					imported_name: Some(imported.to_string()),
+					import_path: imports.first().cloned().unwrap_or_else(|| path.to_string()),
+				});
+			}
+		}
+		_ => {}
+	}
+
+	bindings
 }
 
-impl<'a> SymbolIndex<'a> {
-	fn build(all_nodes: &'a [CodeNode]) -> Self {
+/// Symbol lookup structures shared by symbol-edge discovery.
+struct SymbolIndex {
+	/// Symbol name → symbol node ids declaring it (project-wide).
+	by_name: HashMap<String, Vec<String>>,
+	/// Owning file path → (symbol name → symbol node ids).
+	by_file: HashMap<String, HashMap<String, Vec<String>>>,
+	/// Owning type/module + symbol name → symbol node ids.
+	by_owner: HashMap<(String, String), Vec<String>>,
+	/// File + owning type/module + symbol name → symbol node ids.
+	by_file_owner: HashMap<(String, String, String), Vec<String>>,
+}
+
+impl SymbolIndex {
+	fn build(files: &[SymbolFileData]) -> Self {
 		let mut index = SymbolIndex {
 			by_name: HashMap::new(),
 			by_file: HashMap::new(),
+			by_owner: HashMap::new(),
+			by_file_owner: HashMap::new(),
 		};
-		for node in all_nodes {
-			if !node.is_symbol_node() || node.language == "markdown" {
-				continue;
+		for file in files {
+			let ids = symbol_node_ids(&file.path, &file.symbols);
+			for (symbol, id) in file.symbols.iter().zip(ids) {
+				index
+					.by_name
+					.entry(symbol.name.clone())
+					.or_default()
+					.push(id.clone());
+				index
+					.by_file
+					.entry(file.path.clone())
+					.or_default()
+					.entry(symbol.name.clone())
+					.or_default()
+					.push(id.clone());
+				if let Some(owner) = &symbol.owner {
+					index
+						.by_owner
+						.entry((owner.clone(), symbol.name.clone()))
+						.or_default()
+						.push(id.clone());
+					index
+						.by_file_owner
+						.entry((file.path.clone(), owner.clone(), symbol.name.clone()))
+						.or_default()
+						.push(id);
+				}
 			}
-			index
-				.by_name
-				.entry(node.name.as_str())
-				.or_default()
-				.push(node.id.as_str());
-			index
-				.by_file
-				.entry(node.path.as_str())
-				.or_default()
-				.entry(node.name.as_str())
-				.or_default()
-				.push(node.id.as_str());
 		}
 		index
 	}
@@ -260,7 +476,7 @@ impl<'a> SymbolIndex<'a> {
 		target_name: &str,
 		imported_files: &[String],
 		allow_ambiguous: bool,
-	) -> Vec<(&'a str, Provenance, f32)> {
+	) -> Vec<(&str, Provenance, f32)> {
 		// 1. Same file — direct AST fact.
 		if let Some(targets) = self
 			.by_file
@@ -268,58 +484,198 @@ impl<'a> SymbolIndex<'a> {
 			.and_then(|m| m.get(target_name))
 		{
 			if targets.len() == 1 {
-				return vec![(targets[0], Provenance::Extracted, 0.9)];
+				return vec![(targets[0].as_str(), Provenance::Extracted, 0.9)];
 			}
 			if allow_ambiguous {
 				return targets
 					.iter()
-					.map(|id| (*id, Provenance::Ambiguous, 0.4))
+					.map(|id| (id.as_str(), Provenance::Ambiguous, 0.4))
 					.collect();
 			}
 			return Vec::new();
 		}
 
-		// 2. A file the source imports declares the target.
+		// 2. Files the source imports declare the target. Collect across every
+		// import before deciding: returning the first match makes import order
+		// silently choose between two equally plausible declarations.
+		let mut imported_targets = Vec::new();
 		for imported in imported_files {
 			if let Some(targets) = self
 				.by_file
 				.get(imported.as_str())
 				.and_then(|m| m.get(target_name))
 			{
-				if targets.len() == 1 {
-					return vec![(targets[0], Provenance::Extracted, 0.85)];
-				}
+				imported_targets.extend(targets);
 			}
+		}
+		imported_targets.sort_unstable();
+		imported_targets.dedup();
+		if imported_targets.len() == 1 {
+			return vec![(imported_targets[0].as_str(), Provenance::Extracted, 0.85)];
+		}
+		if !imported_targets.is_empty() {
+			if allow_ambiguous {
+				return imported_targets
+					.into_iter()
+					.map(|id| (id.as_str(), Provenance::Ambiguous, 0.45))
+					.collect();
+			}
+			return Vec::new();
 		}
 
 		// 3. Unique global declaration.
 		match self.by_name.get(target_name) {
-			Some(ids) if ids.len() == 1 => vec![(ids[0], Provenance::Inferred, 0.6)],
+			Some(ids) if ids.len() == 1 => {
+				vec![(ids[0].as_str(), Provenance::Inferred, 0.6)]
+			}
 			// Multiple candidates: only type relations (extends/implements)
 			// record them — call sites hit ubiquitous method names (`new`,
 			// `get`) and would balloon the edge set with noise.
 			Some(ids) if allow_ambiguous => ids
 				.iter()
-				.map(|id| (&**id, Provenance::Ambiguous, 0.4))
+				.map(|id| (id.as_str(), Provenance::Ambiguous, 0.4))
 				.collect(),
 			_ => Vec::new(),
 		}
+	}
+
+	fn resolve_call(
+		&self,
+		source_path: &str,
+		source_owner: Option<&str>,
+		target: &CallTarget,
+		imports: &[(String, String)],
+		bindings: &[(ImportBinding, String)],
+	) -> Vec<(&str, Provenance, f32)> {
+		let imported_files: Vec<String> = imports.iter().map(|(_, path)| path.clone()).collect();
+		let mut bound_targets = Vec::new();
+		for (binding, path) in bindings {
+			if target.qualifier.is_none() && binding.local_name == target.name {
+				let imported_name = binding.imported_name.as_deref().unwrap_or(&target.name);
+				if let Some(ids) = self
+					.by_file
+					.get(path)
+					.and_then(|symbols| symbols.get(imported_name))
+				{
+					bound_targets.extend(ids);
+				}
+			}
+			if target.qualifier.as_deref() == Some(binding.local_name.as_str()) {
+				let ids = if let Some(owner) = &binding.imported_name {
+					self.by_file_owner
+						.get(&(path.clone(), owner.clone(), target.name.clone()))
+				} else {
+					self.by_file
+						.get(path)
+						.and_then(|symbols| symbols.get(&target.name))
+				};
+				if let Some(ids) = ids {
+					bound_targets.extend(ids);
+				}
+			}
+		}
+		bound_targets.sort_unstable();
+		bound_targets.dedup();
+		if bound_targets.len() == 1 {
+			return vec![(bound_targets[0].as_str(), Provenance::Extracted, 0.95)];
+		}
+		if bound_targets.len() > 1 {
+			return Vec::new();
+		}
+
+		let Some(qualifier) = target.qualifier.as_deref() else {
+			return self.resolve(source_path, &target.name, &imported_files, false);
+		};
+		let qualifier_leaf = qualifier
+			.rsplit("::")
+			.next()
+			.unwrap_or(qualifier)
+			.trim_start_matches('$');
+
+		if matches!(qualifier_leaf, "self" | "Self" | "this") {
+			if let Some(owner) = source_owner {
+				if let Some(ids) = self.by_file_owner.get(&(
+					source_path.to_string(),
+					owner.to_string(),
+					target.name.clone(),
+				)) {
+					if ids.len() == 1 {
+						return vec![(ids[0].as_str(), Provenance::Extracted, 0.95)];
+					}
+				}
+			}
+			return Vec::new();
+		}
+
+		// Static/type-qualified call (`Service::run`, `Service.run`).
+		if let Some(ids) = self.by_file_owner.get(&(
+			source_path.to_string(),
+			qualifier_leaf.to_string(),
+			target.name.clone(),
+		)) {
+			if ids.len() == 1 {
+				return vec![(ids[0].as_str(), Provenance::Extracted, 0.95)];
+			}
+		}
+		if let Some(ids) = self
+			.by_owner
+			.get(&(qualifier_leaf.to_string(), target.name.clone()))
+		{
+			if ids.len() == 1 {
+				return vec![(ids[0].as_str(), Provenance::Extracted, 0.9)];
+			}
+			let imported: Vec<_> = ids
+				.iter()
+				.filter(|id| {
+					imported_files
+						.iter()
+						.any(|path| id.starts_with(path.as_str()))
+				})
+				.collect();
+			if imported.len() == 1 {
+				return vec![(imported[0].as_str(), Provenance::Extracted, 0.85)];
+			}
+		}
+
+		// Module-qualified call: constrain lookup to the matching imported file.
+		for (raw_import, imported_file) in imports {
+			let import_leaf = raw_import
+				.rsplit([':', '.', '/'])
+				.next()
+				.unwrap_or(raw_import)
+				.trim_matches(|character: char| !character.is_alphanumeric() && character != '_');
+			let file_stem = std::path::Path::new(imported_file)
+				.file_stem()
+				.and_then(|stem| stem.to_str())
+				.unwrap_or_default();
+			if qualifier_leaf == import_leaf || qualifier_leaf == file_stem {
+				if let Some(ids) = self
+					.by_file
+					.get(imported_file)
+					.and_then(|symbols| symbols.get(&target.name))
+				{
+					if ids.len() == 1 {
+						return vec![(ids[0].as_str(), Provenance::Extracted, 0.9)];
+					}
+				}
+			}
+		}
+
+		// Unknown instance receiver: retain only a uniquely resolvable scoped
+		// target and mark it inferred; never fan out ubiquitous method names.
+		self.resolve(source_path, &target.name, &imported_files, false)
+			.into_iter()
+			.map(|(id, _, confidence)| (id, Provenance::Inferred, confidence.min(0.65)))
+			.collect()
 	}
 }
 
 /// Discover symbol→symbol edges (calls / extends / implements) for the given
 /// source files against the full graph. Pure tree-sitter + name resolution —
 /// no LLM. File-level edges are produced separately by `relationships.rs`.
-pub fn discover_symbol_relationships(
-	new_files: &[SymbolFileData],
-	all_nodes: &[CodeNode],
-) -> Vec<CodeRelationship> {
-	let index = SymbolIndex::build(all_nodes);
-	let all_files: Vec<String> = all_nodes
-		.iter()
-		.filter(|n| !n.is_symbol_node())
-		.map(|n| n.path.clone())
-		.collect();
+pub fn discover_symbol_relationships(new_files: &[SymbolFileData]) -> Vec<CodeRelationship> {
+	let index = SymbolIndex::build(new_files);
+	let all_files: Vec<String> = new_files.iter().map(|file| file.path.clone()).collect();
 
 	let mut relationships = Vec::new();
 
@@ -332,10 +688,27 @@ pub fn discover_symbol_relationships(
 		};
 
 		// Resolve each import to a concrete project file once per source file.
-		let imported_files: Vec<String> = source_file
+		let resolved_imports: Vec<(String, String)> = source_file
 			.imports
 			.iter()
-			.filter_map(|imp| lang_impl.resolve_import(imp, &source_file.path, &all_files))
+			.filter_map(|import| {
+				lang_impl
+					.resolve_import(import, &source_file.path, &all_files)
+					.map(|path| (import.clone(), path))
+			})
+			.collect();
+		let resolved_bindings: Vec<(ImportBinding, String)> = source_file
+			.import_bindings
+			.iter()
+			.filter_map(|binding| {
+				lang_impl
+					.resolve_import(&binding.import_path, &source_file.path, &all_files)
+					.map(|path| (binding.clone(), path))
+			})
+			.collect();
+		let imported_files: Vec<String> = resolved_imports
+			.iter()
+			.map(|(_, path)| path.clone())
 			.collect();
 
 		let symbol_ids = symbol_node_ids(&source_file.path, &source_file.symbols);
@@ -350,19 +723,40 @@ pub fn discover_symbol_relationships(
 						&& (!functions_only || symbol.kind == "function")
 				})
 				.min_by_key(|(_, symbol)| symbol.end_line.saturating_sub(symbol.start_line))
-				.map(|(index, symbol)| (symbol_ids[index].as_str(), symbol.name.as_str()))
+				.map(|(index, symbol)| (symbol_ids[index].as_str(), symbol))
 		};
 
 		for (line, callee) in &source_file.calls {
-			if let Some((source_id, source_name)) = owning_symbol(*line, true) {
-				for (target, provenance, confidence) in
-					index.resolve(&source_file.path, callee, &imported_files, false)
-				{
+			if let Some((source_id, source_symbol)) = owning_symbol(*line, true) {
+				let callee_display = callee
+					.qualifier
+					.as_ref()
+					.map(|qualifier| format!("{}::{}", qualifier, callee.name))
+					.unwrap_or_else(|| callee.name.clone());
+				if callee.qualifier.is_none() && callee.name == source_symbol.name {
+					relationships.push(CodeRelationship {
+						source: source_id.to_string(),
+						target: source_id.to_string(),
+						relation_type: RelationType::Calls,
+						description: format!("{} calls itself", source_symbol.name),
+						confidence: 1.0,
+						weight: 0.8,
+						provenance: Provenance::Extracted,
+					});
+					continue;
+				}
+				for (target, provenance, confidence) in index.resolve_call(
+					&source_file.path,
+					source_symbol.owner.as_deref(),
+					callee,
+					&resolved_imports,
+					&resolved_bindings,
+				) {
 					relationships.push(CodeRelationship {
 						source: source_id.to_string(),
 						target: target.to_string(),
 						relation_type: RelationType::Calls,
-						description: format!("{} calls {}", source_name, callee),
+						description: format!("{} calls {}", source_symbol.name, callee_display),
 						confidence,
 						weight: 0.8,
 						provenance,
@@ -380,10 +774,10 @@ pub fn discover_symbol_relationships(
 						.enumerate()
 						.filter(|(_, symbol)| symbol.name == name)
 						.min_by_key(|(_, symbol)| symbol.end_line.saturating_sub(symbol.start_line))
-						.map(|(index, symbol)| (symbol_ids[index].as_str(), symbol.name.as_str()))
+						.map(|(index, symbol)| (symbol_ids[index].as_str(), symbol))
 				})
 			});
-			if let Some((source_id, source_name)) = owner {
+			if let Some((source_id, source_symbol)) = owner {
 				let relation_type = match relation.kind {
 					TypeRelationKind::Extends => RelationType::Extends,
 					TypeRelationKind::Implements => RelationType::Implements,
@@ -400,7 +794,7 @@ pub fn discover_symbol_relationships(
 						relation_type: relation_type.clone(),
 						description: format!(
 							"{} {} {}",
-							source_name,
+							source_symbol.name,
 							relation_type.as_str(),
 							relation.target_name
 						),
@@ -431,44 +825,22 @@ mod tests {
 		SymbolDecl {
 			name: name.to_string(),
 			kind: kind.to_string(),
+			owner: None,
 			start_line,
 			end_line,
 		}
 	}
 
-	fn file_node(path: &str) -> CodeNode {
-		CodeNode {
-			id: path.to_string(),
-			name: path.to_string(),
-			kind: "source_file".to_string(),
-			path: path.to_string(),
-			description: String::new(),
-			symbols: Vec::new(),
-			hash: String::new(),
-			embedding: Vec::new(),
-			imports: Vec::new(),
-			exports: Vec::new(),
-			functions: Vec::new(),
-			size_lines: 0,
-			language: "rust".to_string(),
-		}
-	}
-
-	fn symbol_node(path: &str, name: &str) -> CodeNode {
-		CodeNode {
-			id: format!("{}::{}", path, name),
-			name: name.to_string(),
-			kind: "function".to_string(),
-			path: path.to_string(),
-			description: String::new(),
-			symbols: Vec::new(),
-			hash: String::new(),
-			embedding: Vec::new(),
-			imports: Vec::new(),
-			exports: Vec::new(),
-			functions: Vec::new(),
-			size_lines: 0,
-			language: "rust".to_string(),
+	fn owned_declaration(
+		owner: &str,
+		name: &str,
+		kind: &str,
+		start_line: u32,
+		end_line: u32,
+	) -> SymbolDecl {
+		SymbolDecl {
+			owner: Some(owner.to_string()),
+			..declaration(name, kind, start_line, end_line)
 		}
 	}
 
@@ -541,6 +913,7 @@ pub fn main_fn() {
 		assert_eq!(config.kind, "struct");
 		let new = find("new").expect("new symbol");
 		assert_eq!(new.kind, "function");
+		assert_eq!(new.owner.as_deref(), Some("Config"));
 		let helper = find("helper").expect("helper symbol");
 		assert_eq!(helper.kind, "function");
 		let main_fn = find("main_fn").expect("main_fn symbol");
@@ -550,7 +923,7 @@ pub fn main_fn() {
 
 		// Call sites extracted with lines
 		assert!(
-			data.calls.iter().any(|(_, c)| c == "helper"),
+			data.calls.iter().any(|(_, call)| call.name == "helper"),
 			"calls: {:?}",
 			data.calls
 		);
@@ -585,9 +958,18 @@ pub fn main_fn() {
 			path: "src/a.rs".to_string(),
 			language: "rust".to_string(),
 			imports: Vec::new(),
+			import_bindings: Vec::new(),
 			calls: ["helper", "unique_fn", "new"]
 				.into_iter()
-				.map(|callee| (5, callee.to_string()))
+				.map(|callee| {
+					(
+						5,
+						CallTarget {
+							name: callee.to_string(),
+							qualifier: None,
+						},
+					)
+				})
 				.collect(),
 			type_relations: vec![TypeRelationDecl {
 				line: 5,
@@ -600,24 +982,33 @@ pub fn main_fn() {
 				declaration("helper", "function", 20, 25),
 			],
 		};
-		let a_file = file_node("src/a.rs");
-		let b = file_node("src/b.rs");
-		let c = file_node("src/c.rs");
+		let b = SymbolFileData {
+			path: "src/b.rs".to_string(),
+			language: "rust".to_string(),
+			imports: Vec::new(),
+			import_bindings: Vec::new(),
+			calls: Vec::new(),
+			type_relations: Vec::new(),
+			symbols: vec![
+				declaration("unique_fn", "function", 0, 1),
+				declaration("new", "function", 2, 3),
+				declaration("Base", "struct", 4, 5),
+			],
+		};
+		let c = SymbolFileData {
+			path: "src/c.rs".to_string(),
+			language: "rust".to_string(),
+			imports: Vec::new(),
+			import_bindings: Vec::new(),
+			calls: Vec::new(),
+			type_relations: Vec::new(),
+			symbols: vec![
+				declaration("new", "function", 0, 1),
+				declaration("Base", "struct", 2, 3),
+			],
+		};
 
-		let all_nodes = vec![
-			a_file,
-			b,
-			c,
-			symbol_node("src/a.rs", "run"),
-			symbol_node("src/a.rs", "helper"),
-			symbol_node("src/b.rs", "unique_fn"),
-			symbol_node("src/b.rs", "new"),
-			symbol_node("src/c.rs", "new"),
-			symbol_node("src/b.rs", "Base"),
-			symbol_node("src/c.rs", "Base"),
-		];
-
-		let edges = discover_symbol_relationships(&[a], &all_nodes);
+		let edges = discover_symbol_relationships(&[a, b, c]);
 
 		let find = |source: &str, target: &str, rel: RelationType| {
 			edges
@@ -646,5 +1037,154 @@ pub fn main_fn() {
 		let amb_c = find("src/a.rs::run", "src/c.rs::Base", RelationType::Extends)
 			.expect("ambiguous extends edge to c");
 		assert_eq!(amb_c.provenance, Provenance::Ambiguous);
+	}
+
+	#[test]
+	fn qualified_and_self_calls_resolve_to_the_correct_owner() {
+		let file = SymbolFileData {
+			path: "src/services.rs".to_string(),
+			language: "rust".to_string(),
+			imports: Vec::new(),
+			import_bindings: Vec::new(),
+			calls: vec![
+				(
+					5,
+					CallTarget {
+						name: "run".to_string(),
+						qualifier: Some("self".to_string()),
+					},
+				),
+				(
+					25,
+					CallTarget {
+						name: "run".to_string(),
+						qualifier: Some("Worker".to_string()),
+					},
+				),
+			],
+			type_relations: Vec::new(),
+			symbols: vec![
+				owned_declaration("Service", "execute", "function", 0, 10),
+				owned_declaration("Service", "run", "function", 12, 16),
+				owned_declaration("Worker", "dispatch", "function", 20, 30),
+				owned_declaration("Worker", "run", "function", 32, 36),
+			],
+		};
+
+		let edges = discover_symbol_relationships(&[file]);
+		assert!(edges.iter().any(|edge| {
+			edge.source == "src/services.rs::Service::execute"
+				&& edge.target == "src/services.rs::Service::run"
+				&& edge.provenance == Provenance::Extracted
+		}));
+		assert!(edges.iter().any(|edge| {
+			edge.source == "src/services.rs::Worker::dispatch"
+				&& edge.target == "src/services.rs::Worker::run"
+				&& edge.provenance == Provenance::Extracted
+		}));
+	}
+
+	#[test]
+	fn imported_symbol_alias_resolves_to_original_declaration() {
+		let source = SymbolFileData {
+			path: "src/main.js".to_string(),
+			language: "javascript".to_string(),
+			imports: vec!["./utils".to_string()],
+			import_bindings: vec![ImportBinding {
+				local_name: "h".to_string(),
+				imported_name: Some("helper".to_string()),
+				import_path: "./utils".to_string(),
+			}],
+			calls: vec![(
+				2,
+				CallTarget {
+					name: "h".to_string(),
+					qualifier: None,
+				},
+			)],
+			type_relations: Vec::new(),
+			symbols: vec![declaration("main", "function", 0, 5)],
+		};
+		let target = SymbolFileData {
+			path: "src/utils.js".to_string(),
+			language: "javascript".to_string(),
+			imports: Vec::new(),
+			import_bindings: Vec::new(),
+			calls: Vec::new(),
+			type_relations: Vec::new(),
+			symbols: vec![declaration("helper", "function", 0, 1)],
+		};
+
+		let edges = discover_symbol_relationships(&[source, target]);
+		assert!(edges.iter().any(|edge| {
+			edge.source == "src/main.js::main"
+				&& edge.target == "src/utils.js::helper"
+				&& edge.relation_type == RelationType::Calls
+		}));
+	}
+
+	#[test]
+	fn svelte_embedded_script_builds_symbols_and_calls() {
+		let path = std::env::temp_dir().join(format!(
+			"octocode_symbols_svelte_test_{}.svelte",
+			std::process::id()
+		));
+		std::fs::write(
+			&path,
+			"<script>\nfunction helper() {}\nfunction run() { helper(); }\n</script>\n",
+		)
+		.unwrap();
+
+		let data = extract_symbols_from_file(path.to_str().unwrap(), "svelte").unwrap();
+		std::fs::remove_file(&path).unwrap();
+
+		assert!(data.symbols.iter().any(|symbol| symbol.name == "helper"));
+		assert!(data.symbols.iter().any(|symbol| symbol.name == "run"));
+		assert!(data.calls.iter().any(|(_, call)| call.name == "helper"));
+	}
+
+	#[test]
+	fn supported_object_languages_extract_method_owners() {
+		let cases = [
+			("javascript", "class Service { run() {} }", "run"),
+			("typescript", "class Service { run(): void {} }", "run"),
+			(
+				"python",
+				"class Service:\n    def run(self):\n        pass\n",
+				"run",
+			),
+			(
+				"go",
+				"package p\ntype Service struct{}\nfunc (s *Service) Run() {}\n",
+				"Run",
+			),
+			("java", "class Service { void run() {} }", "run"),
+			("cpp", "class Service { void run() {} };", "run"),
+			("php", "<?php class Service { function run() {} }", "run"),
+			("ruby", "class Service\n  def run\n  end\nend\n", "run"),
+			("lua", "function Service.run() end", "run"),
+			("swift", "class Service { func run() {} }", "run"),
+		];
+
+		for (index, (language, code, method)) in cases.into_iter().enumerate() {
+			let path = std::env::temp_dir().join(format!(
+				"octocode_owner_test_{}_{}",
+				std::process::id(),
+				index
+			));
+			std::fs::write(&path, code).unwrap();
+			let data = extract_symbols_from_file(path.to_str().unwrap(), language).unwrap();
+			std::fs::remove_file(&path).unwrap();
+			let declaration = data
+				.symbols
+				.iter()
+				.find(|symbol| symbol.name == method)
+				.unwrap_or_else(|| panic!("{language} should extract method {method}: {data:?}"));
+			assert_eq!(
+				declaration.owner.as_deref(),
+				Some("Service"),
+				"{language} should attribute {method} to Service"
+			);
+		}
 	}
 }

--- a/src/indexer/graphrag/tests.rs
+++ b/src/indexer/graphrag/tests.rs
@@ -958,7 +958,7 @@ def _private_function():
 		node: tree_sitter::Node,
 		contents: &str,
 		lang_impl: &dyn Language,
-		calls: &mut Vec<(u32, String)>,
+		calls: &mut Vec<(u32, crate::indexer::languages::CallTarget)>,
 	) {
 		let callees = lang_impl.extract_function_calls(node, contents);
 		if !callees.is_empty() {
@@ -998,17 +998,22 @@ fn helper_function(x: i32) -> i32 {
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), rust_code, lang.as_ref(), &mut calls);
 
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Rust calls: {:?}", callee_names);
 
 		assert!(
 			callee_names.contains(&"new"),
 			"Should extract Config::new() call"
 		);
-		assert!(
-			callee_names.contains(&"Config"),
-			"Should extract Config from Config::new()"
-		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "new" && call.qualifier.as_deref() == Some("Config")
+		}));
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "run" && call.qualifier.as_deref() == Some("config")
+		}));
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "process" && call.qualifier.as_deref() == Some("other_module")
+		}));
 		assert!(
 			callee_names.contains(&"helper_function"),
 			"Should extract helper_function() call"
@@ -1049,7 +1054,7 @@ def helper(x):
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), python_code, lang.as_ref(), &mut calls);
 
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Python calls: {:?}", callee_names);
 
 		assert!(
@@ -1064,6 +1069,9 @@ def helper(x):
 			callee_names.contains(&"process_data"),
 			"Should extract process_data() call"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "join" && call.qualifier.as_deref() == Some("os::path")
+		}));
 	}
 
 	#[test]
@@ -1086,7 +1094,7 @@ function main() {
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), js_code, lang.as_ref(), &mut calls);
 
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("JavaScript calls: {:?}", callee_names);
 
 		assert!(
@@ -1101,6 +1109,9 @@ function main() {
 			callee_names.contains(&"MyClass"),
 			"Should extract new MyClass() constructor"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "log" && call.qualifier.as_deref() == Some("console")
+		}));
 	}
 
 	#[test]
@@ -1128,7 +1139,7 @@ func helper(x int) int {
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), go_code, lang.as_ref(), &mut calls);
 
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Go calls: {:?}", callee_names);
 
 		assert!(
@@ -1143,6 +1154,9 @@ func helper(x int) int {
 			callee_names.contains(&"process"),
 			"Should extract process() call"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "Println" && call.qualifier.as_deref() == Some("fmt")
+		}));
 	}
 
 	#[test]
@@ -1316,7 +1330,7 @@ public class Main {
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), java_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Java calls: {:?}", callee_names);
 
 		assert!(
@@ -1331,6 +1345,9 @@ public class Main {
 			callee_names.contains(&"MyClass"),
 			"Should extract new MyClass()"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "println" && call.qualifier.as_deref() == Some("System::out")
+		}));
 	}
 
 	#[test]
@@ -1350,7 +1367,7 @@ void foo() {
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), cpp_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("C++ calls: {:?}", callee_names);
 
 		assert!(callee_names.contains(&"bar"), "Should extract bar() call");
@@ -1373,13 +1390,19 @@ function main() {
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), php_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("PHP calls: {:?}", callee_names);
 
 		assert!(
 			callee_names.contains(&"helper"),
 			"Should extract helper() call"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "method" && call.qualifier.as_deref() == Some("$obj")
+		}));
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "staticMethod" && call.qualifier.as_deref() == Some("ClassName")
+		}));
 	}
 
 	#[test]
@@ -1398,7 +1421,7 @@ end
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), ruby_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Ruby calls: {:?}", callee_names);
 
 		// Should have some calls, but not require/require_relative (filtered)
@@ -1410,6 +1433,9 @@ end
 			!callee_names.contains(&"require"),
 			"Should filter out require"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "method" && call.qualifier.as_deref() == Some("obj")
+		}));
 	}
 
 	#[test]
@@ -1428,7 +1454,7 @@ end
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), lua_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Lua calls: {:?}", callee_names);
 
 		assert!(
@@ -1444,6 +1470,9 @@ end
 			!callee_names.contains(&"require"),
 			"Should filter out require"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "method" && call.qualifier.as_deref() == Some("other")
+		}));
 	}
 
 	#[test]
@@ -1461,7 +1490,7 @@ my_function() {
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), bash_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("Bash calls: {:?}", callee_names);
 
 		assert!(
@@ -1497,7 +1526,7 @@ function main(): void {
 
 		let mut calls = Vec::new();
 		extract_function_calls_recursive(tree.root_node(), ts_code, lang.as_ref(), &mut calls);
-		let callee_names: Vec<&str> = calls.iter().map(|(_, name)| name.as_str()).collect();
+		let callee_names: Vec<&str> = calls.iter().map(|(_, call)| call.name.as_str()).collect();
 		println!("TypeScript calls: {:?}", callee_names);
 
 		assert!(
@@ -1508,6 +1537,9 @@ function main(): void {
 			callee_names.contains(&"log"),
 			"Should extract console.log() call"
 		);
+		assert!(calls.iter().any(|(_, call)| {
+			call.name == "log" && call.qualifier.as_deref() == Some("console")
+		}));
 	}
 
 	/// Helper function to extract imports/exports recursively (same as in builder.rs)

--- a/src/indexer/graphrag/types.rs
+++ b/src/indexer/graphrag/types.rs
@@ -227,9 +227,8 @@ impl CodeNode {
 		}
 	}
 
-	/// True for symbol-tier nodes (`{file_path}::{symbol_name}`), created by
-	/// `graphrag.symbols`. File node ids are relative paths and never contain
-	/// `::` in practice.
+	/// True for lightweight symbol-tier nodes (`{file_path}::{symbol_name}`).
+	/// File node ids are relative paths and never contain `::` in practice.
 	pub fn is_symbol_node(&self) -> bool {
 		self.id.contains("::")
 	}

--- a/src/indexer/graphrag/types.rs
+++ b/src/indexer/graphrag/types.rs
@@ -70,6 +70,8 @@ pub enum RelationType {
 	ParentModule,
 	/// Child directory relationship
 	ChildModule,
+	/// File contains a declared symbol (symbol-tier GraphRAG)
+	Contains,
 }
 
 impl RelationType {
@@ -90,7 +92,7 @@ impl RelationType {
 			Self::References => 0.6,
 
 			// Low importance - organizational structure
-			Self::SiblingModule | Self::ParentModule | Self::ChildModule => 0.3,
+			Self::SiblingModule | Self::ParentModule | Self::ChildModule | Self::Contains => 0.3,
 		}
 	}
 
@@ -112,6 +114,7 @@ impl RelationType {
 			Self::SiblingModule => "sibling_module",
 			Self::ParentModule => "parent_module",
 			Self::ChildModule => "child_module",
+			Self::Contains => "contains",
 		}
 	}
 }
@@ -137,6 +140,7 @@ impl FromStr for RelationType {
 			"sibling_module" => Self::SiblingModule,
 			"parent_module" => Self::ParentModule,
 			"child_module" => Self::ChildModule,
+			"contains" => Self::Contains,
 			// Default fallback for unknown types
 			_ => Self::Imports,
 		})
@@ -146,6 +150,40 @@ impl FromStr for RelationType {
 impl fmt::Display for RelationType {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "{}", self.as_str())
+	}
+}
+
+/// How a relationship was derived. `Extracted` = read directly from the AST
+/// (import statements, declared inheritance, same-file calls, module layout);
+/// `Inferred` = resolved by heuristics (cross-file name matching, unique-global
+/// resolution, LLM suggestions); `Ambiguous` = the reference matches multiple
+/// targets and no import disambiguated it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+	#[default]
+	Extracted,
+	Inferred,
+	Ambiguous,
+}
+
+impl Provenance {
+	/// Parse from the database column value; unknown/absent values (older
+	/// rows written before the column existed) default to `Extracted`.
+	pub fn parse_or_default(s: &str) -> Self {
+		match s {
+			"inferred" => Self::Inferred,
+			"ambiguous" => Self::Ambiguous,
+			_ => Self::Extracted,
+		}
+	}
+
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Self::Extracted => "extracted",
+			Self::Inferred => "inferred",
+			Self::Ambiguous => "ambiguous",
+		}
 	}
 }
 
@@ -188,6 +226,13 @@ impl CodeNode {
 			language: self.language.clone(),
 		}
 	}
+
+	/// True for symbol-tier nodes (`{file_path}::{symbol_name}`), created by
+	/// `graphrag.symbols`. File node ids are relative paths and never contain
+	/// `::` in practice.
+	pub fn is_symbol_node(&self) -> bool {
+		self.id.contains("::")
+	}
 }
 
 // Function-level information for better granularity. Also doubles as the
@@ -220,6 +265,8 @@ pub struct CodeRelationship {
 	pub description: String,         // Brief description
 	pub confidence: f32,             // Confidence score (0.0-1.0)
 	pub weight: f32,                 // Relationship strength/frequency
+	#[serde(default)]
+	pub provenance: Provenance, // How the relationship was derived
 }
 
 impl CodeRelationship {
@@ -237,6 +284,7 @@ impl CodeRelationship {
 			description,
 			confidence: 0.9, // Default high confidence for AST-based relationships
 			weight: 1.0,     // Default weight, will be calculated later
+			provenance: Provenance::default(),
 		}
 	}
 
@@ -256,6 +304,7 @@ impl CodeRelationship {
 			description,
 			confidence,
 			weight,
+			provenance: Provenance::default(),
 		}
 	}
 }
@@ -507,5 +556,76 @@ mod tests {
 		assert_eq!(deserialized.target, rel.target);
 		assert_eq!(deserialized.relation_type, rel.relation_type);
 		assert_eq!(deserialized.description, rel.description);
+	}
+
+	#[test]
+	fn test_relation_type_contains_roundtrip() {
+		assert_eq!(RelationType::Contains.as_str(), "contains");
+		assert_eq!(
+			"contains".parse::<RelationType>().unwrap(),
+			RelationType::Contains
+		);
+		assert_eq!(RelationType::Contains.importance_weight(), 0.3);
+	}
+
+	#[test]
+	fn test_provenance_serde_roundtrip() {
+		let mut rel = CodeRelationship::new(
+			"src/a.rs".to_string(),
+			"src/a.rs::foo".to_string(),
+			RelationType::Contains,
+			"File contains function foo".to_string(),
+		);
+		assert_eq!(rel.provenance, Provenance::default());
+
+		rel.provenance = Provenance::Inferred;
+		let json = serde_json::to_string(&rel).unwrap();
+		assert!(json.contains("\"inferred\""));
+		let deserialized: CodeRelationship = serde_json::from_str(&json).unwrap();
+		assert_eq!(deserialized.provenance, Provenance::Inferred);
+	}
+
+	#[test]
+	fn test_provenance_parse_or_default() {
+		assert_eq!(
+			Provenance::parse_or_default("extracted"),
+			Provenance::Extracted
+		);
+		assert_eq!(
+			Provenance::parse_or_default("inferred"),
+			Provenance::Inferred
+		);
+		assert_eq!(
+			Provenance::parse_or_default("ambiguous"),
+			Provenance::Ambiguous
+		);
+		// Unknown values (rows written before the column existed) default to Extracted
+		assert_eq!(Provenance::parse_or_default(""), Provenance::Extracted);
+		assert_eq!(
+			Provenance::parse_or_default("legacy"),
+			Provenance::Extracted
+		);
+	}
+
+	#[test]
+	fn test_code_node_is_symbol_node() {
+		let mut node = CodeNode {
+			id: "src/lib.rs".to_string(),
+			name: "lib".to_string(),
+			kind: "source_file".to_string(),
+			path: "src/lib.rs".to_string(),
+			description: String::new(),
+			symbols: Vec::new(),
+			hash: String::new(),
+			embedding: Vec::new(),
+			imports: Vec::new(),
+			exports: Vec::new(),
+			functions: Vec::new(),
+			size_lines: 0,
+			language: "rust".to_string(),
+		};
+		assert!(!node.is_symbol_node());
+		node.id = "src/lib.rs::my_func".to_string();
+		assert!(node.is_symbol_node());
 	}
 }

--- a/src/indexer/graphrag/types.rs
+++ b/src/indexer/graphrag/types.rs
@@ -70,7 +70,7 @@ pub enum RelationType {
 	ParentModule,
 	/// Child directory relationship
 	ChildModule,
-	/// File contains a declared symbol (symbol-tier GraphRAG)
+	/// File contains a declared live AST symbol
 	Contains,
 }
 
@@ -227,7 +227,8 @@ impl CodeNode {
 		}
 	}
 
-	/// True for lightweight symbol-tier nodes (`{file_path}::{symbol_name}`).
+	/// True for live AST symbol nodes (`{file_path}::{symbol_name}` or
+	/// `{file_path}::{owner}::{method}`).
 	/// File node ids are relative paths and never contain `::` in practice.
 	pub fn is_symbol_node(&self) -> bool {
 		self.id.contains("::")

--- a/src/indexer/graphrag/utils.rs
+++ b/src/indexer/graphrag/utils.rs
@@ -246,7 +246,8 @@ pub fn normalize_node_id(input: &str) -> String {
 }
 
 /// Find a node in the graph with fuzzy matching.
-/// Tries: exact match → normalized match → file suffix → unique symbol name.
+/// Tries: exact match → normalized match → file suffix → unique owner-qualified
+/// symbol suffix → unique bare symbol name.
 /// Returns the actual node ID stored in the graph.
 pub fn find_node_id<'a>(graph: &'a super::types::CodeGraph, input: &str) -> Option<&'a str> {
 	// 1. Exact match
@@ -286,7 +287,25 @@ pub fn find_node_id<'a>(graph: &'a super::types::CodeGraph, input: &str) -> Opti
 		return best_match;
 	}
 
-	// 4. Bare symbol name. Resolve only when unique so overloaded/common names
+	// 4. Owner-qualified symbol suffix (`Service::run`). Resolve only when
+	// unique across files, just like a bare symbol name.
+	if normalized.contains("::") {
+		let suffix = format!("::{}", normalized_lower);
+		let mut owned_match = None;
+		for key in graph.nodes.keys() {
+			if key.to_lowercase().ends_with(&suffix) {
+				if owned_match.is_some() {
+					return None;
+				}
+				owned_match = Some(key.as_str());
+			}
+		}
+		if owned_match.is_some() {
+			return owned_match;
+		}
+	}
+
+	// 5. Bare symbol name. Resolve only when unique so overloaded/common names
 	// never silently select an arbitrary graph node.
 	let mut symbol_match = None;
 	for (key, node) in &graph.nodes {
@@ -387,6 +406,19 @@ mod tests {
 			symbol_node("tests/config.rs::parse_config", "parse_config"),
 		);
 		assert_eq!(find_node_id(&graph, "parse_config"), None);
+	}
+
+	#[test]
+	fn resolves_unique_owner_qualified_symbol_suffix() {
+		let mut graph = super::super::types::CodeGraph::default();
+		graph.nodes.insert(
+			"src/service.rs::Service::run".to_string(),
+			symbol_node("src/service.rs::Service::run", "run"),
+		);
+		assert_eq!(
+			find_node_id(&graph, "Service::run"),
+			Some("src/service.rs::Service::run")
+		);
 	}
 
 	#[test]

--- a/src/indexer/graphrag/utils.rs
+++ b/src/indexer/graphrag/utils.rs
@@ -246,7 +246,7 @@ pub fn normalize_node_id(input: &str) -> String {
 }
 
 /// Find a node in the graph with fuzzy matching.
-/// Tries: exact match → normalized match → suffix match.
+/// Tries: exact match → normalized match → file suffix → unique symbol name.
 /// Returns the actual node ID stored in the graph.
 pub fn find_node_id<'a>(graph: &'a super::types::CodeGraph, input: &str) -> Option<&'a str> {
 	// 1. Exact match
@@ -282,7 +282,23 @@ pub fn find_node_id<'a>(graph: &'a super::types::CodeGraph, input: &str) -> Opti
 		}
 	}
 
-	best_match
+	if best_match.is_some() {
+		return best_match;
+	}
+
+	// 4. Bare symbol name. Resolve only when unique so overloaded/common names
+	// never silently select an arbitrary graph node.
+	let mut symbol_match = None;
+	for (key, node) in &graph.nodes {
+		if node.is_symbol_node() && node.name.eq_ignore_ascii_case(&normalized) {
+			if symbol_match.is_some() {
+				return None;
+			}
+			symbol_match = Some(key.as_str());
+		}
+	}
+
+	symbol_match
 }
 
 // Check if two symbols match (accounting for common patterns)
@@ -335,6 +351,43 @@ pub fn is_parent_child_relationship(path1: &str, path2: &str) -> bool {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn symbol_node(id: &str, name: &str) -> super::super::types::CodeNode {
+		super::super::types::CodeNode {
+			id: id.to_string(),
+			name: name.to_string(),
+			kind: "function".to_string(),
+			path: id.split("::").next().unwrap_or_default().to_string(),
+			description: String::new(),
+			symbols: Vec::new(),
+			hash: String::new(),
+			embedding: Vec::new(),
+			imports: Vec::new(),
+			exports: Vec::new(),
+			functions: Vec::new(),
+			size_lines: 0,
+			language: "rust".to_string(),
+		}
+	}
+
+	#[test]
+	fn resolves_only_unique_bare_symbol_names() {
+		let mut graph = super::super::types::CodeGraph::default();
+		graph.nodes.insert(
+			"src/config.rs::parse_config".to_string(),
+			symbol_node("src/config.rs::parse_config", "parse_config"),
+		);
+		assert_eq!(
+			find_node_id(&graph, "parse_config"),
+			Some("src/config.rs::parse_config")
+		);
+
+		graph.nodes.insert(
+			"tests/config.rs::parse_config".to_string(),
+			symbol_node("tests/config.rs::parse_config", "parse_config"),
+		);
+		assert_eq!(find_node_id(&graph, "parse_config"), None);
+	}
 
 	#[test]
 	fn test_is_parent_child_relationship_cross_platform() {

--- a/src/indexer/languages/bash.rs
+++ b/src/indexer/languages/bash.rs
@@ -32,6 +32,26 @@ impl Language for Bash {
 		vec!["function_definition", "command"] // command for source/. statements
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Only named functions are symbols; `command` nodes (source/. calls)
+		// declare nothing.
+		vec!["function_definition"]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		// Bash function names are `word` nodes exposed via the `name` field;
+		// the default identifier/name scan never matches them — and on
+		// `command` nodes it would match `command_name`, turning every
+		// command into a bogus symbol.
+		if node.kind() == "function_definition" {
+			return node
+				.child_by_field_name("name")
+				.and_then(|n| n.utf8_text(contents.as_bytes()).ok())
+				.map(str::to_string);
+		}
+		None
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/bash.rs
+++ b/src/indexer/languages/bash.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ impl Language for Bash {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "command" {
 			// Use the `name` field rather than child(0) — a `command` node can have
 			// leading `variable_assignment`/redirect children (e.g. `DEBUG=1 cmd`),
@@ -163,7 +163,7 @@ impl Language for Bash {
 					if name == "source" || name == "." {
 						return Vec::new();
 					}
-					return vec![name.to_string()];
+					return super::extract_call_target(name).into_iter().collect();
 				}
 			}
 		}

--- a/src/indexer/languages/cpp.rs
+++ b/src/indexer/languages/cpp.rs
@@ -56,6 +56,20 @@ impl Language for Cpp {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier restores class/struct containers and drops noise:
+		// `declaration` matches every local variable declaration (its
+		// identifier child would become a bogus symbol), and #include
+		// directives declare no symbol.
+		vec![
+			"function_definition",
+			"class_specifier",
+			"struct_specifier",
+			"enum_specifier",
+			"namespace_definition",
+		]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/cpp.rs
+++ b/src/indexer/languages/cpp.rs
@@ -77,6 +77,16 @@ impl Language for Cpp {
 			let callable = text.split('(').next().unwrap_or(text);
 			return super::extract_call_target(callable).map(|target| target.name);
 		}
+		// Bodyless specifiers are type REFERENCES (`struct stat st;`) or forward
+		// declarations, not definitions — naming them would mint a bogus symbol
+		// at every usage site.
+		if matches!(
+			node.kind(),
+			"class_specifier" | "struct_specifier" | "enum_specifier"
+		) && node.child_by_field_name("body").is_none()
+		{
+			return None;
+		}
 		node.child_by_field_name("name")
 			.and_then(|name| name.utf8_text(contents.as_bytes()).ok())
 			.map(str::to_string)

--- a/src/indexer/languages/cpp.rs
+++ b/src/indexer/languages/cpp.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,6 +68,41 @@ impl Language for Cpp {
 			"enum_specifier",
 			"namespace_definition",
 		]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() == "function_definition" {
+			let declarator = node.child_by_field_name("declarator")?;
+			let text = declarator.utf8_text(contents.as_bytes()).ok()?;
+			let callable = text.split('(').next().unwrap_or(text);
+			return super::extract_call_target(callable).map(|target| target.name);
+		}
+		node.child_by_field_name("name")
+			.and_then(|name| name.utf8_text(contents.as_bytes()).ok())
+			.map(str::to_string)
+			.or_else(|| {
+				super::extract_symbol_by_kinds(
+					node,
+					contents,
+					&["identifier", "type_identifier", "namespace_identifier"],
+				)
+			})
+	}
+
+	fn extract_symbol_owner(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() == "function_definition" {
+			if let Some(declarator) = node.child_by_field_name("declarator") {
+				if let Ok(text) = declarator.utf8_text(contents.as_bytes()) {
+					let callable = text.split('(').next().unwrap_or(text);
+					if let Some(owner) =
+						super::extract_call_target(callable).and_then(|target| target.qualifier)
+					{
+						return super::simple_type_name(&owner);
+					}
+				}
+			}
+		}
+		super::find_graph_symbol_owner(node, contents)
 	}
 
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
@@ -348,11 +383,11 @@ impl Language for Cpp {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "call_expression" {
 			if let Some(func_node) = node.child(0) {
 				if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-					return super::extract_callee_identifiers(text);
+					return super::extract_call_target(text).into_iter().collect();
 				}
 			}
 		}

--- a/src/indexer/languages/go.rs
+++ b/src/indexer/languages/go.rs
@@ -175,15 +175,30 @@ impl Language for Go {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "call_expression" {
 			if let Some(func_node) = node.child(0) {
 				if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-					return super::extract_callee_identifiers(text);
+					return super::extract_call_target(text).into_iter().collect();
 				}
 			}
 		}
 		Vec::new()
+	}
+
+	fn extract_symbol_owner(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() != "method_declaration" {
+			return super::find_graph_symbol_owner(node, contents);
+		}
+		let receiver = node.child_by_field_name("receiver")?;
+		for parameter in receiver.children(&mut receiver.walk()) {
+			if let Some(receiver_type) = parameter.child_by_field_name("type") {
+				if let Ok(text) = receiver_type.utf8_text(contents.as_bytes()) {
+					return super::simple_type_name(text);
+				}
+			}
+		}
+		None
 	}
 
 	fn extract_type_relations(

--- a/src/indexer/languages/go.rs
+++ b/src/indexer/languages/go.rs
@@ -39,6 +39,15 @@ impl Language for Go {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// `type_spec` instead of `type_declaration`: the name lives two levels
+		// deep (type_declaration > type_spec > identifier), so per-spec nodes
+		// are the only way the default name scan resolves them — and grouped
+		// declarations (`type ( A ...; B ... )`) yield one symbol per spec.
+		// const/var/import declarations declare no single named symbol.
+		vec!["function_declaration", "method_declaration", "type_spec"]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/java.rs
+++ b/src/indexer/languages/java.rs
@@ -273,26 +273,28 @@ impl Language for Java {
 		});
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		match node.kind() {
 			"method_invocation" => {
-				// Extract method name and object identifiers
-				let mut result = Vec::new();
-				for child in node.children(&mut node.walk()) {
-					if child.kind() == "identifier" {
-						if let Ok(text) = child.utf8_text(contents.as_bytes()) {
-							result.push(text.to_string());
-						}
-					}
-				}
-				result
+				let Some(name_node) = node.child_by_field_name("name") else {
+					return Vec::new();
+				};
+				let Ok(name) = name_node.utf8_text(contents.as_bytes()) else {
+					return Vec::new();
+				};
+				let raw = node
+					.child_by_field_name("object")
+					.and_then(|object| object.utf8_text(contents.as_bytes()).ok())
+					.map(|object| format!("{}.{}", object, name))
+					.unwrap_or_else(|| name.to_string());
+				super::extract_call_target(&raw).into_iter().collect()
 			}
 			"object_creation_expression" => {
 				// new Foo() → extract type name
 				for child in node.children(&mut node.walk()) {
 					if child.kind() == "type_identifier" || child.kind() == "generic_type" {
 						if let Ok(text) = child.utf8_text(contents.as_bytes()) {
-							return super::extract_callee_identifiers(text);
+							return super::extract_call_target(text).into_iter().collect();
 						}
 					}
 				}

--- a/src/indexer/languages/java.rs
+++ b/src/indexer/languages/java.rs
@@ -49,6 +49,21 @@ impl Language for Java {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier restores the type containers chunking excludes and drops
+		// non-symbol noise: field_declaration would name the symbol after its
+		// TYPE (first matching child), and lambdas/imports declare no symbol.
+		vec![
+			"class_declaration",
+			"interface_declaration",
+			"enum_declaration",
+			"record_declaration",
+			"annotation_type_declaration",
+			"method_declaration",
+			"constructor_declaration",
+		]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/java.rs
+++ b/src/indexer/languages/java.rs
@@ -64,6 +64,15 @@ impl Language for Java {
 		]
 	}
 
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		// The default child scan would match a method's RETURN TYPE
+		// (type_identifier precedes the name), so use the grammar's `name`
+		// field — every symbol kind above declares one.
+		node.child_by_field_name("name")
+			.and_then(|name| name.utf8_text(contents.as_bytes()).ok())
+			.map(str::to_string)
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/javascript.rs
+++ b/src/indexer/languages/javascript.rs
@@ -47,8 +47,23 @@ impl Language for JavaScript {
 		vec![
 			"function_declaration",
 			"method_definition",
+			"arrow_function",
 			"class_declaration",
 		]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() == "arrow_function" {
+			let parent = node.parent()?;
+			if parent.kind() != "variable_declarator" {
+				return None;
+			}
+			return parent
+				.child_by_field_name("name")
+				.and_then(|name| name.utf8_text(contents.as_bytes()).ok())
+				.map(str::to_string);
+		}
+		super::extract_symbol_by_kinds(node, contents, &["identifier", "name"])
 	}
 
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
@@ -186,13 +201,13 @@ impl Language for JavaScript {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		match node.kind() {
 			"call_expression" => {
 				// First child is the function being called
 				if let Some(func_node) = node.child(0) {
 					if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-						return super::extract_callee_identifiers(text);
+						return super::extract_call_target(text).into_iter().collect();
 					}
 				}
 				Vec::new()
@@ -201,7 +216,7 @@ impl Language for JavaScript {
 				// child(0) = "new" keyword, child(1) = constructor
 				if let Some(ctor) = node.child(1) {
 					if let Ok(text) = ctor.utf8_text(contents.as_bytes()) {
-						return super::extract_callee_identifiers(text);
+						return super::extract_call_target(text).into_iter().collect();
 					}
 				}
 				Vec::new()

--- a/src/indexer/languages/javascript.rs
+++ b/src/indexer/languages/javascript.rs
@@ -40,6 +40,17 @@ impl Language for JavaScript {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier adds the class container chunking excludes; drops
+		// anonymous arrow functions and import/export statements, which
+		// declare no symbol.
+		vec![
+			"function_declaration",
+			"method_definition",
+			"class_declaration",
+		]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/lua.rs
+++ b/src/indexer/languages/lua.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,24 @@ impl Language for Lua {
 			// Individual fields and simple assignments will be filtered out
 			// Module system - only module-level returns are meaningful
 		]
+	}
+
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// `function_definition` is anonymous in this grammar. Named local and
+		// table methods are represented by `function_declaration`.
+		vec!["function_declaration"]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		let name = node.child_by_field_name("name")?;
+		let text = name.utf8_text(contents.as_bytes()).ok()?;
+		super::extract_call_target(text).map(|target| target.name)
+	}
+
+	fn extract_symbol_owner(&self, node: Node, contents: &str) -> Option<String> {
+		let name = node.child_by_field_name("name")?;
+		let text = name.utf8_text(contents.as_bytes()).ok()?;
+		super::extract_call_target(text).and_then(|target| target.qualifier)
 	}
 
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
@@ -175,16 +193,16 @@ impl Language for Lua {
 		vec!["lua"]
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "function_call" {
 			// First child is the function name — skip "require" (that's an import)
-			if let Some(func_node) = node.child(0) {
+			if let Some(func_node) = node.child_by_field_name("name") {
 				if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
 					let name = text.trim();
 					if name == "require" {
 						return Vec::new();
 					}
-					return super::extract_callee_identifiers(name);
+					return super::extract_call_target(name).into_iter().collect();
 				}
 			}
 		}

--- a/src/indexer/languages/mod.rs
+++ b/src/indexer/languages/mod.rs
@@ -81,6 +81,14 @@ pub trait Language: Send + Sync {
 	/// Returns node kinds considered meaningful for this language
 	fn get_meaningful_kinds(&self) -> Vec<&'static str>;
 
+	/// Node kinds that become symbol-level GraphRAG nodes. Defaults to the
+	/// chunking kinds; languages override when chunking deliberately drops
+	/// large containers (classes/interfaces/enums) or keeps non-declaration
+	/// nodes (imports, calls, statements) that must not become symbols.
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		self.get_meaningful_kinds()
+	}
+
 	/// Extract symbols from a node
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String>;
 

--- a/src/indexer/languages/mod.rs
+++ b/src/indexer/languages/mod.rs
@@ -70,6 +70,26 @@ pub enum TypeRelationKind {
 	Implements,
 }
 
+/// A callable reference extracted from a language AST.
+///
+/// `name` is always the terminal callable (`run` in `service.run()`), while
+/// `qualifier` preserves the receiver/module/type (`service`). Keeping both
+/// avoids turning every segment of a qualified expression into a bogus call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallTarget {
+	pub name: String,
+	pub qualifier: Option<String>,
+}
+
+/// A code region embedded in another supported language (for example a
+/// JavaScript/TypeScript `<script>` inside Svelte).
+#[derive(Debug, Clone)]
+pub struct EmbeddedSource {
+	pub language: &'static str,
+	pub contents: String,
+	pub start_line: u32,
+}
+
 /// Common trait for all language parsers
 pub trait Language: Send + Sync {
 	/// Name of the language
@@ -105,8 +125,22 @@ pub trait Language: Send + Sync {
 	/// Extract function/method call names from a node.
 	/// Returns callee names if this node represents a function call.
 	/// The recursive walk and line tracking is handled by the caller.
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<CallTarget> {
 		let _ = (node, contents);
+		Vec::new()
+	}
+
+	/// Owning type/module for a declared symbol, when it is syntactically known.
+	/// The default handles the common class/module/impl ancestor shapes used by
+	/// the supported tree-sitter grammars. Languages with receiver syntax on the
+	/// declaration itself (notably Go) override this method.
+	fn extract_symbol_owner(&self, node: Node, contents: &str) -> Option<String> {
+		find_graph_symbol_owner(node, contents)
+	}
+
+	/// Extract embedded code regions that should participate in the live graph.
+	fn extract_embedded_sources(&self, root: Node, contents: &str) -> Vec<EmbeddedSource> {
+		let _ = (root, contents);
 		Vec::new()
 	}
 
@@ -328,7 +362,9 @@ pub fn simple_type_name(text: &str) -> Option<String> {
 	let stripped = text.split('<').next().unwrap_or(text);
 	let after_colons = stripped.rsplit("::").next().unwrap_or(stripped);
 	let after_dots = after_colons.rsplit('.').next().unwrap_or(after_colons);
-	let trimmed = after_dots.trim();
+	let trimmed = after_dots
+		.trim()
+		.trim_matches(|character: char| !character.is_alphanumeric() && character != '_');
 	if trimmed.is_empty() {
 		None
 	} else {
@@ -336,26 +372,96 @@ pub fn simple_type_name(text: &str) -> Option<String> {
 	}
 }
 
-/// Extract callee name(s) from a call expression's function child.
-/// Splits compound names (e.g. `Foo::bar`, `obj.method`) into individual identifiers
-/// for matching against exported symbols.
-pub fn extract_callee_identifiers(text: &str) -> Vec<String> {
-	let trimmed = text.trim();
+/// Parse a textual callee expression without losing its qualifier.
+///
+/// Handles the shared forms used by the supported languages: `foo`,
+/// `module.foo`, `Type::method`, `ptr->method`, and optional chaining. Generic
+/// arguments on the callable are removed before splitting.
+pub fn extract_call_target(text: &str) -> Option<CallTarget> {
+	let mut trimmed = text.trim().trim_start_matches('&').trim_start_matches('*');
 	if trimmed.is_empty() {
-		return Vec::new();
+		return None;
 	}
 
-	let mut results = Vec::new();
-
-	// Split on :: and . to get individual segments
-	for segment in trimmed.split(['.', ':']) {
-		let seg = segment.trim();
-		if !seg.is_empty() && seg != "self" && seg != "Self" && seg != "this" && seg != "super" {
-			results.push(seg.to_string());
+	let mut without_generics = String::with_capacity(trimmed.len());
+	let mut generic_depth = 0u32;
+	for character in trimmed.chars() {
+		match character {
+			'<' => generic_depth += 1,
+			'>' if generic_depth > 0 => generic_depth -= 1,
+			_ if generic_depth == 0 => without_generics.push(character),
+			_ => {}
 		}
 	}
+	trimmed = without_generics.trim();
+	let normalized = trimmed.replace("?.", ".").replace("->", ".");
+	let segments: Vec<&str> = normalized
+		.split(['.', ':'])
+		.map(str::trim)
+		.filter(|segment| !segment.is_empty())
+		.collect();
+	let (name, qualifier_segments) = segments.split_last()?;
+	let name =
+		name.trim_matches(|character: char| !character.is_alphanumeric() && character != '_');
+	if name.is_empty()
+		|| !name
+			.chars()
+			.all(|character| character.is_alphanumeric() || character == '_')
+	{
+		return None;
+	}
+	let qualifier = if qualifier_segments.is_empty() {
+		None
+	} else {
+		if qualifier_segments.iter().any(|segment| {
+			!segment.chars().all(|character| {
+				character.is_alphanumeric() || matches!(character, '_' | '$' | '@' | '#')
+			})
+		}) {
+			return None;
+		}
+		Some(qualifier_segments.join("::"))
+	};
+	Some(CallTarget {
+		name: name.to_string(),
+		qualifier,
+	})
+}
 
-	results
+/// Find the nearest enclosing declaration that provides a stable method owner.
+pub fn find_graph_symbol_owner(node: Node, contents: &str) -> Option<String> {
+	let mut current = node.parent();
+	while let Some(parent) = current {
+		let kind = parent.kind();
+		let is_owner = !kind.contains("body")
+			&& (kind.contains("class")
+				|| kind.contains("struct")
+				|| kind.contains("interface")
+				|| kind.contains("trait")
+				|| kind.contains("module")
+				|| kind.contains("namespace")
+				|| kind.contains("extension")
+				|| kind == "impl_item");
+		if is_owner {
+			for field in ["type", "name"] {
+				if let Some(name_node) = parent.child_by_field_name(field) {
+					if let Ok(text) = name_node.utf8_text(contents.as_bytes()) {
+						if let Some(name) = simple_type_name(text) {
+							return Some(name);
+						}
+					}
+				}
+			}
+			return extract_symbol_by_kinds(
+				parent,
+				contents,
+				&["identifier", "name", "type_identifier", "constant"],
+			)
+			.and_then(|name| simple_type_name(&name));
+		}
+		current = parent.parent();
+	}
+	None
 }
 
 /// Extract a symbol from a node by finding a child matching any of multiple kinds
@@ -431,4 +537,31 @@ pub fn find_enclosing_container_name(
 		cur = parent.parent();
 	}
 	None
+}
+
+#[cfg(test)]
+mod graph_extraction_tests {
+	use super::*;
+
+	#[test]
+	fn structured_callee_preserves_terminal_name_and_qualifier() {
+		for (input, expected_name, expected_qualifier) in [
+			("helper", "helper", None),
+			("service.run", "run", Some("service")),
+			("Service::new", "new", Some("Service")),
+			("std::vector<Item>::make", "make", Some("std::vector")),
+			("ptr->flush", "flush", Some("ptr")),
+			("client?.send", "send", Some("client")),
+		] {
+			let target = extract_call_target(input).expect("callee should parse");
+			assert_eq!(target.name, expected_name);
+			assert_eq!(target.qualifier.as_deref(), expected_qualifier);
+		}
+	}
+
+	#[test]
+	fn dynamic_callee_is_dropped_instead_of_inventing_a_symbol() {
+		assert!(extract_call_target("obj[method]").is_none());
+		assert!(extract_call_target("condition ? first : second").is_none());
+	}
 }

--- a/src/indexer/languages/mod.rs
+++ b/src/indexer/languages/mod.rs
@@ -123,6 +123,13 @@ pub trait Language: Send + Sync {
 		Vec::new()
 	}
 
+	/// Name of the declaration that owns type relationships emitted for this
+	/// node. Most languages put the declaration name directly on the same node;
+	/// languages with separate implementation blocks can override this.
+	fn extract_type_relation_source(&self, node: Node, contents: &str) -> Option<String> {
+		self.extract_declaration_name(node, contents)
+	}
+
 	/// Declared name of the symbol at this node, for symbol-level GraphRAG
 	/// nodes. Unlike `extract_symbols` (which enriches and sorts), this must
 	/// return exactly the name the declaration introduces, or None when the

--- a/src/indexer/languages/mod.rs
+++ b/src/indexer/languages/mod.rs
@@ -115,6 +115,16 @@ pub trait Language: Send + Sync {
 		Vec::new()
 	}
 
+	/// Declared name of the symbol at this node, for symbol-level GraphRAG
+	/// nodes. Unlike `extract_symbols` (which enriches and sorts), this must
+	/// return exactly the name the declaration introduces, or None when the
+	/// node has no single declarable name. The default covers the dominant
+	/// tree-sitter convention: a direct child whose kind is or contains
+	/// "identifier", "name", or "type_identifier".
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		extract_symbol_by_kinds(node, contents, &["identifier", "name", "type_identifier"])
+	}
+
 	/// Check if two node types are semantically equivalent for grouping
 	/// This allows each language to define its own semantic relationships
 	fn are_node_types_equivalent(&self, type1: &str, type2: &str) -> bool {

--- a/src/indexer/languages/php.rs
+++ b/src/indexer/languages/php.rs
@@ -193,28 +193,24 @@ impl Language for Php {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		match node.kind() {
 			"function_call_expression" => {
 				// First child is the function name
 				if let Some(func_node) = node.child(0) {
 					if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-						return super::extract_callee_identifiers(text);
+						return super::extract_call_target(text).into_iter().collect();
 					}
 				}
 				Vec::new()
 			}
 			"member_call_expression" | "scoped_call_expression" => {
 				// $obj->method() or ClassName::method()
-				let mut result = Vec::new();
-				for child in node.children(&mut node.walk()) {
-					if child.kind() == "name" {
-						if let Ok(text) = child.utf8_text(contents.as_bytes()) {
-							result.push(text.to_string());
-						}
-					}
-				}
-				result
+				let Ok(text) = node.utf8_text(contents.as_bytes()) else {
+					return Vec::new();
+				};
+				let callable = text.split('(').next().unwrap_or(text);
+				super::extract_call_target(callable).into_iter().collect()
 			}
 			_ => Vec::new(),
 		}

--- a/src/indexer/languages/php.rs
+++ b/src/indexer/languages/php.rs
@@ -41,6 +41,19 @@ impl Language for Php {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier restores the type containers chunking excludes; drops
+		// namespace nodes (one per file, not a declared symbol).
+		vec![
+			"function_definition",
+			"method_declaration",
+			"class_declaration",
+			"interface_declaration",
+			"trait_declaration",
+			"enum_declaration",
+		]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/python.rs
+++ b/src/indexer/languages/python.rs
@@ -166,12 +166,12 @@ impl Language for Python {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "call" {
 			// First child is the function being called
 			if let Some(func_node) = node.child(0) {
 				if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-					return super::extract_callee_identifiers(text);
+					return super::extract_call_target(text).into_iter().collect();
 				}
 			}
 		}

--- a/src/indexer/languages/python.rs
+++ b/src/indexer/languages/python.rs
@@ -39,6 +39,12 @@ impl Language for Python {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier adds the class container chunking excludes; imports
+		// declare no symbol.
+		vec!["function_definition", "class_definition"]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/ruby.rs
+++ b/src/indexer/languages/ruby.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ impl Language for Ruby {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "call" {
 			// The `method` field is the actual callee name; for `receiver.method(...)`
 			// calls, children appear in source order (receiver, operator, method), so
@@ -207,7 +207,12 @@ impl Language for Ruby {
 					if name == "require" || name == "require_relative" || name == "load" {
 						return Vec::new();
 					}
-					return super::extract_callee_identifiers(name);
+					let raw = node
+						.child_by_field_name("receiver")
+						.and_then(|receiver| receiver.utf8_text(contents.as_bytes()).ok())
+						.map(|receiver| format!("{}.{}", receiver, name))
+						.unwrap_or_else(|| name.to_string());
+					return super::extract_call_target(&raw).into_iter().collect();
 				}
 			}
 		}

--- a/src/indexer/languages/ruby.rs
+++ b/src/indexer/languages/ruby.rs
@@ -52,12 +52,18 @@ impl Language for Ruby {
 					"constant" => Some(child),
 					"scope_resolution" => {
 						let mut inner = child.walk();
-						child.children(&mut inner).filter(|c| c.kind() == "constant").last()
+						child
+							.children(&mut inner)
+							.filter(|c| c.kind() == "constant")
+							.last()
 					}
 					_ => None,
 				};
 				if let Some(name_node) = name_node {
-					return name_node.utf8_text(contents.as_bytes()).ok().map(String::from);
+					return name_node
+						.utf8_text(contents.as_bytes())
+						.ok()
+						.map(String::from);
 				}
 			}
 			return None;

--- a/src/indexer/languages/ruby.rs
+++ b/src/indexer/languages/ruby.rs
@@ -35,6 +35,36 @@ impl Language for Ruby {
 		vec!["method", "singleton_method", "call"]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier restores class/module containers and drops `call`: a
+		// call's method-name child matches the default name scan, which would
+		// turn every call site into a bogus symbol node.
+		vec!["method", "singleton_method", "class", "module"]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		if matches!(node.kind(), "class" | "module") {
+			// Names are `constant` nodes; qualified names (`Foo::Bar`) are
+			// `scope_resolution` nodes whose LAST `constant` is the defined one.
+			let mut cursor = node.walk();
+			for child in node.children(&mut cursor) {
+				let name_node = match child.kind() {
+					"constant" => Some(child),
+					"scope_resolution" => {
+						let mut inner = child.walk();
+						child.children(&mut inner).filter(|c| c.kind() == "constant").last()
+					}
+					_ => None,
+				};
+				if let Some(name_node) = name_node {
+					return name_node.utf8_text(contents.as_bytes()).ok().map(String::from);
+				}
+			}
+			return None;
+		}
+		super::extract_symbol_by_kinds(node, contents, &["identifier", "name", "type_identifier"])
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/rust.rs
+++ b/src/indexer/languages/rust.rs
@@ -217,13 +217,13 @@ impl Language for Rust {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		match node.kind() {
 			"call_expression" => {
 				// First child is the function being called
 				if let Some(func_node) = node.child(0) {
 					if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-						return super::extract_callee_identifiers(text);
+						return super::extract_call_target(text).into_iter().collect();
 					}
 				}
 				Vec::new()
@@ -235,7 +235,7 @@ impl Language for Rust {
 					if let Ok(text) = macro_node.utf8_text(contents.as_bytes()) {
 						let name = text.trim().trim_end_matches('!');
 						if !name.is_empty() {
-							return super::extract_callee_identifiers(name);
+							return super::extract_call_target(name).into_iter().collect();
 						}
 					}
 				}

--- a/src/indexer/languages/rust.rs
+++ b/src/indexer/languages/rust.rs
@@ -286,6 +286,15 @@ impl Language for Rust {
 		out
 	}
 
+	fn extract_type_relation_source(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() == "impl_item" {
+			let type_node = node.child_by_field_name("type")?;
+			let text = type_node.utf8_text(contents.as_bytes()).ok()?;
+			return super::simple_type_name(text);
+		}
+		self.extract_declaration_name(node, contents)
+	}
+
 	fn resolve_import(
 		&self,
 		import_path: &str,

--- a/src/indexer/languages/svelte.rs
+++ b/src/indexer/languages/svelte.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,6 +81,13 @@ impl Language for Svelte {
 			"element", // But we'll filter this in extract_symbols
 			           // Skip individual HTML tags as they create too much noise
 		]
+	}
+
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Script declarations are parsed with the JavaScript/TypeScript grammar by
+		// `extract_embedded_sources`; Svelte HTML/style container nodes are not
+		// callable code symbols.
+		Vec::new()
 	}
 
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
@@ -208,6 +215,40 @@ impl Language for Svelte {
 		}
 
 		(imports, exports)
+	}
+
+	fn extract_embedded_sources(&self, root: Node, contents: &str) -> Vec<super::EmbeddedSource> {
+		let mut sources = Vec::new();
+		let mut stack = vec![root];
+		while let Some(node) = stack.pop() {
+			if node.kind() == "script_element" {
+				let script_text = node.utf8_text(contents.as_bytes()).unwrap_or_default();
+				let language = if script_text.contains("lang=\"ts\"")
+					|| script_text.contains("lang='ts'")
+					|| script_text.contains("lang=\"typescript\"")
+				{
+					"typescript"
+				} else {
+					"javascript"
+				};
+				for child in node.children(&mut node.walk()) {
+					if child.kind() == "raw_text" {
+						if let Ok(source) = child.utf8_text(contents.as_bytes()) {
+							sources.push(super::EmbeddedSource {
+								language,
+								contents: source.to_string(),
+								start_line: child.start_position().row as u32,
+							});
+						}
+					}
+				}
+				continue;
+			}
+			let mut children: Vec<_> = node.children(&mut node.walk()).collect();
+			children.reverse();
+			stack.extend(children);
+		}
+		sources
 	}
 
 	fn resolve_import(

--- a/src/indexer/languages/swift.rs
+++ b/src/indexer/languages/swift.rs
@@ -47,6 +47,36 @@ impl Language for Swift {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		vec![
+			"function_declaration",
+			"class_declaration",
+			"protocol_declaration",
+			"init_declaration",
+			"typealias_declaration",
+		]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() == "init_declaration" {
+			return Some("init".to_string());
+		}
+		for field in ["name", "type"] {
+			if let Some(name) = node.child_by_field_name(field) {
+				if let Ok(text) = name.utf8_text(contents.as_bytes()) {
+					if let Some(simple) = super::simple_type_name(text) {
+						return Some(simple);
+					}
+				}
+			}
+		}
+		super::extract_symbol_by_kinds(
+			node,
+			contents,
+			&["simple_identifier", "type_identifier", "user_type"],
+		)
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 
@@ -258,12 +288,12 @@ impl Language for Swift {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		if node.kind() == "call_expression" {
 			// The first child of call_expression is the callee expression
 			if let Some(callee) = node.child(0) {
 				if let Ok(text) = callee.utf8_text(contents.as_bytes()) {
-					return super::extract_callee_identifiers(text);
+					return super::extract_call_target(text).into_iter().collect();
 				}
 			}
 		}

--- a/src/indexer/languages/swift_test.rs
+++ b/src/indexer/languages/swift_test.rs
@@ -394,17 +394,20 @@ func test() {
 			calls
 		);
 		assert!(
-			calls.iter().any(|c| c == "print"),
+			calls.iter().any(|call| call.name == "print"),
 			"Should contain 'print' call: got {:?}",
 			calls
 		);
+		assert!(calls.iter().any(|call| {
+			call.name == "process" && call.qualifier.as_deref() == Some("someObject")
+		}));
 	}
 
 	fn collect_calls(
 		node: tree_sitter::Node,
 		code: &str,
 		lang: &dyn Language,
-		calls: &mut Vec<String>,
+		calls: &mut Vec<crate::indexer::languages::CallTarget>,
 	) {
 		calls.extend(lang.extract_function_calls(node, code));
 		let mut cursor = node.walk();

--- a/src/indexer/languages/typescript.rs
+++ b/src/indexer/languages/typescript.rs
@@ -44,6 +44,19 @@ impl Language for TypeScript {
 		]
 	}
 
+	fn get_symbol_kinds(&self) -> Vec<&'static str> {
+		// Symbol tier adds the class/enum containers chunking excludes; drops
+		// anonymous arrow functions and import/export statements.
+		vec![
+			"function_declaration",
+			"method_definition",
+			"class_declaration",
+			"interface_declaration",
+			"type_alias_declaration",
+			"enum_declaration",
+		]
+	}
+
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
 		let mut symbols = Vec::new();
 

--- a/src/indexer/languages/typescript.rs
+++ b/src/indexer/languages/typescript.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,11 +50,26 @@ impl Language for TypeScript {
 		vec![
 			"function_declaration",
 			"method_definition",
+			"arrow_function",
 			"class_declaration",
 			"interface_declaration",
 			"type_alias_declaration",
 			"enum_declaration",
 		]
+	}
+
+	fn extract_declaration_name(&self, node: Node, contents: &str) -> Option<String> {
+		if node.kind() == "arrow_function" {
+			let parent = node.parent()?;
+			if parent.kind() != "variable_declarator" {
+				return None;
+			}
+			return parent
+				.child_by_field_name("name")
+				.and_then(|name| name.utf8_text(contents.as_bytes()).ok())
+				.map(str::to_string);
+		}
+		super::extract_symbol_by_kinds(node, contents, &["identifier", "name"])
 	}
 
 	fn extract_symbols(&self, node: Node, contents: &str) -> Vec<String> {
@@ -242,12 +257,12 @@ impl Language for TypeScript {
 		(imports, exports)
 	}
 
-	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<String> {
+	fn extract_function_calls(&self, node: Node, contents: &str) -> Vec<super::CallTarget> {
 		match node.kind() {
 			"call_expression" => {
 				if let Some(func_node) = node.child(0) {
 					if let Ok(text) = func_node.utf8_text(contents.as_bytes()) {
-						return super::extract_callee_identifiers(text);
+						return super::extract_call_target(text).into_iter().collect();
 					}
 				}
 				Vec::new()
@@ -255,7 +270,7 @@ impl Language for TypeScript {
 			"new_expression" => {
 				if let Some(ctor) = node.child(1) {
 					if let Ok(text) = ctor.utf8_text(contents.as_bytes()) {
-						return super::extract_callee_identifiers(text);
+						return super::extract_call_target(text).into_iter().collect();
 					}
 				}
 				Vec::new()

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -263,7 +263,7 @@ pub fn get_file_mtime(file_path: &std::path::Path) -> Result<u64> {
 }
 
 // Detect language based on file extension
-pub fn detect_language(path: &std::path::Path) -> Option<&str> {
+pub fn detect_language(path: &std::path::Path) -> Option<&'static str> {
 	FileUtils::detect_language(path)
 }
 

--- a/src/mcp/graphrag.rs
+++ b/src/mcp/graphrag.rs
@@ -19,6 +19,7 @@ use tracing::debug;
 use crate::config::Config;
 use crate::indexer::branch::BranchManifest;
 use crate::indexer::graphrag::find_node_id;
+use crate::indexer::graphrag::runtime::{self, RuntimeGraphCache};
 use crate::indexer::{self, graphrag::GraphRAG};
 use crate::mcp::types::McpError;
 
@@ -74,26 +75,33 @@ pub struct GraphRagProvider {
 	graphrag: GraphRAG,
 	working_directory: std::path::PathBuf,
 	branch_manifest: Option<BranchManifest>,
+	runtime_cache: RuntimeGraphCache,
 }
 
 impl GraphRagProvider {
-	pub fn new(config: Config, working_directory: std::path::PathBuf) -> Option<Self> {
-		if config.graphrag.enabled {
-			let branch_manifest = crate::indexer::branch::detect_branch_context(&working_directory)
-				.and_then(|branch_name| {
+	pub fn new(config: Config, working_directory: std::path::PathBuf) -> Self {
+		let branch_manifest = if config.graphrag.enabled {
+			crate::indexer::branch::detect_branch_context(&working_directory).and_then(
+				|branch_name| {
 					let branch_dir =
 						crate::storage::get_branch_dir(&working_directory, &branch_name).ok()?;
 					crate::indexer::branch::load_manifest(&branch_dir).ok()?
-				});
-
-			Some(Self {
-				graphrag: GraphRAG::new(config, working_directory.clone()),
-				working_directory,
-				branch_manifest,
-			})
+				},
+			)
 		} else {
 			None
+		};
+
+		Self {
+			graphrag: GraphRAG::new(config, working_directory.clone()),
+			working_directory,
+			branch_manifest,
+			runtime_cache: RuntimeGraphCache::default(),
 		}
+	}
+
+	pub fn runtime_cache(&self) -> RuntimeGraphCache {
+		self.runtime_cache.clone()
 	}
 
 	/// Execute the graphrag tool with any operation
@@ -124,8 +132,11 @@ impl GraphRagProvider {
 					.and_then(|v| v.as_str())
 					.ok_or_else(|| McpError::invalid_params("Missing required parameter 'query' for search operation: must be a detailed question about code relationships or architecture", "graphrag"))?;
 
-				if query.len() < 10 {
-					return Err(McpError::invalid_params("Invalid query: must be at least 10 characters long and describe relationships or architecture", "graphrag"));
+				if query.trim().is_empty() {
+					return Err(McpError::invalid_params(
+						"Invalid query: must not be empty",
+						"graphrag",
+					));
 				}
 				if query.len() > 1000 {
 					return Err(McpError::invalid_params(
@@ -172,7 +183,14 @@ impl GraphRagProvider {
 		let max_depth = arguments
 			.get("max_depth")
 			.and_then(|v| v.as_u64())
-			.unwrap_or(3) as usize;
+			.unwrap_or(3);
+		if !(1..=10).contains(&max_depth) {
+			return Err(McpError::invalid_params(
+				"Invalid max_depth: must be between 1 and 10",
+				"graphrag",
+			));
+		}
+		let max_depth = max_depth as usize;
 
 		let format_str = arguments
 			.get("format")
@@ -223,69 +241,123 @@ impl GraphRagProvider {
 
 	/// Execute GraphRAG operation using CLI logic with MCP-optimized output
 	async fn execute_graphrag_operation(&self, args: &GraphRAGArgs) -> Result<String> {
-		// Check if GraphRAG is enabled (this should always be true since we're created conditionally)
 		let config = self.graphrag.config();
-		if !config.graphrag.enabled {
-			return Err(anyhow::anyhow!("GraphRAG is not enabled in configuration"));
-		}
-
-		// Initialize the GraphBuilder
-		let graph_builder =
-			indexer::GraphBuilder::new_with_quiet(config.clone(), &self.working_directory, true)
-				.await
-				.map_err(|e| anyhow::anyhow!("Failed to initialize GraphRAG system: {}", e))?;
-
-		// Branch-aware GraphRAG: filter main graph and merge branch data.
-		// MCP is long-lived and the main DB can move under us via background
-		// reindexing; re-check coherence on every call rather than trusting
-		// the snapshot we took at provider construction.
-		if let Some(ref manifest) = self.branch_manifest {
-			let main_commit = match crate::store::Store::new_at(&self.working_directory).await {
-				Ok(s) => s.get_last_commit_hash().await.ok().flatten(),
-				Err(_) => None,
-			};
-			if crate::indexer::branch::manifest_is_coherent_with(manifest, main_commit.as_deref()) {
-				let overridden = manifest.overridden_paths();
-				graph_builder.apply_branch_filter(&overridden).await;
-				if let Ok(branch_store) = crate::store::Store::new_for_branch_at(
-					&self.working_directory,
-					&manifest.branch_name,
-				)
-				.await
-				{
-					if let Err(e) = graph_builder.merge_branch_graph(&branch_store).await {
-						tracing::warn!(error = %e, "Failed to merge branch GraphRAG data");
-					}
-				}
-			} else {
-				tracing::warn!(
-					branch = %manifest.branch_name,
-					recorded = %manifest.base_db_commit,
-					main_now = ?main_commit,
-					"Branch GraphRAG overlay skipped: branch DB doesn't match current main commit."
-				);
-			}
-		}
-
-		// Get the current graph
-		let graph = graph_builder
-			.get_graph()
+		let graph_builder = if config.graphrag.enabled {
+			match indexer::GraphBuilder::new_with_quiet(
+				config.clone(),
+				&self.working_directory,
+				true,
+			)
 			.await
-			.map_err(|e| anyhow::anyhow!("Failed to load GraphRAG knowledge graph: {}", e))?;
+			{
+				Ok(builder) => {
+					// Branch-aware persisted enrichment.
+					if let Some(ref manifest) = self.branch_manifest {
+						let main_commit =
+							match crate::store::Store::new_at(&self.working_directory).await {
+								Ok(store) => store.get_last_commit_hash().await.ok().flatten(),
+								Err(_) => None,
+							};
+						if crate::indexer::branch::manifest_is_coherent_with(
+							manifest,
+							main_commit.as_deref(),
+						) {
+							let overridden = manifest.overridden_paths();
+							builder.apply_branch_filter(&overridden).await;
+							if let Ok(branch_store) = crate::store::Store::new_for_branch_at(
+								&self.working_directory,
+								&manifest.branch_name,
+							)
+							.await
+							{
+								if let Err(error) = builder.merge_branch_graph(&branch_store).await
+								{
+									tracing::warn!(%error, "Failed to merge branch GraphRAG data");
+								}
+							}
+						} else {
+							tracing::warn!(
+								branch = %manifest.branch_name,
+								recorded = %manifest.base_db_commit,
+								main_now = ?main_commit,
+								"Branch GraphRAG overlay skipped: branch DB doesn't match current main commit."
+							);
+						}
+					}
+					Some(builder)
+				}
+				Err(error) => {
+					tracing::warn!(%error, "Persisted GraphRAG unavailable; using live structural graph");
+					None
+				}
+			}
+		} else {
+			None
+		};
+
+		let runtime_graph = self.runtime_cache.graph(&self.working_directory).await?;
+		let (graph, enrichment_active) = if let Some(builder) = &graph_builder {
+			match builder.get_graph().await {
+				Ok(enriched) => {
+					let active = !enriched.nodes.is_empty() || !enriched.relationships.is_empty();
+					(
+						std::sync::Arc::new(runtime::merge_enrichment(
+							&runtime_graph,
+							enriched,
+							&self.working_directory,
+						)),
+						active,
+					)
+				}
+				Err(error) => {
+					tracing::warn!(%error, "Failed to load persisted GraphRAG; using live structural graph");
+					(runtime_graph, false)
+				}
+			}
+		} else {
+			(runtime_graph, false)
+		};
 
 		// Check if graph is empty
 		if graph.nodes.is_empty() {
-			return Err(anyhow::anyhow!("GraphRAG knowledge graph is empty. Run 'octocode index' to build the knowledge graph."));
+			return Err(anyhow::anyhow!(
+				"No supported source symbols were found for graph search"
+			));
 		}
 
 		// Execute the requested operation and capture output
 		match args.operation {
 			GraphRAGOperation::Search => {
-				let query = args.query.as_ref().unwrap(); // Validated in caller
-				let nodes = graph_builder
-					.search_nodes(query)
-					.await
-					.map_err(|e| anyhow::anyhow!("Search failed: {}", e))?;
+				let query = args
+					.query
+					.as_deref()
+					.ok_or_else(|| anyhow::anyhow!("Search query is missing"))?;
+				let nodes = if let Some(builder) = &graph_builder {
+					let semantic_nodes = match builder.search_nodes(query).await {
+						Ok(nodes) => nodes,
+						Err(error) => {
+							tracing::warn!(%error, "Semantic graph seed search failed; using lexical seeds");
+							Vec::new()
+						}
+					};
+					// Symbols are live AST nodes, never embedding rows. Seed them by
+					// deterministic name/path lookup, then append semantic file hits.
+					let mut nodes = runtime::search_nodes(&graph, query, 20);
+					let mut seen: std::collections::HashSet<String> =
+						nodes.iter().map(|node| node.id.clone()).collect();
+					for node in semantic_nodes
+						.into_iter()
+						.filter(|node| !node.is_symbol_node())
+					{
+						if seen.insert(node.id.clone()) {
+							nodes.push(node);
+						}
+					}
+					nodes.truncate(50);
+					nodes
+				} else {
+					runtime::search_nodes(&graph, query, 50)
+				};
 
 				// Render based on format
 				match args.format {
@@ -302,7 +374,10 @@ impl GraphRagProvider {
 				}
 			}
 			GraphRAGOperation::GetNode => {
-				let node_id = args.node_id.as_ref().unwrap(); // Validated in caller
+				let node_id = args
+					.node_id
+					.as_deref()
+					.ok_or_else(|| anyhow::anyhow!("Node id is missing"))?;
 				match find_node_id(&graph, node_id) {
 					Some(resolved_id) => {
 						let node = &graph.nodes[resolved_id];
@@ -340,7 +415,10 @@ impl GraphRagProvider {
 				}
 			}
 			GraphRAGOperation::GetRelationships => {
-				let node_id = args.node_id.as_ref().unwrap(); // Validated in caller
+				let node_id = args
+					.node_id
+					.as_deref()
+					.ok_or_else(|| anyhow::anyhow!("Node id is missing"))?;
 
 				// Resolve node ID with fuzzy matching
 				let resolved_id = find_node_id(&graph, node_id)
@@ -458,8 +536,14 @@ impl GraphRagProvider {
 				}
 			}
 			GraphRAGOperation::FindPath => {
-				let source_id_input = args.source_id.as_ref().unwrap(); // Validated in caller
-				let target_id_input = args.target_id.as_ref().unwrap(); // Validated in caller
+				let source_id_input = args
+					.source_id
+					.as_deref()
+					.ok_or_else(|| anyhow::anyhow!("Source node id is missing"))?;
+				let target_id_input = args
+					.target_id
+					.as_deref()
+					.ok_or_else(|| anyhow::anyhow!("Target node id is missing"))?;
 
 				// Resolve source and target with fuzzy matching
 				let source_id = find_node_id(&graph, source_id_input)
@@ -470,10 +554,7 @@ impl GraphRagProvider {
 					.to_string();
 
 				// Find paths
-				let paths = graph_builder
-					.find_paths(&source_id, &target_id, args.max_depth)
-					.await
-					.map_err(|e| anyhow::anyhow!("Path finding failed: {}", e))?;
+				let paths = runtime::find_paths(&graph, &source_id, &target_id, args.max_depth);
 
 				if paths.is_empty() {
 					return Ok(format!(
@@ -582,6 +663,11 @@ impl GraphRagProvider {
 				}
 			}
 			GraphRAGOperation::Overview => {
+				let graph_mode = if enrichment_active {
+					"persisted_enriched"
+				} else {
+					"runtime_structural"
+				};
 				// Get statistics
 				let node_count = graph.nodes.len();
 				let relationship_count = graph.relationships.len();
@@ -601,6 +687,7 @@ impl GraphRagProvider {
 				match args.format {
 					OutputFormat::Json => {
 						let overview = json!({
+							"mode": graph_mode,
 							"node_count": node_count,
 							"relationship_count": relationship_count,
 							"node_types": node_types,
@@ -610,7 +697,7 @@ impl GraphRagProvider {
 							.map_err(|e| anyhow::anyhow!("JSON serialization failed: {}", e))?)
 					}
 					OutputFormat::Md => {
-						let mut output = format!("# GraphRAG Knowledge Graph Overview\n\nThe knowledge graph contains {} nodes and {} relationships.\n\n", node_count, relationship_count);
+						let mut output = format!("# Code Graph Overview\n\nMode: `{}`\n\nThe graph contains {} nodes and {} relationships.\n\n", graph_mode, node_count, relationship_count);
 
 						output.push_str("## Node Types\n\n");
 						for (kind, count) in node_types.iter() {
@@ -629,8 +716,8 @@ impl GraphRagProvider {
 					_ => {
 						// Text format for token efficiency
 						let mut output = format!(
-							"GraphRAG Overview: {} nodes, {} relationships\n\n",
-							node_count, relationship_count
+							"Code Graph Overview ({}): {} nodes, {} relationships\n\n",
+							graph_mode, node_count, relationship_count
 						);
 
 						output.push_str("Node Types:\n");

--- a/src/mcp/multi.rs
+++ b/src/mcp/multi.rs
@@ -154,14 +154,20 @@ impl MultiServer {
 		// Read-only unless the in-process indexer is enabled; otherwise serve the
 		// existing per-repo index without spawning a watcher/indexer.
 		let bg = if self.config.index.mcp_index {
-			McpServer::start_repo_services(self.config.clone(), repo_path, self.no_git, self.debug)
-				.await
-				.map_err(|e| {
-					ErrorData::internal_error(
-						format!("Failed to start services for '{}': {}", project, e),
-						None,
-					)
-				})?
+			McpServer::start_repo_services(
+				self.config.clone(),
+				repo_path,
+				self.no_git,
+				self.debug,
+				server.runtime_graph_cache(),
+			)
+			.await
+			.map_err(|e| {
+				ErrorData::internal_error(
+					format!("Failed to start services for '{}': {}", project, e),
+					None,
+				)
+			})?
 		} else {
 			BackgroundServices::none()
 		};
@@ -266,8 +272,9 @@ impl ServerHandler for MultiServer {
 		let instructions = format!(
 			"Multi-repository Octocode MCP server. {} repositories are available ({}); \
 			 every tool requires a `project` argument naming the target repository. \
-			 Use 'semantic_search' for code/documentation searches and 'graphrag' \
-			 (if enabled) for relationship queries.",
+			 Use 'semantic_search' for conceptual lookups, 'structural_search' for \
+			 syntax and occurrences, and the always-available 'graphrag' for symbol \
+			 relationships and dependency paths.",
 			self.repos.len(),
 			self.project_list()
 		);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -166,13 +166,13 @@ where
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct GraphRagParams {
-	/// 'search' (semantic node search), 'get-node' (node details), 'get-relationships' (node connections), 'find-path' (path between two nodes), 'overview' (graph stats)
+	/// 'search' (symbol/file lookup), 'get-node' (node details), 'get-relationships' (node connections), 'find-path' (path between two nodes), 'overview' (graph stats)
 	#[schemars(extend("enum" = ["search", "get-node", "get-relationships", "find-path", "overview"]))]
 	pub operation: String,
-	/// Search query for 'search' operation
+	/// Symbol, file, or architectural query for 'search'. Uses deterministic lexical lookup when GraphRAG is disabled and semantic lookup when enabled.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub query: Option<String>,
-	/// Node ID for 'get-node'/'get-relationships' (format: 'path/to/file' or 'path/to/file/symbol')
+	/// Node ID for 'get-node'/'get-relationships' (format: 'path/to/file' or 'path/to/file::symbol')
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub node_id: Option<String>,
 	/// Source node ID for 'find-path'
@@ -405,7 +405,7 @@ pub struct McpServer {
 	/// so multiple per-repo servers can run concurrently under `--multi`.
 	working_directory: std::path::PathBuf,
 	semantic_code: SemanticCodeProvider,
-	graphrag: Option<GraphRagProvider>,
+	graphrag: GraphRagProvider,
 	lsp: Option<Arc<Mutex<crate::mcp::lsp::LspProvider>>>,
 	/// Separate process handle for deterministic shutdown without waiting for
 	/// the provider mutex, which initialization may hold for several minutes.
@@ -467,7 +467,7 @@ impl McpServer {
 	}
 
 	#[tool(
-		description = "Knowledge graph operations over the indexed codebase. Use for architectural queries: component relationships, dependency chains, data flows. For simple code lookup use semantic_search instead."
+		description = "Always-available code graph operations for symbols, calls, imports, inheritance, neighbors, and dependency paths. Builds a fast in-memory Tree-sitter graph directly from current source; when GraphRAG is enabled, persisted enrichment is overlaid on that live graph. Use structural_search for syntax/occurrence matching and semantic_search for conceptual lookup."
 	)]
 	async fn graphrag(
 		&self,
@@ -475,21 +475,14 @@ impl McpServer {
 	) -> Result<String, String> {
 		debug!("Executing graphrag with operation: {}", params.operation);
 
-		match &self.graphrag {
-			Some(provider) => {
-				let arguments = match serde_json::to_value(&params) {
-					Ok(v) => v,
-					Err(e) => return Err(format!("Failed to serialize params: {}", e)),
-				};
+		let arguments = match serde_json::to_value(&params) {
+			Ok(v) => v,
+			Err(e) => return Err(format!("Failed to serialize params: {}", e)),
+		};
 
-				match provider.execute(&arguments).await {
-					Ok(result) => Ok(result),
-					Err(e) => Err(e.to_string()),
-				}
-			}
-			None => Err(
-				"GraphRAG is not enabled in the current configuration. Please enable GraphRAG in octocode.toml to use relationship-aware search.".to_string(),
-			),
+		match self.graphrag.execute(&arguments).await {
+			Ok(result) => Ok(result),
+			Err(e) => Err(e.to_string()),
 		}
 	}
 
@@ -889,16 +882,17 @@ impl ServerHandler for McpServer {
 		let capabilities = ServerCapabilities::builder().enable_tools().build();
 
 		let instructions = if self.indexer_enabled {
-			"This server provides modular AI tools: semantic code search, view signatures, and GraphRAG (if available). Use 'semantic_search' for code/documentation searches and 'graphrag' (if enabled) for relationship queries."
+			"This server provides semantic search, structural search, signatures, and an always-available live Tree-sitter graph. Use 'graphrag' for symbol relationships and dependency paths; persisted enrichment is overlaid when enabled."
 		} else {
-			"NOTE: in-process indexing is disabled — Octocode is serving an EXISTING index read-only, so the semantic index may be empty or stale. Prefer 'structural_search' (find known symbols, patterns, and usages) and 'view_signatures' (map a file's declarations before reading it), plus your own grep, to navigate the code. Use 'semantic_search' only for concept/behavior lookups where you don't know the symbol name — it may return nothing if the index is empty."
+			"NOTE: in-process indexing is disabled, so the semantic index may be empty or stale. 'structural_search', 'view_signatures', and 'graphrag' still read current source directly; use 'graphrag' for symbol relationships and paths. Use 'semantic_search' only for conceptual lookups where you do not know the symbol name."
 		};
 
 		ServerInfo::new(capabilities)
 			.with_protocol_version(ProtocolVersion::V_2026_07_28)
 			.with_server_info(
-				Implementation::new("octocode-mcp", env!("CARGO_PKG_VERSION"))
-					.with_description("Semantic code search server with vector embeddings and optional GraphRAG support"),
+				Implementation::new("octocode-mcp", env!("CARGO_PKG_VERSION")).with_description(
+					"Semantic and structural code intelligence with an always-available code graph",
+				),
 			)
 			.with_instructions(instructions)
 	}
@@ -992,10 +986,6 @@ impl McpServer {
 			tool_router.remove_route(name);
 		}
 
-		if graphrag.is_none() {
-			tool_router.remove_route("graphrag");
-		}
-
 		Self {
 			working_directory,
 			semantic_code,
@@ -1012,6 +1002,12 @@ impl McpServer {
 	/// these and injects a `project` argument before serving them to clients.
 	pub(crate) fn list_tool_defs(&self) -> Vec<Tool> {
 		self.tool_router.list_all()
+	}
+
+	pub(crate) fn runtime_graph_cache(
+		&self,
+	) -> crate::indexer::graphrag::runtime::RuntimeGraphCache {
+		self.graphrag.runtime_cache()
 	}
 
 	/// Dispatch a tool call against this server's router. Used by the
@@ -1033,6 +1029,7 @@ impl McpServer {
 		working_directory: std::path::PathBuf,
 		no_git: bool,
 		debug: bool,
+		runtime_graph_cache: crate::indexer::graphrag::runtime::RuntimeGraphCache,
 	) -> Result<BackgroundServices> {
 		let db_path = crate::storage::get_project_database_path(&working_directory)?;
 		crate::storage::ensure_project_storage_exists(&working_directory)?;
@@ -1058,7 +1055,16 @@ impl McpServer {
 			});
 		}
 
-		start_background_services(config, store, working_directory, no_git, debug, None).await
+		start_background_services(
+			config,
+			store,
+			working_directory,
+			no_git,
+			debug,
+			None,
+			runtime_graph_cache,
+		)
+		.await
 	}
 
 	/// Create a new MCP server instance.
@@ -1153,11 +1159,6 @@ impl McpServer {
 			}
 		}
 
-		// Remove GraphRAG tool if not configured
-		if graphrag.is_none() {
-			tool_router.remove_route("graphrag");
-		}
-
 		let server = Self {
 			working_directory: working_directory.clone(),
 			semantic_code,
@@ -1178,6 +1179,7 @@ impl McpServer {
 				no_git,
 				debug_mode,
 				server.lsp.clone(),
+				server.graphrag.runtime_cache(),
 			)
 			.await
 			{
@@ -1321,6 +1323,7 @@ pub(crate) async fn start_background_services(
 	no_git: bool,
 	debug: bool,
 	lsp: Option<Arc<Mutex<crate::mcp::lsp::LspProvider>>>,
+	runtime_graph_cache: crate::indexer::graphrag::runtime::RuntimeGraphCache,
 ) -> Result<BackgroundServices> {
 	let (file_tx, file_rx) = mpsc::channel(MCP_MAX_PENDING_EVENTS);
 	let (index_tx, index_rx) = mpsc::channel(10);
@@ -1337,6 +1340,7 @@ pub(crate) async fn start_background_services(
 	let indexing_in_progress = Arc::new(AtomicBool::new(false));
 	let indexing_flag = indexing_in_progress.clone();
 	let debug_mode = debug;
+	let graph_cache = runtime_graph_cache;
 	let index_handle = tokio::spawn(async move {
 		let mut file_rx = file_rx;
 		let mut last_event_time = None::<Instant>;
@@ -1349,6 +1353,7 @@ pub(crate) async fn start_background_services(
 				event_result = file_rx.recv() => {
 					match event_result {
 						Some(_) => {
+							graph_cache.invalidate();
 							pending_events += 1;
 							last_event_time = Some(Instant::now());
 							log_watcher_event("file_change", None, pending_events as usize);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -169,10 +169,10 @@ pub struct GraphRagParams {
 	/// 'search' (symbol/file lookup), 'get-node' (node details), 'get-relationships' (node connections), 'find-path' (path between two nodes), 'overview' (graph stats)
 	#[schemars(extend("enum" = ["search", "get-node", "get-relationships", "find-path", "overview"]))]
 	pub operation: String,
-	/// Symbol, file, or architectural query for 'search'. Uses deterministic lexical lookup when GraphRAG is disabled and semantic lookup when enabled.
+	/// Symbol, file, or architectural query for 'search'. Always uses deterministic name/path lookup and adds semantic file lookup when persisted GraphRAG is enabled.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub query: Option<String>,
-	/// Node ID for 'get-node'/'get-relationships' (format: 'path/to/file' or 'path/to/file::symbol')
+	/// Node ID for 'get-node'/'get-relationships' (format: 'path/to/file', 'path/to/file::symbol', or 'path/to/file::Owner::method')
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub node_id: Option<String>,
 	/// Source node ID for 'find-path'

--- a/src/store/graphrag.rs
+++ b/src/store/graphrag.rs
@@ -993,6 +993,11 @@ impl<'a> GraphRagOperations<'a> {
 				.downcast_ref::<arrow::array::Float32Array>()
 				.ok_or_else(|| anyhow::anyhow!("Invalid weight column type"))?;
 
+			// Absent in tables written before the provenance column existed.
+			let provenance_array = batch
+				.column_by_name("provenance")
+				.and_then(|c| c.as_any().downcast_ref::<StringArray>());
+
 			// Convert to CodeRelationship objects
 			for i in 0..batch.num_rows() {
 				let relationship = crate::indexer::graphrag::types::CodeRelationship {
@@ -1005,6 +1010,14 @@ impl<'a> GraphRagOperations<'a> {
 					description: desc_array.value(i).to_string(),
 					confidence: conf_array.value(i),
 					weight: weight_array.value(i),
+					provenance: provenance_array.map_or(
+						crate::indexer::graphrag::types::Provenance::Extracted,
+						|arr| {
+							crate::indexer::graphrag::types::Provenance::parse_or_default(
+								arr.value(i),
+							)
+						},
+					),
 				};
 				relationships.push(relationship);
 			}
@@ -1082,6 +1095,11 @@ impl<'a> GraphRagOperations<'a> {
 				.downcast_ref::<arrow::array::Float32Array>()
 				.ok_or_else(|| anyhow::anyhow!("Invalid weight column type"))?;
 
+			// Absent in tables written before the provenance column existed.
+			let provenance_array = batch
+				.column_by_name("provenance")
+				.and_then(|c| c.as_any().downcast_ref::<StringArray>());
+
 			for i in 0..batch.num_rows() {
 				let relationship = crate::indexer::graphrag::types::CodeRelationship {
 					source: source_array.value(i).to_string(),
@@ -1093,6 +1111,14 @@ impl<'a> GraphRagOperations<'a> {
 					description: desc_array.value(i).to_string(),
 					confidence: conf_array.value(i),
 					weight: weight_array.value(i),
+					provenance: provenance_array.map_or(
+						crate::indexer::graphrag::types::Provenance::Extracted,
+						|arr| {
+							crate::indexer::graphrag::types::Provenance::parse_or_default(
+								arr.value(i),
+							)
+						},
+					),
 				};
 				relationships.push(relationship);
 			}
@@ -1329,6 +1355,11 @@ impl<'a> GraphRagOperations<'a> {
 				.downcast_ref::<arrow::array::Float32Array>()
 				.ok_or_else(|| anyhow::anyhow!("Invalid weight column type"))?;
 
+			// Absent in tables written before the provenance column existed.
+			let provenance_array = batch
+				.column_by_name("provenance")
+				.and_then(|c| c.as_any().downcast_ref::<StringArray>());
+
 			for i in 0..batch.num_rows() {
 				let relationship = crate::indexer::graphrag::types::CodeRelationship {
 					source: source_array.value(i).to_string(),
@@ -1340,6 +1371,14 @@ impl<'a> GraphRagOperations<'a> {
 					description: desc_array.value(i).to_string(),
 					confidence: conf_array.value(i),
 					weight: weight_array.value(i),
+					provenance: provenance_array.map_or(
+						crate::indexer::graphrag::types::Provenance::Extracted,
+						|arr| {
+							crate::indexer::graphrag::types::Provenance::parse_or_default(
+								arr.value(i),
+							)
+						},
+					),
 				};
 				relationships.push(relationship);
 			}

--- a/src/store/graphrag.rs
+++ b/src/store/graphrag.rs
@@ -26,6 +26,7 @@ use crate::store::{sql::escape_single_quotes, table_ops::TableOperations, tables
 use futures::TryStreamExt;
 use lancedb::{
 	query::{ExecutableQuery, QueryBase},
+	table::NewColumnTransform,
 	Connection, DistanceType, Table,
 };
 use tokio::sync::RwLock as AsyncRwLock;
@@ -562,6 +563,30 @@ impl<'a> GraphRagOperations<'a> {
 
 	/// Store graph relationships in the database
 	pub async fn store_graph_relationships(&self, rel_batch: RecordBatch) -> Result<()> {
+		// LanceDB append requires matching schemas; it does not add nullable
+		// columns automatically. Upgrade pre-provenance derived graph tables in
+		// place before appending the new batch.
+		if self
+			.table_ops
+			.table_exists(tables::GRAPHRAG_RELATIONSHIPS)
+			.await?
+		{
+			let table = self.get_table(tables::GRAPHRAG_RELATIONSHIPS).await?;
+			let schema = table.schema().await?;
+			if schema.field_with_name("provenance").is_err() {
+				table
+					.add_columns(
+						NewColumnTransform::AllNulls(Arc::new(Schema::new(vec![Field::new(
+							"provenance",
+							DataType::Utf8,
+							true,
+						)]))),
+						None,
+					)
+					.await?;
+			}
+		}
+
 		// Store in database first
 		self.table_ops
 			.store_batch(tables::GRAPHRAG_RELATIONSHIPS, rel_batch.clone())
@@ -872,6 +897,7 @@ impl<'a> GraphRagOperations<'a> {
 				Field::new("description", DataType::Utf8, false),
 				Field::new("confidence", DataType::Float32, false),
 				Field::new("weight", DataType::Float32, false),
+				Field::new("provenance", DataType::Utf8, true),
 			]));
 			return Ok(RecordBatch::new_empty(schema));
 		}
@@ -900,6 +926,7 @@ impl<'a> GraphRagOperations<'a> {
 				Field::new("description", DataType::Utf8, false),
 				Field::new("confidence", DataType::Float32, false),
 				Field::new("weight", DataType::Float32, false),
+				Field::new("provenance", DataType::Utf8, true),
 			]));
 			Ok(RecordBatch::new_empty(schema))
 		} else if all_batches.len() == 1 {


### PR DESCRIPTION
- Implement single-pass AST extraction for symbols, calls, and relations
- Add SymbolIndex for scoped name resolution across files
- Introduce provenance tracking for AI-inferred and extracted edges
- Add Contains relation type for file-to-symbol links
- Implement import-aware symbol resolution with confidence scoring
- Update database schema and store to support provenance persistence
- Add backward compatibility for missing provenance columns
- Update Language trait with declaration name extraction
- Add comprehensive tests for symbol resolution and provenance
- Bump octolib dependency to 0.32.0