### PR TITLE
fix(mcp): keep semantic index fresh by default

### DIFF
--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -19,11 +19,10 @@ embeddings_batch_size = 16  # 16 files per batch - table.add() every 16 files fo
 embeddings_max_tokens_per_batch = 100000  # Keep existing token limit
 flush_frequency = 2  # Flush every 2 batches = every 32 files for coordinated persistence
 require_git = true  # Require git repository for indexing
-# When true, the MCP server runs background indexing + a file watcher to keep the index
-# fresh while serving. When false (default), MCP serves search, view_signatures, and
-# structural_search over the EXISTING index read-only and never (re)indexes in-process.
+# The MCP server keeps the semantic index fresh in the background by default.
+# Set this to false to serve an existing index read-only without indexing or watching.
 # The `index` CLI command is unaffected — this gates only the in-process MCP indexer.
-mcp_index = false
+mcp_index = true
 quantization = true  # Enable RaBitQ quantization (32x compression) vs IVF_HNSW_SQ (4x compression)
 # Contextual chunk enrichment: use LLM to generate natural language descriptions
 # of code chunks at indexing time. Descriptions are prepended to chunk content before

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,11 +157,9 @@ pub struct IndexConfig {
 	#[serde(default = "default_contextual_batch_size")]
 	pub contextual_batch_size: usize,
 
-	/// When `true`, the MCP server runs background indexing + a file watcher to keep
-	/// the index fresh while serving. When `false` (default), MCP serves search,
-	/// `view_signatures`, and `structural_search` over the EXISTING index in read-only
-	/// mode and never (re)indexes in-process. The `index` CLI command is unaffected —
-	/// this gates only the in-process MCP indexer.
+	/// When `true` (default), the MCP server runs background indexing + a file watcher
+	/// to keep the index fresh while serving. When `false`, MCP serves the existing
+	/// index read-only. The `index` CLI command is unaffected.
 	pub mcp_index: bool,
 }
 
@@ -178,7 +176,7 @@ impl Default for IndexConfig {
 			contextual_descriptions: false,
 			contextual_model: "openrouter:openai/gpt-4o-mini".to_string(),
 			contextual_batch_size: 10,
-			mcp_index: false,
+			mcp_index: true,
 		}
 	}
 }
