### PR TITLE
feat(indexer): support project file associations

### DIFF
--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -37,6 +37,12 @@ contextual_model = "openrouter:openai/gpt-4o-mini"
 # Number of code chunks to send per LLM description batch
 contextual_batch_size = 10
 
+# Project-specific final-extension associations. Keys may include a leading dot;
+# values must name an existing Octocode language. Explicit associations override
+# built-in detection. Use OCTOCODE_CONFIG_PATH to select a project-specific config.
+[index.file_associations]
+# inc = "php"
+
 [search]
 max_results = 20
 similarity_threshold = 0.65

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -100,6 +100,9 @@ quantization = true                          # RaBitQ quantization for ~32x vect
 contextual_descriptions = false              # Contextual Retrieval: enrich chunks with AI context
 contextual_model = "openrouter:openai/gpt-4o-mini"  # Model for contextual descriptions
 contextual_batch_size = 10                   # Chunks per batch for contextual enrichment
+
+[index.file_associations]
+# inc = "php"                                # Treat this project's .inc files as PHP
 ```
 
 ## Embedding Providers
@@ -213,6 +216,25 @@ Core embedding configuration.
 
 - `code_model`: Model for code embedding
 - `text_model`: Model for text/documentation embedding
+
+### [index.file_associations]
+
+Map a project's ambiguous or nonstandard final file extensions to an existing
+Octocode language. Keys are case-insensitive and may include a leading dot;
+explicit associations override built-in detection.
+
+```toml
+[index.file_associations]
+inc = "php"
+```
+
+Associations affect semantic indexing, signatures, GraphRAG, structural search,
+and MCP language detection. Unknown language names and invalid extensions fail
+configuration loading instead of silently skipping source files.
+
+The default configuration path is global. To keep associations project-specific,
+set `OCTOCODE_CONFIG_PATH` to that project's complete configuration file when
+launching Octocode.
 
 ### [graphrag]
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -153,6 +153,16 @@ pub fn execute(args: &ConfigArgs, mut config: Config) -> Result<()> {
 			"   Batch size: {} texts",
 			config.index.embeddings_batch_size
 		);
+		if config.index.file_associations.is_empty() {
+			println!("   File associations: none");
+		} else {
+			let mut associations: Vec<_> = config.index.file_associations.iter().collect();
+			associations.sort_unstable_by_key(|(extension, _)| *extension);
+			println!("   File associations:");
+			for (extension, language) in associations {
+				println!("     .{extension} → {language}");
+			}
+		}
 		println!(
 			"   GraphRAG: {}",
 			if config.graphrag.enabled {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@
 use anyhow::{Context, Result};
 use octolib::utils::config_file;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -137,6 +138,10 @@ pub struct IndexConfig {
 	/// Require git repository for indexing (default: true)
 	pub require_git: bool,
 
+	/// Project-specific final-extension to language associations.
+	#[serde(default)]
+	pub file_associations: HashMap<String, String>,
+
 	/// Enable RaBitQ quantization for vector indexes (default: true)
 	/// When enabled, uses IVF_RQ (32x compression) instead of IVF_HNSW_SQ (4x compression)
 	/// RaBitQ provides better storage efficiency while maintaining good recall
@@ -174,6 +179,7 @@ impl Default for IndexConfig {
 			embeddings_max_tokens_per_batch: 100000,
 			flush_frequency: 2,
 			require_git: true,
+			file_associations: HashMap::new(),
 			quantization: true,
 			contextual_descriptions: false,
 			contextual_model: "openrouter:openai/gpt-4o-mini".to_string(),
@@ -366,7 +372,9 @@ impl Default for Config {
 impl Config {
 	pub fn load() -> Result<Self> {
 		let config_path = Self::get_config_path()?;
-		Self::load_from_path(&config_path)
+		let config = Self::load_from_path(&config_path)?;
+		crate::language::configure_file_associations(&config.index.file_associations)?;
+		Ok(config)
 	}
 
 	fn load_from_path(config_path: &Path) -> Result<Self> {
@@ -637,6 +645,22 @@ mod tests {
 			"fastembed:jina-reranker-v2-base-multilingual"
 		);
 		assert_eq!(config.search.hybrid.default_vector_weight, 0.6);
+		assert!(config.index.file_associations.is_empty());
+	}
+
+	#[test]
+	fn parses_project_file_associations() {
+		let configured = DEFAULT_CONFIG_TEMPLATE.replace("# inc = \"php\"", "inc = \"php\"");
+		let config: Config = toml::from_str(&configured).expect("association should parse");
+
+		assert_eq!(
+			config
+				.index
+				.file_associations
+				.get("inc")
+				.map(String::as_str),
+			Some("php")
+		);
 	}
 
 	#[test]

--- a/src/grep.rs
+++ b/src/grep.rs
@@ -263,6 +263,10 @@ fn pattern_info_with_lang<L: LanguageExt + AstGrepLanguage + Clone>(
 
 /// Determine language from file extension.
 pub fn language_from_extension(path: &Path) -> Option<&'static str> {
+	if let Some(language) = crate::language::associated_language(path) {
+		return Some(language);
+	}
+
 	let ext = path.extension()?.to_str()?;
 	match ext {
 		"rs" => Some("rust"),

--- a/src/indexer/file_utils.rs
+++ b/src/indexer/file_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,6 +115,10 @@ impl FileUtils {
 
 	/// Detect language based on file extension
 	pub fn detect_language(path: &Path) -> Option<&'static str> {
+		if let Some(language) = crate::language::associated_language(path) {
+			return Some(language);
+		}
+
 		match path.extension()?.to_str()? {
 			// Rust
 			"rs" => Some("rust"),

--- a/src/indexer/languages/resolution_utils.rs
+++ b/src/indexer/languages/resolution_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Muvon Un Limited
+// Copyright 2026 Muvon Un Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -254,6 +254,10 @@ pub fn normalize_path(path: &str) -> String {
 /// Detect language from file path extension
 pub fn detect_language_from_path(file_path: &str) -> Option<String> {
 	let path = Path::new(file_path);
+	if let Some(language) = crate::language::associated_language(path) {
+		return Some(language.to_string());
+	}
+
 	let extension = path.extension()?.to_str()?;
 
 	match extension {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -419,67 +419,8 @@ fn fast_count_indexable_files(
 			continue;
 		}
 
-		// Quick check: just see if file has an extension that might be indexable
-		// This is much faster than full language detection
-		if let Some(ext) = entry.path().extension() {
-			let ext_str = ext.to_str().unwrap_or("");
-			// Quick list of common extensions we index
-			if matches!(
-				ext_str,
-				"rs" | "js"
-					| "ts" | "jsx" | "tsx"
-					| "py" | "go" | "java"
-					| "c" | "cpp" | "cc"
-					| "cxx" | "c++" | "h"
-					| "hpp" | "hxx" | "cppm"
-					| "ixx" | "mxx" | "ccm"
-					| "cxxm" | "cs" | "php"
-					| "rb" | "swift"
-					| "kt" | "scala"
-					| "r" | "m" | "mm"
-					| "md" | "markdown"
-					| "txt" | "json"
-					| "yaml" | "yml"
-					| "toml" | "xml"
-					| "html" | "css"
-					| "scss" | "sass"
-					| "less" | "sql"
-					| "sh" | "bash" | "zsh"
-					| "fish" | "vim"
-					| "lua" | "pl" | "pm"
-					| "t" | "pod" | "raku"
-					| "rakumod" | "rakudoc"
-					| "nix" | "dhall"
-					| "tf" | "tfvars"
-					| "hcl" | "vue" | "svelte"
-					| "elm" | "purs"
-					| "hs" | "lhs" | "ml"
-					| "mli" | "fs" | "fsi"
-					| "fsx" | "clj" | "cljs"
-					| "cljc" | "edn"
-					| "ex" | "exs" | "erl"
-					| "hrl" | "zig" | "v"
-					| "vsh" | "nim" | "nims"
-					| "cr" | "jl" | "d"
-					| "dart" | "pas"
-					| "pp" | "inc" | "asm"
-					| "s" | "S" | "rst"
-					| "adoc" | "tex"
-					| "bib" | "org" | "wiki"
-					| "pod6" | "rakutest"
-					| "cfg" | "conf"
-					| "config" | "ini"
-					| "env" | "properties"
-					| "gradle" | "cmake"
-					| "make" | "makefile"
-					| "dockerfile" | "containerfile"
-					| "vagrantfile" | "gemfile"
-					| "rakefile" | "guardfile"
-					| "podfile" | "fastfile"
-					| "brewfile"
-			) {
-				count += 1;
-			}
+		if detect_language(entry.path()).is_some() || is_allowed_text_extension(entry.path()) {
+			count += 1;
 		}
 	}
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,0 +1,100 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{bail, Result};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::LazyLock;
+
+static FILE_ASSOCIATIONS: LazyLock<RwLock<HashMap<String, &'static str>>> =
+	LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Replace the process-wide file associations loaded from the active config.
+pub fn configure_file_associations(associations: &HashMap<String, String>) -> Result<()> {
+	*FILE_ASSOCIATIONS.write() = normalize_file_associations(associations)?;
+	Ok(())
+}
+
+/// Return a configured language association for a path, if one exists.
+pub fn associated_language(path: &Path) -> Option<&'static str> {
+	let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+	FILE_ASSOCIATIONS.read().get(&extension).copied()
+}
+
+fn normalize_file_associations(
+	associations: &HashMap<String, String>,
+) -> Result<HashMap<String, &'static str>> {
+	associations
+		.iter()
+		.map(|(extension, language)| {
+			let extension = extension
+				.strip_prefix('.')
+				.unwrap_or(extension)
+				.to_ascii_lowercase();
+			if extension.is_empty()
+				|| !extension
+					.chars()
+					.all(|character| character.is_ascii_alphanumeric() || "_+-".contains(character))
+			{
+				bail!("invalid file association extension '{extension}'");
+			}
+
+			let Some(language) = canonical_language(language) else {
+				bail!("unsupported file association language '{language}'");
+			};
+			Ok((extension, language))
+		})
+		.collect()
+}
+
+fn canonical_language(language: &str) -> Option<&'static str> {
+	let language = language.to_ascii_lowercase();
+	crate::indexer::languages::get_language(&language).map(|language| language.name())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn normalizes_extensions_and_language_names() {
+		let associations = HashMap::from([(".INC".to_string(), "PHP".to_string())]);
+		let normalized = normalize_file_associations(&associations).unwrap();
+
+		assert_eq!(normalized.get("inc"), Some(&"php"));
+	}
+
+	#[test]
+	fn applies_configured_association() {
+		let associations = HashMap::from([("pfbinc".to_string(), "php".to_string())]);
+		configure_file_associations(&associations).unwrap();
+
+		assert_eq!(
+			associated_language(Path::new("functions.pfbinc")),
+			Some("php")
+		);
+
+		configure_file_associations(&HashMap::new()).unwrap();
+	}
+
+	#[test]
+	fn rejects_invalid_associations() {
+		let invalid_extension = HashMap::from([("*.inc".to_string(), "php".to_string())]);
+		assert!(normalize_file_associations(&invalid_extension).is_err());
+
+		let invalid_language = HashMap::from([("inc".to_string(), "pascal".to_string())]);
+		assert!(normalize_file_associations(&invalid_language).is_err());
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod constants;
 pub mod embedding;
 pub mod grep;
 pub mod indexer;
+pub mod language;
 pub mod llm;
 pub mod lock;
 pub mod mcp;


### PR DESCRIPTION
## Description

Add project-specific final-extension associations for source files whose language cannot be inferred safely from the extension alone.

For example, pfBlockerNG stores executable PHP in `.inc` files, while other ecosystems use `.inc` for Pascal, assembly includes, or plain text. A project can now opt in without changing Octocode's global defaults:

```toml
[index.file_associations]
inc = "php"
```

The active configuration is normalized and validated once at startup. Explicit associations override built-in detection consistently for semantic indexing, signatures, GraphRAG, structural search, and MCP language detection. Invalid extensions or unsupported target languages fail configuration loading.

The indexable-file counter now reuses the real processing predicate instead of maintaining a larger, divergent extension list.

Closes #80.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `cargo test --no-default-features` — 366 passed
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo build` with the default FastEmbed/HuggingFace features
- [x] Manual end-to-end fixture: configured `.inc = "php"`, extracted a PHP function signature, indexed one PHP code block, and confirmed the stored language and symbol

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Tests pass locally