@@ -535,6 +533,10 @@ mod tests {
 	fn test_default_config() {
 		let config = Config::load_from_template().expect("Failed to load template config");
 		assert_eq!(config.version, 2);
+		assert!(
+			config.index.mcp_index,
+			"MCP must keep its semantic index fresh by default"
+		);
 		assert_eq!(config.llm.model, "openrouter:openai/gpt-4o-mini");
 		assert_eq!(config.index.chunk_size, 2000);
 		assert_eq!(config.search.max_results, 20);

--- a/src/indexer/branch.rs
+++ b/src/indexer/branch.rs
@@ -20,6 +20,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -119,10 +120,16 @@ pub fn get_current_branch(repo_path: &Path) -> Option<String> {
 	Some(branch)
 }
 
-/// Determine whether the current checkout is on a non-default branch.
-/// Returns `Some(branch_name)` if on a feature branch, `None` if on default or detached.
+/// Determine whether the current checkout needs a branch-delta index.
+/// Named feature branches use their branch name. Detached worktrees get a stable,
+/// worktree-specific name so they cannot overwrite the shared main index.
 pub fn detect_branch_context(repo_path: &Path) -> Option<String> {
-	let current = get_current_branch(repo_path)?;
+	let Some(current) = get_current_branch(repo_path) else {
+		let path = repo_path.canonicalize().ok()?;
+		let path_hash = format!("{:x}", Sha256::digest(path.to_string_lossy().as_bytes()));
+		get_branch_commit(repo_path, "HEAD").ok()?;
+		return Some(format!("detached/{}", &path_hash[..12]));
+	};
 	let default = GitUtils::get_default_branch(repo_path).ok()?;
 	if current == default {
 		None
@@ -567,6 +574,7 @@ pub fn resolve_branch_state(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::process::Command;
 
 	#[test]
 	fn test_sanitize_branch_name() {
@@ -592,6 +600,70 @@ mod tests {
 		for name in names {
 			assert_eq!(desanitize_branch_name(&sanitize_branch_name(name)), name);
 		}
+	}
+
+	#[test]
+	fn detached_worktrees_get_distinct_branch_contexts() {
+		let root = std::env::temp_dir().join(format!(
+			"octocode-detached-context-{}",
+			uuid::Uuid::new_v4()
+		));
+		let repo = root.join("repo");
+		let first = root.join("first");
+		let second = root.join("second");
+		std::fs::create_dir_all(&repo).unwrap();
+
+		for args in [
+			vec!["init"],
+			vec!["config", "user.email", "test@example.com"],
+			vec!["config", "user.name", "Test"],
+		] {
+			assert!(Command::new("git")
+				.args(args)
+				.current_dir(&repo)
+				.status()
+				.unwrap()
+				.success());
+		}
+		std::fs::write(repo.join("tracked.txt"), "tracked\n").unwrap();
+		for args in [vec!["add", "tracked.txt"], vec!["commit", "-m", "initial"]] {
+			assert!(Command::new("git")
+				.args(args)
+				.current_dir(&repo)
+				.status()
+				.unwrap()
+				.success());
+		}
+		for path in [&first, &second] {
+			assert!(Command::new("git")
+				.args(["worktree", "add", "--detach"])
+				.arg(path)
+				.arg("HEAD")
+				.current_dir(&repo)
+				.status()
+				.unwrap()
+				.success());
+		}
+
+		let first_context = detect_branch_context(&first).expect("detached worktree context");
+		let second_context = detect_branch_context(&second).expect("detached worktree context");
+
+		assert_ne!(first_context, second_context);
+		assert!(first_context.starts_with("detached/"));
+		assert!(second_context.starts_with("detached/"));
+
+		std::fs::write(first.join("tracked.txt"), "changed\n").unwrap();
+		for args in [vec!["add", "tracked.txt"], vec!["commit", "-m", "next"]] {
+			assert!(Command::new("git")
+				.args(args)
+				.current_dir(&first)
+				.status()
+				.unwrap()
+				.success());
+		}
+		assert_eq!(detect_branch_context(&first).unwrap(), first_context);
+
+		std::fs::remove_dir_all(root).unwrap();
 	}
 
 	fn make_manifest(changed: Vec<&str>, deleted: Vec<&str>) -> BranchManifest {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1036,25 +1036,6 @@ impl McpServer {
 		let store = Arc::new(Store::new_with_path(db_path).await?);
 		store.initialize_collections().await?;
 
-		// One-shot initial index so a freshly-accessed repo is searchable without
-		// waiting for a file change. Incremental and lock-guarded, so it's cheap
-		// when already indexed and safe against the watcher-triggered reindex.
-		{
-			let store = store.clone();
-			let config = config.clone();
-			let working_directory = working_directory.clone();
-			tokio::spawn(async move {
-				if let Err(e) = perform_indexing(&store, &config, &working_directory, no_git).await
-				{
-					warn!(
-						"Initial index failed for {}: {}",
-						working_directory.display(),
-						e
-					);
-				}
-			});
-		}
-
 		start_background_services(
 			config,
 			store,
@@ -1122,9 +1103,8 @@ impl McpServer {
 			(None, None, None)
 		};
 
-		// The in-process MCP indexer is opt-in via `index.mcp_index`. When disabled,
-		// MCP serves the existing index read-only; when enabled, the usual git gate
-		// still applies.
+		// The in-process MCP indexer is enabled by default. Explicit read-only mode
+		// still serves the existing index, and the usual git gate applies otherwise.
 		let should_start_indexer = config.index.mcp_index
 			&& (no_git
 				|| !config.index.require_git
@@ -1327,6 +1307,9 @@ pub(crate) async fn start_background_services(
 ) -> Result<BackgroundServices> {
 	let (file_tx, file_rx) = mpsc::channel(MCP_MAX_PENDING_EVENTS);
 	let (index_tx, index_rx) = mpsc::channel(10);
+	index_tx
+		.try_send(())
+		.map_err(|e| anyhow::anyhow!("Failed to queue initial index: {}", e))?;
 
 	// 1. File watcher
 	let working_dir = working_directory.clone();
@@ -1337,7 +1320,7 @@ pub(crate) async fn start_background_services(
 	});
 
 	// 2. Debouncer: accumulates file events, triggers indexing after quiet period
-	let indexing_in_progress = Arc::new(AtomicBool::new(false));
+	let indexing_in_progress = Arc::new(AtomicBool::new(true));
 	let indexing_flag = indexing_in_progress.clone();
 	let debug_mode = debug;
 	let graph_cache = runtime_graph_cache;


### PR DESCRIPTION
## What changed

- enable MCP background indexing and file watching by default
- queue an initial index as soon as background services start
- reuse that queue for single- and multi-repository MCP modes, removing the duplicate multi-mode bootstrap task
- route detached worktrees through stable, worktree-specific branch overlays instead of the shared main index
- retain `index.mcp_index = false` as an explicit read-only opt-out

## Why

`semantic_search` is Octocode's conceptual retrieval path. Since 0.21.0, MCP defaulted to read-only mode, so a generated configuration could silently serve an index many commits behind the working tree. Even after opting in, single-repository MCP mode waited for a file-system event before indexing, unlike multi-repository mode.

This made semantic search stale precisely when users relied on it to discover code without knowing symbol names. Structural search and the live graph do not replace that capability.

Default-on indexing also exposed an existing detached-worktree gap: detached checkouts were treated as the default branch and could rewrite the shared main store from different HEADs. They now reuse the existing branch-delta pipeline under stable per-worktree keys.

## Impact

New default configurations keep semantic search current in the background. MCP remains responsive while the existing incremental, lock-guarded indexer runs. Detached worktrees maintain isolated overlays that remain stable as their HEAD advances. File changes continue through the existing debounce pipeline, and indexing failures remain isolated to background logging so structural tools stay available.

Existing configurations that explicitly set `mcp_index = false` remain read-only.

## Validation

- frozen regression failed before the production change: `config::tests::test_default_config` reported `MCP must keep its semantic index fresh by default`
- `cargo test --no-default-features` — 362 passed before detached-worktree hardening
- `cargo test --all-features` — 363 passed
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
